### PR TITLE
Add convert-llms-to-txt extension for agent-friendly docs

### DIFF
--- a/extensions/convert-llms-to-txt.js
+++ b/extensions/convert-llms-to-txt.js
@@ -1,0 +1,182 @@
+'use strict';
+
+/**
+ * Extracts markdown from llms.adoc page and generates llms.txt and llms-full.txt.
+ *
+ * This extension:
+ * 1. Adds site-url attribute to home component:
+ *    - In preview builds (PREVIEW=true): Uses DEPLOY_PRIME_URL
+ *    - In production builds: Uses playbook.site.url
+ * 2. Finds llms page in home component (after AsciiDoc processing)
+ * 3. Gets the markdown content from page.markdownContents (set by convert-to-markdown extension)
+ * 4. Unpublishes the HTML page
+ * 5. Places llms.txt (markdown) at site root
+ * 6. Generates llms-full.txt with markdown from latest versions
+ *
+ * Must run after convert-to-markdown extension to access page.markdownContents.
+ */
+module.exports.register = function () {
+  const logger = this.getLogger('convert-llms-to-txt-extension');
+  let siteUrl = '';
+
+  // Add site-url attribute to home component
+  this.on('playbookBuilt', ({ playbook }) => {
+    // In preview builds, always use the deploy preview URL
+    if (process.env.PREVIEW === 'true' && process.env.DEPLOY_PRIME_URL) {
+      siteUrl = process.env.DEPLOY_PRIME_URL;
+      logger.info(`Using deploy preview URL: ${siteUrl}`);
+    } else {
+      siteUrl = playbook.site?.url || 'https://docs.redpanda.com';
+      logger.info(`Using site URL: ${siteUrl}`);
+    }
+  });
+
+  this.on('contentClassified', ({ contentCatalog }) => {
+    // Add site-url attribute to home component
+    const homeComponent = contentCatalog.getComponents().find(c => c.name === 'home');
+    if (homeComponent && homeComponent.versions) {
+      homeComponent.versions.forEach(version => {
+        if (!version.asciidoc) version.asciidoc = {};
+        if (!version.asciidoc.attributes) version.asciidoc.attributes = {};
+        version.asciidoc.attributes['site-url'] = siteUrl;
+        logger.debug(`Added site-url attribute to home component: ${siteUrl}`);
+      });
+    }
+  });
+
+  // Run after pagesComposed so convert-to-markdown has already run
+  this.on('beforePublish', ({ contentCatalog, siteCatalog }) => {
+    // Find llms.adoc page in home component (after markdown conversion)
+    const llmsPage = contentCatalog.findBy({
+      component: 'home',
+      family: 'page',
+    }).find(page => page.src.stem === 'llms');
+
+    if (!llmsPage) {
+      logger.warn('No llms page found, skipping llms.txt generation');
+    } else {
+      logger.info(`Found llms page: ${llmsPage.src.path}`);
+      logger.info(`Has markdownContents: ${!!llmsPage.markdownContents}`);
+      logger.info(`Has out: ${!!llmsPage.out}`);
+      try {
+        // The convert-to-markdown extension has already processed this page
+        // and stored the markdown in page.markdownContents
+        if (!llmsPage.markdownContents) {
+          throw new Error('No markdown content found on llms page. Ensure convert-to-markdown extension runs before this extension.');
+        }
+
+        let content = llmsPage.markdownContents.toString('utf8');
+        logger.info(`Extracted ${content.length} bytes of markdown content`);
+
+        // Strip HTML comments added by convert-to-markdown extension
+        // These reference the unpublished /home/llms/ URL which doesn't make sense for llms.txt
+        content = content.replace(/^<!--[\s\S]*?-->\s*/gm, '').trim();
+        logger.debug(`Stripped HTML comments, now ${content.length} bytes`);
+
+        // Unpublish the HTML page FIRST (following unpublish-pages pattern)
+        if (llmsPage.out) {
+          if (!siteCatalog.unpublishedPages) siteCatalog.unpublishedPages = [];
+          if (llmsPage.pub?.url) {
+            siteCatalog.unpublishedPages.push(llmsPage.pub.url);
+          }
+          delete llmsPage.out;
+          logger.info('Unpublished llms HTML page');
+        }
+
+        // Store cleaned markdown content for adding after llms-full.txt
+        llmsPage.llmsTxtContent = content;
+
+      } catch (err) {
+        logger.error(`Failed to extract markdown from llms page: ${err.message}`);
+        logger.debug(err.stack);
+      }
+    }
+
+    // Generate llms-full.txt - aggregate markdown from latest version of each component
+    logger.info('Generating llms-full.txt from latest version pages with markdown...');
+
+    // Get all components and identify latest versions
+    const components = contentCatalog.getComponents();
+    const latestVersions = new Set();
+
+    components.forEach(component => {
+      // Find the latest version (non-prerelease if available, otherwise the first version)
+      const latest = component.latest || component.versions[0];
+      if (latest) {
+        latestVersions.add(`${component.name}@${latest.version}`);
+        logger.debug(`Latest version for ${component.name}: ${latest.version}`);
+      }
+    });
+
+    // Filter pages to only include latest versions
+    const allPages = contentCatalog.getPages((p) => p.markdownContents);
+    const pages = allPages.filter(page => {
+      const pageKey = `${page.src.component}@${page.src.version}`;
+      return latestVersions.has(pageKey);
+    });
+
+    if (!pages.length) {
+      logger.warn('No pages with markdown content found in latest versions, skipping llms-full.txt generation');
+      return;
+    }
+
+    logger.info(`Filtered to ${pages.length} pages from ${latestVersions.size} latest component versions (from ${allPages.length} total pages)`);
+
+    let fullContent = `# Redpanda Documentation - Full Markdown Export\n\n`;
+    fullContent += `> This file contains all documentation pages in markdown format for AI agent consumption.\n`;
+    fullContent += `> Generated from ${pages.length} pages on ${new Date().toISOString()}\n`;
+    fullContent += `> Site: ${siteUrl}\n\n`;
+    fullContent += `## About This Export\n\n`;
+    fullContent += `This export includes only the **latest version** of each component's documentation:\n`;
+    components.forEach(component => {
+      const latest = component.latest || component.versions[0];
+      if (latest) {
+        fullContent += `- **${component.title}**: version ${latest.version}\n`;
+      }
+    });
+    fullContent += `\n`;
+    fullContent += `### Accessing Versioned Content\n\n`;
+    fullContent += `For components with versioned documentation (like Redpanda Self-Managed), older versions can be accessed by replacing the version segment in the URL:\n`;
+    fullContent += `- Latest: \`${siteUrl}/current/page-path\`\n`;
+    fullContent += `- Specific version: \`${siteUrl}/24.3/page-path\`, \`${siteUrl}/25.1/page-path\`, etc.\n\n`;
+    fullContent += `Available versioned components: ${components.filter(c => c.versions.length > 1).map(c => c.name).join(', ')}\n\n`;
+    fullContent += `---\n\n`;
+
+    // Sort pages by URL for consistent ordering
+    pages.sort((a, b) => {
+      const urlA = a.pub?.url || '';
+      const urlB = b.pub?.url || '';
+      return urlA.localeCompare(urlB);
+    });
+
+    pages.forEach((page, index) => {
+      const pageUrl = page.pub?.url ? `${siteUrl}${page.pub.url}` : 'unknown';
+      const pageTitle = page.asciidoc?.doctitle || page.src?.stem || 'Untitled';
+
+      fullContent += `# Page ${index + 1}: ${pageTitle}\n\n`;
+      fullContent += `**URL**: ${pageUrl}\n\n`;
+      fullContent += `---\n\n`;
+      fullContent += page.markdownContents.toString('utf8');
+      fullContent += `\n\n---\n\n`;
+    });
+
+    // Add llms-full.txt to site root
+    siteCatalog.addFile({
+      contents: Buffer.from(fullContent, 'utf8'),
+      out: { path: 'llms-full.txt' },
+    });
+    logger.info(`Generated llms-full.txt with ${pages.length} pages`);
+
+    // Add llms.txt to site root (using content extracted earlier)
+    if (llmsPage && llmsPage.llmsTxtContent) {
+      logger.info('Adding llms.txt to site root');
+      siteCatalog.addFile({
+        contents: Buffer.from(llmsPage.llmsTxtContent, 'utf8'),
+        out: { path: 'llms.txt' },
+      });
+      logger.info('Successfully added llms.txt');
+    } else {
+      logger.warn('llms.txt not generated - page not found or no content extracted');
+    }
+  });
+};

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -10,7 +10,7 @@ content:
   sources:
   - url: .
     branches: HEAD
