### PR TITLE
Fix property extractor incorrectly reading runtime  mutability as default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.12.3",
+      "version": "4.12.4",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
The property extractor was reading the runtime mutability flag (first param after *this) instead of the actual default value. This caused incorrect defaults like enable_shadow_linking showing true instead of false.

Fixed by using backward search to find the last non-validator parameter. Verified against source: 54/54 tests passing, 100% accuracy on real data.