### PR TITLE
Fix the Helm version fetcher with the corrected paths to the chart

### DIFF
--- a/__tests__/extensions/version-fetcher/get-latest-redpanda-helm-version-from-operator.test.js
+++ b/__tests__/extensions/version-fetcher/get-latest-redpanda-helm-version-from-operator.test.js
@@ -1,0 +1,204 @@
+const getLatestHelmVersion = require('../../../extensions/version-fetcher/get-latest-redpanda-helm-version-from-operator');
+
+describe('getLatestHelmVersion', () => {
+  let mockGithub;
+
+  beforeEach(() => {
+    mockGithub = {
+      repos: {
+        getContent: jest.fn()
+      }
+    };
+  });
+
+  it('should fetch stable helm chart version from release branch', async () => {
+    // Mock the GitHub API response
+    const mockChartYaml = `
+apiVersion: v2
+name: redpanda
+version: 5.9.7
+description: Redpanda is a streaming data platform
+`;
+
+    mockGithub.repos.getContent.mockResolvedValue({
+      data: {
+        content: Buffer.from(mockChartYaml).toString('base64')
+      }
+    });
+
+    const result = await getLatestHelmVersion(
+      mockGithub,
+      'redpanda-data',
+      'redpanda-operator',
+      'v25.1.3',
+      null
+    );
+
+    expect(result.latestStableRelease).toBe('5.9.7');
+    expect(result.latestBetaRelease).toBeNull();
+    expect(mockGithub.repos.getContent).toHaveBeenCalledWith({
+      owner: 'redpanda-data',
+      repo: 'redpanda-operator',
+      path: 'charts/redpanda/chart/Chart.yaml',
+      ref: 'release/v25.1.x'
+    });
+  });
+
+  it('should fetch both stable and beta helm chart versions', async () => {
+    const mockStableChart = `
+apiVersion: v2
+name: redpanda
+version: 5.9.7
+`;
+
+    const mockBetaChart = `
+apiVersion: v2
+name: redpanda
+version: 5.10.0-beta1
+`;
+
+    mockGithub.repos.getContent
+      .mockResolvedValueOnce({
+        data: { content: Buffer.from(mockStableChart).toString('base64') }
+      })
+      .mockResolvedValueOnce({
+        data: { content: Buffer.from(mockBetaChart).toString('base64') }
+      });
+
+    const result = await getLatestHelmVersion(
+      mockGithub,
+      'redpanda-data',
+      'redpanda-operator',
+      'v25.1.3',
+      'v25.2.1-beta1'
+    );
+
+    expect(result.latestStableRelease).toBe('5.9.7');
+    expect(result.latestBetaRelease).toBe('5.10.0-beta1');
+    expect(mockGithub.repos.getContent).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle older version format (v2.x.x)', async () => {
+    const mockChartYaml = `
+apiVersion: v2
+name: redpanda
+version: 2.4.5
+`;
+
+    mockGithub.repos.getContent.mockResolvedValue({
+      data: { content: Buffer.from(mockChartYaml).toString('base64') }
+    });
+
+    const result = await getLatestHelmVersion(
+      mockGithub,
+      'redpanda-data',
+      'redpanda-operator',
+      'v2.4.2',
+      null
+    );
+
+    expect(result.latestStableRelease).toBe('2.4.5');
+    expect(mockGithub.repos.getContent).toHaveBeenCalledWith({
+      owner: 'redpanda-data',
+      repo: 'redpanda-operator',
+      path: 'charts/redpanda/chart/Chart.yaml',
+      ref: 'release/v2.4.x'
+    });
+  });
+
+  it('should handle invalid docker tag format', async () => {
+    const result = await getLatestHelmVersion(
+      mockGithub,
+      'redpanda-data',
+      'redpanda-operator',
+      'invalid-tag',
+      null
+    );
+
+    expect(result.latestStableRelease).toBeNull();
+    expect(result.latestBetaRelease).toBeNull();
+    expect(mockGithub.repos.getContent).not.toHaveBeenCalled();
+  });
+
+  it('should handle GitHub API errors gracefully', async () => {
+    mockGithub.repos.getContent.mockRejectedValue(
+      new Error('Branch not found')
+    );
+
+    const result = await getLatestHelmVersion(
+      mockGithub,
+      'redpanda-data',
+      'redpanda-operator',
+      'v25.1.3',
+      null
+    );
+
+    expect(result.latestStableRelease).toBeNull();
+    expect(result.latestBetaRelease).toBeNull();
+  });
+
+  it('should handle missing version in Chart.yaml', async () => {
+    const mockChartYaml = `
+apiVersion: v2
+name: redpanda
+description: No version field
+`;
+
+    mockGithub.repos.getContent.mockResolvedValue({
+      data: { content: Buffer.from(mockChartYaml).toString('base64') }
+    });
+
+    const result = await getLatestHelmVersion(
+      mockGithub,
+      'redpanda-data',
+      'redpanda-operator',
+      'v25.1.3',
+      null
+    );
+
+    expect(result.latestStableRelease).toBeNull();
+  });
+
+  it('should handle beta tag with -beta suffix', async () => {
+    const mockChartYaml = `
+apiVersion: v2
+name: redpanda
+version: 5.10.0-beta1
+`;
+
+    mockGithub.repos.getContent.mockResolvedValue({
+      data: { content: Buffer.from(mockChartYaml).toString('base64') }
+    });
+
+    const result = await getLatestHelmVersion(
+      mockGithub,
+      'redpanda-data',
+      'redpanda-operator',
+      null,
+      'v25.2.1-beta1'
+    );
+
+    expect(result.latestStableRelease).toBeNull();
+    expect(result.latestBetaRelease).toBe('5.10.0-beta1');
+    expect(mockGithub.repos.getContent).toHaveBeenCalledWith({
+      owner: 'redpanda-data',
+      repo: 'redpanda-operator',
+      path: 'charts/redpanda/chart/Chart.yaml',
+      ref: 'release/v25.2.x'
+    });
+  });
+
+  it('should handle null/undefined dockerTag parameters', async () => {
+    const result = await getLatestHelmVersion(
+      mockGithub,
+      'redpanda-data',
+      'redpanda-operator',
+      null,
+      null
+    );
+
+    expect(result.latestStableRelease).toBeNull();
+    expect(result.latestBetaRelease).toBeNull();
+    expect(mockGithub.repos.getContent).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/version-fetcher/get-latest-redpanda-helm-version-from-operator.js
+++ b/extensions/version-fetcher/get-latest-redpanda-helm-version-from-operator.js
@@ -12,7 +12,7 @@
  */
 module.exports = async (github, owner, repo, stableDockerTag, betaDockerTag) => {
   const yaml = require('js-yaml');
-  const path = 'charts/redpanda/Chart.yaml';
+  const path = 'charts/redpanda/chart/Chart.yaml';
 
   /**
    * Helper function to fetch chart version from a branch derived from a docker tag

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.12.5",
+  "version": "4.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.12.5",
+      "version": "4.12.6",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.12.5",
+  "version": "4.12.6",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
This pull request introduces a new test suite for the `get-latest-redpanda-helm-version-from-operator` module, updates the path used to fetch the Helm chart YAML file, and bumps the package version. The main focus is on improving the reliability and coverage of the version-fetching logic by thoroughly testing various scenarios.

### Testing improvements

* Added comprehensive unit tests for `getLatestHelmVersion` covering stable and beta release fetching, different version formats, error handling, missing fields, and edge cases in `__tests__/extensions/version-fetcher/get-latest-redpanda-helm-version-from-operator.test.js`.

### Bug fixes

* Updated the chart file path from `charts/redpanda/Chart.yaml` to `charts/redpanda/chart/Chart.yaml` in `get-latest-redpanda-helm-version-from-operator.js` to match the actual repository structure.

### Maintenance

* Bumped the package version in `package.json` from `4.12.5` to `4.12.6`.