-    start_paths: [preview/extensions-and-macros, preview/shared]
+    start_paths: [preview/extensions-and-macros, preview/shared, preview/home]
   - url: https://github.com/redpanda-data/docs
     branches: [main, v/*, api, 'site-search', '!v-end-of-life/*']
   - url: https://github.com/redpanda-data/redpanda-labs
@@ -61,6 +61,11 @@ antora:
           file_patterns:
             - '**/docker-compose.yaml'
             - '**/docker-compose.yml'
+        - components:
+            - 'home'
+          file_patterns:
+            - '**/llms.adoc'
+  - require: './extensions/convert-llms-to-txt.js'
   - require: './extensions/archive-attachments'
     data:
       archives:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.14.1",
+  "version": "4.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.14.1",
+      "version": "4.15.0",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.14.1",
+  "version": "4.15.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",
@@ -65,6 +65,7 @@
     "./extensions/find-related-docs": "./extensions/find-related-docs.js",
     "./extensions/unpublish-pages": "./extensions/unpublish-pages.js",
     "./extensions/find-related-labs": "./extensions/find-related-labs.js",
+    "./extensions/convert-llms-to-txt": "./extensions/convert-llms-to-txt.js",
     "./extensions/modify-redirects": "./extensions/produce-redirects.js",
     "./extensions/algolia-indexer/index": "./extensions/algolia-indexer/index.js",
     "./extensions/aggregate-terms": "./extensions/aggregate-terms.js",

--- a/preview/home/antora.yml
+++ b/preview/home/antora.yml
@@ -1,0 +1,6 @@
+name: home
+title: Home
+version: ~
+asciidoc:
+  attributes:
+    test-attribute: Test Value

--- a/preview/home/modules/ROOT/pages/llms.adoc
+++ b/preview/home/modules/ROOT/pages/llms.adoc
@@ -1,0 +1,16 @@
+# Test Documentation
+
+> This is a test llms.adoc file for validating the convert-llms-to-txt extension.
+
+## Test Links
+
+- {site-url}/test-page[Test Page]: A test page link
+- {site-url}/another-page[Another Page]: Another test link
+
+## Test Attributes
+
+The test attribute is: {test-attribute}
+
+## Test Formatting
+
+This has **bold text** and *italic text* and `monospace text`.


### PR DESCRIPTION
## Summary

Adds a new Antora extension that converts `llms.adoc` to plain text files for AI agent consumption, with environment-aware URLs. Uses the `convert-to-markdown` extension to extract markdown content from the rendered page.

## Features

### llms.txt Generation
- Extracts markdown from `llms.adoc` page after conversion by `convert-to-markdown` extension
- Dynamically adds `site-url` attribute from `playbook.site.url`
- Falls back to `DEPLOY_PRIME_URL` env var for Netlify preview deployments
- Unpublishes the HTML page to serve only the `.txt` version
- Places file at site root

### llms-full.txt Generation
- Aggregates **latest version only** of each component's markdown into a single file
- Includes page title, URL, and full markdown for each page
- Sorts pages by URL for consistent ordering
- Adds metadata header with version info and versioned content guidance
- **Result**: 12MB file with 1,583 pages from latest versions (~350k lines)

## Changes

- **New extension**: `extensions/convert-llms-to-txt.js`
  - Runs after `convert-to-markdown` extension in `beforePublish` phase
  - Reads markdown from `page.markdownContents` property
  - Uses add-pages-to-root logic to place files at site root
  - Filters to latest component versions to avoid duplication

- **Package.json**: Export the new extension and bump version to 4.15.0

- **Test site**: Added `preview/home` component with test `llms.adoc`
  - Validates attribute replacement
  - Validates markdown conversion
  - Validates both llms.txt and llms-full.txt generation

## Use Case

This enables docs-site to:
1. Author `llms.txt` as `llms.adoc` with AsciiDoc attributes
2. Use `{site-url}` attribute for all links
3. Automatically generate correct URLs for:
   - Production builds: `https://docs.redpanda.com`
   - PR preview builds: `https://deploy-preview-NNN--redpanda-documentation.netlify.app`
   - Local builds: `http://localhost:8000`
4. Provide full documentation dump for AI agents via `llms-full.txt` (latest versions only)

## Testing

✅ Tested locally and in preview builds:
- **llms.txt**: 7KB with correct URLs and markdown formatting
- **llms-full.txt**: 12MB with 1,583 pages from latest versions (~350k lines)
- Site URL correctly reflects environment (local/preview/production)
- All attributes replaced correctly
- Markdown conversion working properly
- Version filtering working correctly (only latest version of each component)

Preview deployment will show the generated files at:
- https://deploy-preview-173--docs-extensions-and-macros.netlify.app/llms.txt
- https://deploy-preview-173--docs-extensions-and-macros.netlify.app/llms-full.txt

## Related

This will be consumed by redpanda-data/docs-site#159 once merged and published.