### PR TITLE
Add a marker to confirm to the UI that the markdown extension ran

### DIFF
--- a/extensions/convert-to-markdown.js
+++ b/extensions/convert-to-markdown.js
@@ -54,7 +54,8 @@ module.exports.register = function () {
           'pagination',
           'footer',
           'nav-expand',
-          'banner-container'
+          'banner-container',
+          'markdown-dropdown',
         ]
         return toRemove.some(
           (x) => classAttr.includes(x) || idAttr.includes(x)
@@ -249,6 +250,21 @@ module.exports.register = function () {
     addCustomRules(nestedTurndown, true)
     return outerTurndown
   }
+
+  // Add marker attribute before UI rendering so templates can detect markdown availability
+  this.on('documentsConverted', ({ contentCatalog }) => {
+    const pages = contentCatalog.findBy({ family: 'page' })
+    logger.info(`Marking ${pages.length} pages as having markdown equivalents...`)
+
+    pages.forEach((page) => {
+      // Ensure attributes object exists
+      if (!page.asciidoc) page.asciidoc = {}
+      if (!page.asciidoc.attributes) page.asciidoc.attributes = {}
+
+      // Add marker that UI templates can check
+      page.asciidoc.attributes['page-has-markdown'] = ''
+    })
+  })
 
   // Conversion pipeline
   this.on('pagesComposed', async ({ playbook: pb, contentCatalog }) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
This pull request introduces a minor version bump and several improvements to the Markdown conversion extension, focusing on enhanced UI integration and cleanup of rendered HTML. The most notable changes are the addition of a marker for Markdown availability on pages and the expansion of elements removed during conversion.

**UI Integration and Metadata Improvements:**

* Added a new event handler for `documentsConverted` in `convert-to-markdown.js` to mark each page with a `page-has-markdown` attribute, allowing UI templates to detect and respond to Markdown equivalents.

**HTML Cleanup Enhancements:**

* Updated the list of removable elements in `convert-to-markdown.js` to include `markdown-dropdown`, ensuring that dropdowns related to Markdown are stripped from the HTML output.

**Version Update:**

* Bumped the package version in `package.json` from `4.11.0` to `4.11.1` to reflect these changes.