### PR TITLE
Enable manual trigger for npm publish

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,6 +1,7 @@
 ---
 name: publish-to-npm
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 permissions:
@@ -22,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org/'
       - run: npm install
       - uses: JS-DevTools/npm-publish@v3


### PR DESCRIPTION
The action didn't trigger after the last merge to `main`. We should be able to trigger this manually in these cases.