### PR TITLE
gha: bump node version

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: 24
           registry-url: 'https://registry.npmjs.org/'
       - run: npm install
       - uses: JS-DevTools/npm-publish@v4


### PR DESCRIPTION
This should get us to a newer NPM version with support for trusted publishing.