### PR TITLE
Fix ESM import error for @octokit/rest

### DIFF
--- a/cli-utils/octokit-client.js
+++ b/cli-utils/octokit-client.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { Octokit } = require('@octokit/rest')
 const { getGitHubToken } = require('./github-token')
 
 /**
@@ -11,26 +10,44 @@ const { getGitHubToken } = require('./github-token')
  * - Avoid redundant initialization
  * - Share rate limit tracking
  * - Centralize GitHub API configuration
+ *
+ * Uses lazy initialization with async import to support ESM-only @octokit/rest
  */
 
-// Get authentication token from environment
-const token = getGitHubToken()
+// Singleton instance cache
+let octokitInstance = null
 
-// Configure Octokit options
-const octokitOptions = {
-  userAgent: 'redpanda-docs-tools',
-  retry: {
-    enabled: true,
-    retries: 3
+/**
+ * Get or create the shared Octokit client instance
+ * @returns {Promise<Octokit>} The Octokit client instance
+ */
+async function getOctokit() {
+  if (!octokitInstance) {
+    // Dynamic import for ESM-only @octokit/rest
+    const { Octokit } = await import('@octokit/rest')
+
+    // Get authentication token from environment
+    const token = getGitHubToken()
+
+    // Configure Octokit options
+    const octokitOptions = {
+      userAgent: 'redpanda-docs-tools',
+      retry: {
+        enabled: true,
+        retries: 3
+      }
+    }
+
+    // Only add auth if token is available
+    if (token) {
+      octokitOptions.auth = token
+    }
+
+    // Create singleton instance
+    octokitInstance = new Octokit(octokitOptions)
   }
+
+  return octokitInstance
 }
 
-// Only add auth if token is available
-if (token) {
-  octokitOptions.auth = token
-}
-
-// Create singleton instance
-const octokit = new Octokit(octokitOptions)
-
-module.exports = octokit
+module.exports = { getOctokit }

--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -25,9 +25,10 @@ module.exports.register = function ({ config }) {
   // Use csvpath (legacy) or csvPath
   const localCsvPath = csvpath || null
 
-  function loadOctokit () {
+  async function loadOctokit () {
     // Use shared Octokit client
-    return require('../cli-utils/octokit-client')
+    const { getOctokit } = require('../cli-utils/octokit-client')
+    return await getOctokit()
   }
 
   // Use 'on' and return the promise so Antora waits for async completion

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.14.1",
+  "version": "4.14.2",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/cloud-regions/generate-cloud-regions.js
+++ b/tools/cloud-regions/generate-cloud-regions.js
@@ -71,7 +71,8 @@ function displayClusterType(ct) {
 async function fetchYaml({ owner, repo, path, ref = 'main', token }) {
   try {
     // Use shared Octokit client
-    const octokit = require('../../cli-utils/octokit-client');
+    const { getOctokit } = require('../../cli-utils/octokit-client');
+    const octokit = await getOctokit();
 
     console.log(`[cloud-regions] INFO: Fetching ${owner}/${repo}/${path}@${ref} via GitHub API`);
 

--- a/tools/fetch-from-github.js
+++ b/tools/fetch-from-github.js
@@ -2,9 +2,9 @@ const fs = require('fs');
 const path = require('path');
 
 // Use shared Octokit client
-function loadOctokit() {
-  const octokit = require('../cli-utils/octokit-client');
-  return octokit;
+async function loadOctokit() {
+  const { getOctokit } = require('../cli-utils/octokit-client');
+  return await getOctokit();
 }
 
 async function saveFile(content, saveDir, filename) {

--- a/tools/get-console-version.js
+++ b/tools/get-console-version.js
@@ -24,7 +24,8 @@ module.exports = async function getConsoleVersion({ beta = false, fromAntora = f
   }
 
   // Use shared Octokit client
-  const octokit = require('../cli-utils/octokit-client');
+  const { getOctokit } = require('../cli-utils/octokit-client');
+  const octokit = await getOctokit();
 
   // Fetch latest release info
   let data;

--- a/tools/get-redpanda-version.js
+++ b/tools/get-redpanda-version.js
@@ -20,7 +20,8 @@ module.exports = async function getRedpandaVersion({ beta = false, fromAntora = 
   }
 
   // Use shared Octokit client
-  const octokit = require('../cli-utils/octokit-client');
+  const { getOctokit } = require('../cli-utils/octokit-client');
+  const octokit = await getOctokit();
 
   // Fetch version data
   let data;

--- a/tools/redpanda-connect/connector-binary-analyzer.js
+++ b/tools/redpanda-connect/connector-binary-analyzer.js
@@ -1,4 +1,4 @@
-const octokit = require('../../cli-utils/octokit-client');
+const { getOctokit } = require('../../cli-utils/octokit-client');
 const { execSync, spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
@@ -51,6 +51,7 @@ function getPlatformInfo() {
  */
 async function getLatestVersion(binaryType = 'cloud') {
   try {
+    const octokit = await getOctokit();
     const { data: releases } = await octokit.repos.listReleases({
       owner: REPO_OWNER,
       repo: REPO_NAME,
@@ -149,6 +150,7 @@ async function downloadBinary(binaryType, version, destDir) {
   console.log(`Downloading ${binaryType.toUpperCase()} binary v${version} for ${platformInfo.platform}/${platformInfo.arch}...`);
 
   try {
+    const octokit = await getOctokit();
     // Get release information
     const { data: release } = await octokit.repos.getReleaseByTag({
       owner: REPO_OWNER,
@@ -547,6 +549,7 @@ async function getCloudSupport(ossVersion, cloudVersion = null, dataDir = null) 
  */
 async function checkRateLimit() {
   try {
+    const octokit = await getOctokit();
     const { data } = await octokit.rateLimit.get();
     return {
       remaining: data.rate.remaining,

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -1175,7 +1175,8 @@ async function handleRpcnConnectorDocs (options) {
         console.log('\n   INFO: Checking cloud-docs repository for missing connector pages...')
 
         // Use shared Octokit instance
-        const octokit = require('../../cli-utils/octokit-client')
+        const { getOctokit } = require('../../cli-utils/octokit-client')
+        const octokit = await getOctokit()
 
         try {
           // Optimization: Fetch entire directory tree in 1 API call instead of 471 individual calls


### PR DESCRIPTION
Resolves the error: "Error: require() of ES Module @octokit/rest not supported" from api-docs workflow errors https://github.com/redpanda-data/api-docs/actions/workflows/get-cloud-api-spec.yaml

Convert octokit-client.js to use async dynamic import pattern to support ESM-only @octokit/rest v21.1.1.

Changes:
- Convert octokit-client.js from synchronous require() to async import()
- Export getOctokit() async function instead of singleton instance
- Update all 7 consumer files to use async getOctokit() function:
  - extensions/generate-rp-connect-info.js
  - tools/cloud-regions/generate-cloud-regions.js
  - tools/fetch-from-github.js
  - tools/get-console-version.js
  - tools/get-redpanda-version.js
  - tools/redpanda-connect/connector-binary-analyzer.js
  - tools/redpanda-connect/rpcn-connector-docs-handler.js
- Bump version to 4.14.2

Testing:
- All 252 Jest tests pass
- Verified with doc-tools get-console-version
- Verified with doc-tools get-redpanda-version
- Verified with doc-tools fetch command (404 expected for private repo)
- Successfully ran full Antora build with local-antora-playbook.yml
- All extensions loaded and executed correctly in Antora build