### PR TITLE
Fix zero-width spaces in llms.txt URLs

### DIFF
--- a/extensions/convert-llms-to-txt.js
+++ b/extensions/convert-llms-to-txt.js
@@ -73,13 +73,16 @@ module.exports.register = function () {
         content = content.replace(/^<!--[\s\S]*?-->\s*/gm, '').trim();
         logger.debug(`Stripped HTML comments, now ${content.length} bytes`);
 
-        // Fix URLs: convert em dashes back to double hyphens
+        // Fix URLs: convert em dashes back to double hyphens and remove invisible characters
         // The markdown converter applies smart typography that turns -- into — (em dash)
+        // and inserts zero-width spaces (U+200B) and other invisible Unicode characters
         // This breaks URLs like deploy-preview-159--redpanda-documentation.netlify.app
-        content = content.replace(/\(https?:\/\/[^)]*—[^)]*\)/g, (match) => {
-          return match.replace(/—/g, '--');
+        content = content.replace(/\(https?:\/\/[^)]*[—\u200B-\u200D\uFEFF][^)]*\)/g, (match) => {
+          return match
+            .replace(/—/g, '--')
+            .replace(/[\u200B-\u200D\uFEFF]/g, '');
         });
-        logger.debug('Fixed em dashes in URLs');
+        logger.debug('Fixed em dashes and invisible characters in URLs');
 
         // Unpublish the HTML page FIRST (following unpublish-pages pattern)
         if (llmsPage.out) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.15.1",
+  "version": "4.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.15.1",
+      "version": "4.15.2",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.15.1",
+  "version": "4.15.2",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
## Summary

Fixes remaining URL encoding issues in llms.txt where zero-width spaces and other invisible Unicode characters were breaking URLs.

## Problem

After fixing em dashes in PR #174, URLs in llms.txt still contained invisible Unicode characters:
- Zero-width space (U+200B)
- Zero-width non-joiner (U+200C)  
- Zero-width joiner (U+200D)
- Zero-width no-break space (U+FEFF)

These are inserted by the markdown converter's smart typography feature along with em dashes. For example:
```
deploy-preview-159--​redpanda-documentation.netlify.app
```
The `--​` contains an invisible zero-width space after the double hyphens, causing URLs to return 404/503 errors.

## Solution

Updated the URL cleaning regex in convert-llms-to-txt.js to strip all these invisible characters:

```javascript
content = content.replace(/\(https?:\/\/[^)]*[—\u200B-\u200D\uFEFF][^)]*\)/g, (match) => {
  return match
    .replace(/—/g, '--')
    .replace(/[\u200B-\u200D\uFEFF]/g, '');
});
```

## Testing

After this fix, all URLs in llms.txt should resolve correctly and afdocs link resolution checks should pass.

## Changes

- `extensions/convert-llms-to-txt.js` - Added invisible character stripping
- `package.json` - Bumped version to 4.15.2
- `package-lock.json` - Updated for new version