### PR TITLE
fix: place frontmatter after H1 heading in markdown exports

### DIFF
--- a/__tests__/extensions/convert-to-markdown.test.js
+++ b/__tests__/extensions/convert-to-markdown.test.js
@@ -154,3 +154,61 @@ describe('absolute-links rule (from extension)', () => {
     expect(result).toBe('[GitHub](https://github.com/redpanda-data)')
   })
 })
+
+describe('H1 and frontmatter placement', () => {
+  function processMarkdownWithFrontmatter(markdown, frontmatter) {
+    // Simulate the logic from convert-to-markdown.js lines 493-513
+    const h1Match = markdown.match(/^(#\s+.+?)(\n|$)/)
+    let h1Heading = ''
+    let restOfMarkdown = markdown
+
+    if (h1Match) {
+      h1Heading = h1Match[0]
+      restOfMarkdown = markdown.substring(h1Match[0].length).trimStart()
+    }
+
+    // Simplified: just frontmatter placement (matches line 513 logic)
+    let result
+    if (frontmatter) {
+      result = `${h1Heading}\n${frontmatter}${restOfMarkdown}`
+    } else {
+      result = markdown
+    }
+
+    // Apply cleanup logic (lines 517-523)
+    if (result) {
+      result = result.replace(/\n{3,}/g, '\n\n')
+      result = result.replace(/[ \t]+$/gm, '')
+      result = result.trim()
+    }
+
+    return result
+  }
+
+  const frontmatter = '---\ntitle: Test\n---\n'
+
+  test('places frontmatter after H1 at document start', () => {
+    const markdown = '# Heading\n\nSome content'
+    const result = processMarkdownWithFrontmatter(markdown, frontmatter)
+    expect(result).toBe('# Heading\n\n---\ntitle: Test\n---\nSome content')
+  })
+
+  test('places frontmatter at top when no H1', () => {
+    const markdown = 'Some content without heading'
+    const result = processMarkdownWithFrontmatter(markdown, frontmatter)
+    expect(result).toBe('---\ntitle: Test\n---\nSome content without heading')
+  })
+
+  test('does not match H1 later in document (bug fix)', () => {
+    const markdown = 'Intro text\n\n# Heading Later\n\nMore content'
+    const result = processMarkdownWithFrontmatter(markdown, frontmatter)
+    // Should place frontmatter at top since H1 is not at document start
+    expect(result).toBe('---\ntitle: Test\n---\nIntro text\n\n# Heading Later\n\nMore content')
+  })
+
+  test('handles H1 with double newline separator', () => {
+    const markdown = '# Heading\n\nParagraph one\n\nParagraph two'
+    const result = processMarkdownWithFrontmatter(markdown, frontmatter)
+    expect(result).toBe('# Heading\n\n---\ntitle: Test\n---\nParagraph one\n\nParagraph two')
+  })
+})

--- a/extensions/convert-to-markdown.js
+++ b/extensions/convert-to-markdown.js
@@ -490,17 +490,27 @@ module.exports.register = function () {
             logger.debug(`Generated frontmatter for ${page.src?.path}`)
           }
 
-          // Prepend frontmatter first, then source reference and AI-friendly note
+          // Extract H1 heading if present
+          const h1Match = markdown.match(/^(#\s+.+?)(\n|$)/m)
+          let h1Heading = ''
+          let restOfMarkdown = markdown
+
+          if (h1Match) {
+            h1Heading = h1Match[0]
+            restOfMarkdown = markdown.substring(h1Match[0].length).trimStart()
+          }
+
+          // Add frontmatter AFTER H1 heading, then source reference and AI-friendly note
           if (canonicalUrl) {
             const componentName = page.src?.component || '';
             const urlHint = componentName
               ? `<!-- Note for AI: This is a Markdown export. For aggregated content, see /llms.txt (curated overview), /${componentName}-full.txt (this component only), or /llms-full.txt (complete documentation). -->`
               : `<!-- Note for AI: This is a Markdown export. For aggregated content, see /llms.txt (curated overview) or /llms-full.txt (complete documentation). -->`;
 
-            markdown = `${frontmatter}<!-- Source: ${canonicalUrl} -->\n${urlHint}\n\n${markdown}`
+            markdown = `${h1Heading}\n${frontmatter}<!-- Source: ${canonicalUrl} -->\n${urlHint}\n\n${restOfMarkdown}`
           } else if (frontmatter) {
-            // If no canonical URL but we have frontmatter, still add it
-            markdown = `${frontmatter}${markdown}`
+            // If no canonical URL but we have frontmatter, still add it after H1
+            markdown = `${h1Heading}\n${frontmatter}${restOfMarkdown}`
           }
 
           // Clean up unnecessary whitespace

--- a/extensions/convert-to-markdown.js
+++ b/extensions/convert-to-markdown.js
@@ -490,8 +490,8 @@ module.exports.register = function () {
             logger.debug(`Generated frontmatter for ${page.src?.path}`)
           }
 
-          // Extract H1 heading if present
-          const h1Match = markdown.match(/^(#\s+.+?)(\n|$)/m)
+          // Extract H1 heading if present (only at document start)
+          const h1Match = markdown.match(/^(#\s+.+?)(\n|$)/)
           let h1Heading = ''
           let restOfMarkdown = markdown
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.15.5",
+  "version": "4.15.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.15.5",
+      "version": "4.15.6",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.15.5",
+  "version": "4.15.6",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
## Summary

Move YAML frontmatter to appear after the H1 heading instead of at the beginning of markdown files. This improves compatibility with markdown parsers and AI tools that expect standard markdown structure.

## Changes

- Extract H1 heading from markdown content before adding frontmatter
- Place frontmatter immediately after H1 heading
- Maintain source comments and AI hints in correct position after frontmatter
- Bump version to 4.15.6
- Update package-lock.json

## Before

```markdown
---
title: Example
---
<!-- Source: ... -->

# Example Page

Content here
```

## After

```markdown
# Example Page

---
title: Example
---
<!-- Source: ... -->

Content here
```

## Testing

Built and tested locally with docs-site. Verified frontmatter now appears after H1 in all exported markdown files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)