### PR TITLE
Fix Redpanda Connect cloud-only connector automation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.13.3",
+  "version": "4.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.13.3",
+      "version": "4.13.4",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.13.3",
+  "version": "4.13.4",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/redpanda-connect/pr-summary-formatter.js
+++ b/tools/redpanda-connect/pr-summary-formatter.js
@@ -397,8 +397,9 @@ function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = 
         lines.push('');
         cloudSupportedNew.forEach(c => {
           lines.push(`- **${c.name}** (${c.type}, ${c.status})`);
-          if (c.description) {
-            const shortDesc = truncateToSentence(c.description, 2);
+          const desc = c.summary || c.description;
+          if (desc) {
+            const shortDesc = truncateToSentence(desc, 2);
             lines.push(`  - ${shortDesc}`);
           }
         });
@@ -410,8 +411,9 @@ function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = 
         lines.push('');
         selfHostedOnlyNew.forEach(c => {
           lines.push(`- **${c.name}** (${c.type}, ${c.status})`);
-          if (c.description) {
-            const shortDesc = truncateToSentence(c.description, 2);
+          const desc = c.summary || c.description;
+          if (desc) {
+            const shortDesc = truncateToSentence(desc, 2);
             lines.push(`  - ${shortDesc}`);
           }
         });
@@ -421,8 +423,9 @@ function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = 
       // No cloud support info, just list all
       diffData.details.newComponents.forEach(c => {
         lines.push(`- **${c.name}** (${c.type}, ${c.status})`);
-        if (c.description) {
-          const shortDesc = truncateToSentence(c.description, 2);
+        const desc = c.summary || c.description;
+        if (desc) {
+          const shortDesc = truncateToSentence(desc, 2);
           lines.push(`  - ${shortDesc}`);
         }
       });

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -189,8 +189,9 @@ function updateWhatsNew ({ dataDir, oldVersion, newVersion, binaryAnalysis }) {
           for (const comp of comps) {
             section += `** xref:guides:bloblang/functions.adoc#${comp.name}[\`${comp.name}\`]`
             if (comp.status && comp.status !== 'stable') section += ` (${comp.status})`
-            if (comp.description) {
-              section += `: ${capToTwoSentences(comp.description)}`
+            const desc = comp.summary || comp.description
+            if (desc) {
+              section += `: ${capToTwoSentences(desc)}`
             } else {
               section += `\n+\n// TODO: Add description for ${comp.name} function`
             }
@@ -201,8 +202,9 @@ function updateWhatsNew ({ dataDir, oldVersion, newVersion, binaryAnalysis }) {
           for (const comp of comps) {
             section += `** xref:guides:bloblang/methods.adoc#${comp.name}[\`${comp.name}\`]`
             if (comp.status && comp.status !== 'stable') section += ` (${comp.status})`
-            if (comp.description) {
-              section += `: ${capToTwoSentences(comp.description)}`
+            const desc = comp.summary || comp.description
+            if (desc) {
+              section += `: ${capToTwoSentences(desc)}`
             } else {
               section += `\n+\n// TODO: Add description for ${comp.name} method`
             }
@@ -267,7 +269,8 @@ function updateWhatsNew ({ dataDir, oldVersion, newVersion, binaryAnalysis }) {
 
       for (const comp of diff.details.deprecatedComponents) {
         const typeLabel = comp.type.charAt(0).toUpperCase() + comp.type.slice(1)
-        const desc = comp.description ? capToTwoSentences(comp.description) : '-'
+        const descText = comp.summary || comp.description
+        const desc = descText ? capToTwoSentences(descText) : '-'
 
         if (comp.type === 'bloblang-functions') {
           section += `|xref:guides:bloblang/functions.adoc#${comp.name}[${comp.name}]\n`
@@ -913,6 +916,9 @@ async function handleRpcnConnectorDocs (options) {
         fs.unlinkSync(oldestPath)
         console.log(`🧹 Deleted old version from docs-data: ${oldestFile}`)
       }
+
+      // Reload newIndex after augmentation so diff generation uses augmented data
+      newIndex = JSON.parse(fs.readFileSync(dataFile, 'utf8'))
     } catch (err) {
       console.error(`Warning: Failed to augment data file: ${err.message}`)
     }


### PR DESCRIPTION
This pull request updates the logic for generating summaries and descriptions of components in the Redpanda documentation tooling. The main improvement is that, wherever a component has a `summary` field, it will now be preferred over the `description` field for display in summaries and changelogs. This ensures that more concise and relevant information is shown to users. Additionally, the documentation data is now reloaded after augmentation to ensure that the most up-to-date information is used in subsequent processing.

Component summary handling improvements:

* Updated all relevant places in `tools/redpanda-connect/pr-summary-formatter.js` and `tools/redpanda-connect/rpcn-connector-docs-handler.js` to prefer the `summary` field over `description` when generating summaries for new, self-hosted, or deprecated components. This makes changelogs and documentation more concise and user-friendly. [[1]](diffhunk://#diff-ab149da03d45cbd7709463852be8e3e04bbd9986a3b7c1aa6ef99419bae6e8e9L400-R402) [[2]](diffhunk://#diff-ab149da03d45cbd7709463852be8e3e04bbd9986a3b7c1aa6ef99419bae6e8e9L413-R416) [[3]](diffhunk://#diff-ab149da03d45cbd7709463852be8e3e04bbd9986a3b7c1aa6ef99419bae6e8e9L424-R428) [[4]](diffhunk://#diff-fffb5332e29e63902e6d45cc2f85479c0cab3534701e944ca3a63f2bf289ae5aL192-R194) [[5]](diffhunk://#diff-fffb5332e29e63902e6d45cc2f85479c0cab3534701e944ca3a63f2bf289ae5aL204-R207) [[6]](diffhunk://#diff-fffb5332e29e63902e6d45cc2f85479c0cab3534701e944ca3a63f2bf289ae5aL270-R273)

Documentation data consistency:

* After augmenting the documentation data file, the code now reloads the updated data to ensure that any further processing (such as diff generation) uses the latest information and avoid reporting on incorrect data.

Other changes:

* Bumped the package version in `package.json` from `4.13.3` to `4.13.4`.