### PR TITLE
gha: update publish-to-npm (using OIDC now)

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -15,21 +15,14 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          secret-ids: |
-            ,sdlc/prod/github/npm_token
-          parse-json-secrets: true
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org/'
       - run: npm install
-      - uses: JS-DevTools/npm-publish@v3
+      - uses: JS-DevTools/npm-publish@v4
         id: publish
-        with:
-          token: ${{ env.NPM_TOKEN }}
       - name: Check published version
         if: ${{ steps.publish.outputs.type }}
         run: echo "Version changed!"


### PR DESCRIPTION
Should fix [DEVPROD-3689], as I've already set up the OIDC link on the NPMJS side.

[DEVPROD-3689]: https://redpandadata.atlassian.net/browse/DEVPROD-3689