### PR TITLE
properties: obligates script to pull from dev before running

### DIFF
--- a/tools/property-extractor/Makefile
+++ b/tools/property-extractor/Makefile
@@ -80,7 +80,11 @@ redpanda-git:
 	else \
 	  git clone -q https://github.com/redpanda-data/redpanda.git "$(REDPANDA_SRC)"; \
 	fi; \
-	if git -C "$(REDPANDA_SRC)" rev-parse --verify -q "$(TAG)" >/dev/null; then \
+	if git -C "$(REDPANDA_SRC)" rev-parse --verify -q "origin/$(TAG)" >/dev/null 2>&1; then \
+	  echo "🔖 Checking out remote branch 'origin/$(TAG)'"; \
+	  git -C "$(REDPANDA_SRC)" checkout -q "$(TAG)" 2>/dev/null || git -C "$(REDPANDA_SRC)" checkout -q -b "$(TAG)" "origin/$(TAG)"; \
+	  git -C "$(REDPANDA_SRC)" reset --hard "origin/$(TAG)" -q; \
+	elif git -C "$(REDPANDA_SRC)" rev-parse --verify -q "$(TAG)" >/dev/null 2>&1; then \
 	  echo "🔖 Checking out '$(TAG)'"; \
 	  git -C "$(REDPANDA_SRC)" checkout -q "$(TAG)"; \
 	else \


### PR DESCRIPTION
Current behavior doesn't run a pull command if you're running against dev. This can lead to unexpected results if the local version is stale.

This PR changes this behavior to always get the latest from origin. 