### PR TITLE
Wrap `$ref` with sibling properties in `allOf` during OpenAPI spec bundling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ gen/
 tree-sitter/
 test/
 test-results/
+coverage/
 __tests__/.test-cgo-detection/
 modules/
 cloud-controlplane/

--- a/__tests__/tools/bundle-openapi.test.js
+++ b/__tests__/tools/bundle-openapi.test.js
@@ -11,6 +11,7 @@ const {
   normalizeTag,
   getMajorMinor,
   sortObjectKeys,
+  wrapRefSiblings,
   detectBundler,
   createEntrypoint,
   runBundler,
@@ -157,6 +158,124 @@ describe('OpenAPI Bundle Tool - Production Test Suite', () => {
         expect(sortObjectKeys({})).toEqual({});
         expect(sortObjectKeys([])).toEqual([]);
         expect(sortObjectKeys({ a: {}, b: [] })).toEqual({ a: {}, b: [] });
+      });
+    });
+
+    describe('wrapRefSiblings', () => {
+      test('should wrap $ref with sibling description into allOf', () => {
+        const input = {
+          '$ref': '#/components/schemas/Timestamp',
+          description: 'When the password was set.',
+          readOnly: true
+        };
+        const result = wrapRefSiblings(input);
+        expect(result.allOf).toEqual([{ '$ref': '#/components/schemas/Timestamp' }]);
+        expect(result.description).toBe('When the password was set.');
+        expect(result.readOnly).toBe(true);
+        expect(result['$ref']).toBeUndefined();
+      });
+
+      test('should not wrap $ref when it is the only property', () => {
+        const input = { '$ref': '#/components/schemas/Timestamp' };
+        const result = wrapRefSiblings(input);
+        expect(result['$ref']).toBe('#/components/schemas/Timestamp');
+        expect(result.allOf).toBeUndefined();
+      });
+
+      test('should not double-wrap if allOf already exists', () => {
+        const input = {
+          allOf: [{ '$ref': '#/components/schemas/Timestamp' }],
+          '$ref': '#/components/schemas/Other',
+          description: 'Already wrapped.'
+        };
+        const result = wrapRefSiblings(input);
+        // allOf should still have exactly one entry (the original)
+        expect(result.allOf).toEqual([{ '$ref': '#/components/schemas/Timestamp' }]);
+        // $ref stays because allOf already existed
+        expect(result['$ref']).toBe('#/components/schemas/Other');
+      });
+
+      test('should recurse into nested properties', () => {
+        const input = {
+          type: 'object',
+          properties: {
+            passwordSetAt: {
+              '$ref': '#/components/schemas/Timestamp',
+              description: 'When password was set.',
+              title: 'password_set_at'
+            },
+            name: {
+              type: 'string',
+              description: 'User name'
+            }
+          }
+        };
+        const result = wrapRefSiblings(input);
+        expect(result.properties.passwordSetAt.allOf).toEqual([
+          { '$ref': '#/components/schemas/Timestamp' }
+        ]);
+        expect(result.properties.passwordSetAt.description).toBe('When password was set.');
+        expect(result.properties.passwordSetAt.title).toBe('password_set_at');
+        expect(result.properties.passwordSetAt['$ref']).toBeUndefined();
+        // Non-$ref properties should be unchanged
+        expect(result.properties.name.type).toBe('string');
+      });
+
+      test('should recurse into arrays (oneOf, anyOf, items)', () => {
+        const input = {
+          oneOf: [
+            {
+              '$ref': '#/components/schemas/Role',
+              description: 'A role reference.'
+            },
+            { type: 'string' }
+          ]
+        };
+        const result = wrapRefSiblings(input);
+        expect(result.oneOf[0].allOf).toEqual([
+          { '$ref': '#/components/schemas/Role' }
+        ]);
+        expect(result.oneOf[0].description).toBe('A role reference.');
+        expect(result.oneOf[1].type).toBe('string');
+      });
+
+      test('should handle primitives and null', () => {
+        expect(wrapRefSiblings(null)).toBe(null);
+        expect(wrapRefSiblings('string')).toBe('string');
+        expect(wrapRefSiblings(42)).toBe(42);
+        expect(wrapRefSiblings(undefined)).toBe(undefined);
+      });
+
+      test('should handle deeply nested structures', () => {
+        const input = {
+          paths: {
+            '/users': {
+              get: {
+                responses: {
+                  '200': {
+                    content: {
+                      'application/json': {
+                        schema: {
+                          properties: {
+                            expire: {
+                              '$ref': '#/components/schemas/Timestamp',
+                              description: 'Expiry time.'
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+        const result = wrapRefSiblings(input);
+        const expire = result.paths['/users'].get.responses['200'].content['application/json'].schema.properties.expire;
+        expect(expire.allOf).toEqual([{ '$ref': '#/components/schemas/Timestamp' }]);
+        expect(expire.description).toBe('Expiry time.');
+        expect(expire['$ref']).toBeUndefined();
       });
     });
   });
@@ -382,6 +501,57 @@ components:
         const result = postProcessBundle(testBundleFile, options);
         
         expect(result.info.title).toBe('Redpanda Connect RPCs');
+      });
+
+      test('should wrap $ref siblings into allOf during post-processing', () => {
+        const bundleWithRefs = path.join(mockTempDir, 'ref-bundle.yaml');
+        const content = `
+openapi: 3.1.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      summary: Test endpoint
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        passwordSetAt:
+          $ref: "#/components/schemas/google.protobuf.Timestamp"
+          description: "When the password was last set."
+          readOnly: true
+        name:
+          type: string
+    google.protobuf.Timestamp:
+      type: object
+      description: A generic timestamp.
+`.trim();
+        fs.writeFileSync(bundleWithRefs, content);
+
+        const options = {
+          surface: 'admin',
+          normalizedTag: '25.2.4',
+          majorMinor: '25.2',
+          adminMajor: 'v2'
+        };
+
+        const result = postProcessBundle(bundleWithRefs, options);
+
+        const passwordSetAt = result.components.schemas.User.properties.passwordSetAt;
+        expect(passwordSetAt.allOf).toEqual([
+          { '$ref': '#/components/schemas/google.protobuf.Timestamp' }
+        ]);
+        expect(passwordSetAt.description).toBe('When the password was last set.');
+        expect(passwordSetAt.readOnly).toBe(true);
+        expect(passwordSetAt['$ref']).toBeUndefined();
+
+        // Lone $ref should NOT be wrapped
+        const timestamp = result.components.schemas['google.protobuf.Timestamp'];
+        expect(timestamp['$ref']).toBeUndefined();
+        expect(timestamp.allOf).toBeUndefined();
       });
 
       test('should sort keys deterministically', () => {

--- a/tools/bundle-openapi.js
+++ b/tools/bundle-openapi.js
@@ -249,6 +249,53 @@ function createEntrypoint(tempDir, apiSurface) {
 }
 
 /**
+ * Wrap $ref siblings into allOf to preserve field-level descriptions.
+ *
+ * OpenAPI 3.1 renderers (e.g. Bump.sh) ignore sibling properties next to $ref
+ * and instead display the generic description from the referenced schema.
+ * This function transforms { $ref, description, ... } into
+ * { allOf: [{ $ref }], description, ... } so renderers pick up field-level
+ * descriptions correctly.
+ *
+ * @param {*} node - Any value from the parsed OpenAPI spec.
+ * @returns {*} The transformed value (mutates in place for objects).
+ */
+function wrapRefSiblings(node) {
+  if (node === null || typeof node !== 'object') {
+    return node;
+  }
+
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => {
+      node[i] = wrapRefSiblings(item);
+    });
+    return node;
+  }
+
+  // Check if this object has $ref with sibling properties that need wrapping
+  if (node['$ref'] && typeof node['$ref'] === 'string') {
+    const keys = Object.keys(node);
+    const hasSiblings = keys.length > 1;
+
+    if (hasSiblings) {
+      // Don't double-wrap if allOf already exists
+      if (!node.allOf) {
+        const ref = node['$ref'];
+        delete node['$ref'];
+        node.allOf = [{ '$ref': ref }];
+      }
+    }
+  }
+
+  // Recurse into all object values
+  for (const key of Object.keys(node)) {
+    node[key] = wrapRefSiblings(node[key]);
+  }
+
+  return node;
+}
+
+/**
  * Bundle one or more OpenAPI fragment files into a single bundled YAML using a selected external bundler.
  *
  * Merges multiple fragment files into a temporary single entrypoint when required, invokes the specified bundler
@@ -529,6 +576,9 @@ function postProcessBundle(filePath, options, quiet = false) {
     bundle.info['x-generated-at'] = new Date().toISOString();
     bundle.info['x-generator'] = 'redpanda-docs-openapi-bundler';
 
+    // Wrap $ref siblings into allOf so renderers display field descriptions
+    wrapRefSiblings(bundle);
+
     // Sort keys for deterministic output
     const sortedBundle = sortObjectKeys(bundle);
     
@@ -776,6 +826,7 @@ module.exports = {
   normalizeTag,
   getMajorMinor,
   sortObjectKeys,
+  wrapRefSiblings,
   detectBundler,
   createEntrypoint,
   postProcessBundle


### PR DESCRIPTION
Related: https://github.com/redpanda-data/api-docs/pull/60

In OpenAPI 3.0, properties placed alongside $ref (like description and readOnly) are [silently ignored](https://www.learnjsonschema.com/draft4/core/ref/). This causes our rendered API docs on Bump.sh to show the referenced schema's description instead of the more specific inline description.

This PR adds a post-processing step to `bundle-openapi` that wraps $ref nodes having sibling properties in `allOf`:

```
# Before                          # After
passwordSetAt:                    passwordSetAt:
  $ref: "...Timestamp"              allOf:
  description: "The timestamp…"        - $ref: "...Timestamp"
  readOnly: true                    description: "The timestamp…"
                                    readOnly: true
```

The result is already implemented in https://github.com/redpanda-data/api-docs/blob/main/admin/admin-v2.yaml (For example this [instance](https://github.com/redpanda-data/api-docs/blob/main/admin/admin-v2.yaml#L1738) of `passwordsetAt` displays [this description](https://docs.redpanda.com/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-securityservice-getscramcredential#operation-redpanda-core-admin-v2-securityservice-getscramcredential-200-body-application-json-scramcredential-passwordsetat) in the docs, and not `google.protobuf.Timestamp`'s)

This is the standard workaround for OpenAPI 3.0 and has been confirmed as the correct approach by Bump.sh's developer team. The transformation is done during bundling and no changes are needed to source specs.