### PR TITLE
feat: Redpanda Connect connector docs automation with multi-release attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ Redpanda's API documentation is split into many small OpenAPI files. This tool c
 Run it like this:
 
 ```bash
-npx doc-tools generate bundle-openapi --tag v25.3.1
+npx doc-tools generate bundle-openapi --tag v25.3.1 --surface both
 ```
 
 ## Command-line tools
@@ -160,15 +160,15 @@ npx doc-tools get-console-version
 
 ### Download files from GitHub
 
-Sometimes you need files from a specific version of Redpanda. This command downloads them for you.
+Sometimes you need files from GitHub repositories. This command downloads them for you.
 
 ```bash
 # Download a specific directory from GitHub
 npx doc-tools fetch \
-  --repo redpanda-data/redpanda \
-  --path src/v/config \
-  --tag v25.3.1 \
-  --output ./fetched
+  --owner redpanda-data \
+  --repo redpanda \
+  --remote-path src/v/config \
+  --save-dir ./fetched
 ```
 
 ### Set up AI assistant integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,354 @@
+# Redpanda Documentation Extensions and Automation
+
+This repository contains tools that help write and maintain Redpanda's technical documentation. Think of it as a toolbox that automatically generates documentation from source code, so technical writers don't have to manually update documentation every time the software changes.
+
+## What this repository does
+
+This toolbox helps Redpanda's documentation team in several ways. When Redpanda releases a new version, these tools extract information from the code (like configuration options, commands, and features) and create documentation pages automatically. They provide reusable templates and shortcuts that ensure all docs look and work the same way. Instead of manually documenting hundreds of configuration options or commands, these tools do it automatically. The repository also includes a bridge that lets Claude Code (an AI assistant) help with documentation tasks through natural conversation.
+
+## Documentation for this repository
+
+### If you write documentation
+
+The [Command Reference](CLI_REFERENCE.adoc) shows all the commands you can run to generate documentation. You'll learn how to get version numbers, generate different types of docs, and set up AI assistant integration.
+
+The [AI Assistant User Guide](mcp/USER_GUIDE.adoc) explains how to use Claude Code to help with documentation. It includes step-by-step setup instructions, describes what tasks the AI can help with, and shows you how to troubleshoot problems.
+
+The [AI Cost Guide](mcp/COSTS.adoc) breaks down how much it costs to use AI features. It shows the price per operation (ranging from $0.017 to $0.190), explains which AI model to choose for different tasks, and provides tips to reduce costs.
+
+### If you build or maintain these tools
+
+The [Contributing Guide](CONTRIBUTING.adoc) helps developers working on this codebase. It covers how to set up your development environment, run tests, and submit changes.
+
+The [AI Integration Developer Guide](mcp/DEVELOPMENT.adoc) explains how the system is designed, how to add new AI-powered tools, and how to test your changes.
+
+The [Command Interface Specification](mcp/CLI_INTERFACE.adoc) defines the technical contract for command-line tools. It specifies how commands should be structured, what output format to use, and how to handle errors.
+
+The [Antora Extensions Guide](extensions/README.adoc) documents custom build system plugins. Antora is the documentation build system Redpanda uses. Extensions are add-ons that give Antora new capabilities. Examples include automatically fetching version numbers and generating navigation menus.
+
+The [AsciiDoc Shortcuts Guide](macros/README.adoc) explains reusable documentation snippets. AsciiDoc is the markup language used for writing docs (like Markdown but more powerful). Macros are shortcuts that let you insert complex content with simple commands. Examples include tooltips for technical terms and links to configuration options.
+
+## Automatic documentation generators
+
+These tools read Redpanda's source code and automatically create documentation pages.
+
+### Connector documentation generator
+
+Location: [`tools/redpanda-connect/`](tools/redpanda-connect/)
+
+Redpanda Connect has hundreds of connectors (plugins that connect to different systems like Kafka, databases, and cloud services). When new versions are released, connectors are added, removed, or changed. This tool automatically detects those changes and updates the documentation.
+
+See the [AUTOMATION.md](tools/redpanda-connect/AUTOMATION.md) and [README.adoc](tools/redpanda-connect/README.adoc) for detailed documentation.
+
+The tool works by running Redpanda Connect command-line tools to get a list of all connectors. It compares the list to the previous version to find what changed. Then it downloads the actual software to determine which connectors work in the cloud versus self-hosted environments. It creates documentation pages for each connector with all its configuration options. Finally, it generates a summary for pull requests showing what documentation needs updating.
+
+Run it like this:
+
+```bash
+npx doc-tools generate rpcn-connector-docs --fetch-connectors
+```
+
+The tool includes several special features. Multi-version tracking means if you miss documenting several releases (say 4.81.0 through 4.85.0), it processes each release separately to correctly attribute which features appeared in which version. Platform detection automatically figures out if a connector works in Redpanda Cloud, self-hosted Redpanda, or both. Binary analysis detects connectors that require special compilation (CGO). Change summaries create a detailed summary of all changes across multiple releases for pull requests.
+
+### Configuration properties generator
+
+Location: [`tools/property-extractor/`](tools/property-extractor/)
+
+Redpanda has hundreds of configuration settings (things like memory limits, timeout values, and security options). These are defined in C++ code. Instead of manually documenting each one, this tool reads the C++ code and generates documentation automatically.
+
+See [README.adoc](tools/property-extractor/README.adoc) for detailed documentation.
+
+The tool downloads Redpanda source code for a specific version, then parses the C++ code to find configuration property definitions. It extracts property names, default values, descriptions, and valid ranges. The tool creates both JSON data files and documentation pages. You can override auto-generated descriptions with custom text when needed.
+
+Run it like this:
+
+```bash
+npx doc-tools generate property-docs --tag v25.3.1
+```
+
+The tool creates several files. `docs-data/cluster-properties-{version}.json` contains all cluster-level settings. `docs-data/topic-properties-{version}.json` contains all topic-level settings. `modules/.../partials/cluster-properties.adoc` is the documentation page for cluster settings. `modules/.../partials/topic-properties.adoc` is the documentation page for topic settings.
+
+### Metrics documentation generator
+
+Location: [`tools/metrics-extractor/`](tools/metrics-extractor/)
+
+Redpanda exposes hundreds of metrics (measurements like CPU usage, message throughput, and disk I/O) for monitoring. These metrics are defined in C++ code. This tool automatically generates documentation for all metrics.
+
+The tool downloads Redpanda source code and uses a specialized parser (Tree-sitter) to understand C++ code structure. It finds metric definitions in the code, extracts metric names, types, and descriptions, then generates reference documentation pages.
+
+Run it like this:
+
+```bash
+npx doc-tools generate metrics-docs --tag v25.3.1
+```
+
+### Command-line tool documentation generator
+
+Location: [`tools/gen-rpk-ascii.py`](tools/gen-rpk-ascii.py)
+
+Redpanda's command-line tool (rpk) has dozens of commands with many options. Instead of manually documenting each command, this tool runs the commands to extract their help text and generates documentation.
+
+The tool downloads Redpanda source code, builds the rpk command-line tool, runs each command with the `--help` flag to get usage information, then converts the help text into documentation pages.
+
+Run it like this:
+
+```bash
+npx doc-tools generate rpk-docs --tag v25.3.1
+```
+
+### Helm chart documentation generator
+
+Location: [`tools/generate-cli-docs.js`](tools/generate-cli-docs.js)
+
+Helm charts are packages used to deploy Redpanda on Kubernetes. They have many configuration values. This tool reads the `values.yaml` file (where all options are defined) and generates documentation.
+
+Run it like this:
+
+```bash
+npx doc-tools generate helm-spec --tag v25.1.2
+```
+
+### Kubernetes resource documentation generator
+
+Kubernetes Custom Resource Definitions (CRDs) define how Redpanda integrates with Kubernetes. These are complex YAML structures. This tool generates documentation from the CRD definitions.
+
+Run it like this:
+
+```bash
+npx doc-tools generate crd-spec --tag operator/v25.1.2
+```
+
+### Cloud regions table generator
+
+Location: [`tools/cloud-regions/`](tools/cloud-regions/)
+
+Redpanda Cloud is available in different regions (like us-east-1, eu-west-1) with different tiers (free, paid, enterprise). This information is stored in a YAML file. This tool converts it into a documentation table.
+
+Run it like this:
+
+```bash
+npx doc-tools generate cloud-regions
+```
+
+### API documentation bundler
+
+Location: [`tools/bundle-openapi.js`](tools/bundle-openapi.js)
+
+Redpanda's API documentation is split into many small OpenAPI files. This tool combines them into single, complete API specification files that documentation tools can use.
+
+Run it like this:
+
+```bash
+npx doc-tools generate bundle-openapi --tag v25.3.1
+```
+
+## Command-line tools
+
+These utility commands help with documentation tasks.
+
+### Get version numbers
+
+These commands check GitHub to find the latest version numbers, which you need when generating documentation.
+
+```bash
+# Find the latest Redpanda version
+npx doc-tools get-redpanda-version
+
+# Find the latest Redpanda Console version
+npx doc-tools get-console-version
+```
+
+### Download files from GitHub
+
+Sometimes you need files from a specific version of Redpanda. This command downloads them for you.
+
+```bash
+# Download a specific directory from GitHub
+npx doc-tools fetch \
+  --repo redpanda-data/redpanda \
+  --path src/v/config \
+  --tag v25.3.1 \
+  --output ./fetched
+```
+
+### Set up AI assistant integration
+
+These commands configure Claude Code (an AI assistant) to work with these documentation tools.
+
+```bash
+# Connect Claude Code to these tools
+npx doc-tools setup-mcp --local
+
+# Check that everything is configured correctly
+npx doc-tools validate-mcp
+
+# See what version you have installed
+npx doc-tools mcp-version
+```
+
+### Install testing tools
+
+This installs everything needed to test the documentation tools (Docker images, Python packages, etc).
+
+```bash
+# Set up a complete testing environment
+npx doc-tools install-test-dependencies
+```
+
+## Antora build system extensions
+
+Location: [`extensions/`](extensions/)
+
+Antora is the tool that builds Redpanda's documentation website from source files. These extensions add new capabilities to Antora.
+
+See [extensions/README.adoc](extensions/README.adoc) for more details.
+
+Version management extensions automatically fetch the latest version numbers from GitHub instead of hardcoding them. Content generation extensions create index pages, category lists, and other structured content automatically. Navigation extensions manage page visibility, redirects, and links between different versions. Third-party integration extensions connect to search engines (Algolia), show end-of-life banners, and suggest related content. File processing extensions package attachments, replace variables, and collect code samples.
+
+## AsciiDoc shortcuts (macros)
+
+Location: [`macros/`](macros/)
+
+Shortcuts let you insert complex documentation elements with simple commands. AsciiDoc is the markup language used for writing Redpanda docs (similar to Markdown but more powerful).
+
+See [macros/README.adoc](macros/README.adoc) for more details.
+
+The `glossterm` macro adds tooltips that explain technical terms when users hover over them. The `config_ref` macro creates links to configuration property documentation. The `helm_ref` macro creates links to Helm chart configuration values. The `components_by_category` macro shows all Redpanda Connect connectors organized by category. The `component_table` macro creates a searchable table of connectors.
+
+## AI assistant integration (MCP server)
+
+Location: [`mcp/`](mcp/)
+
+A bridge connects Claude Code (an AI assistant) to these documentation tools. Once you set it up, you can ask Claude to generate documentation in plain English instead of memorizing commands.
+
+See [mcp/README.adoc](mcp/README.adoc) for more details.
+
+Set it up like this:
+
+```bash
+cd /path/to/docs-extensions-and-macros
+npm install
+npx doc-tools setup-mcp --local
+```
+
+Claude can perform several tasks for you. The `get_redpanda_version` tool looks up the latest version numbers. The `generate_property_docs` tool creates configuration property documentation. The `generate_metrics_docs` tool creates metrics documentation. The `generate_rpk_docs` tool creates command-line tool documentation. The `generate_rpcn_connector_docs` tool creates connector documentation. The `generate_helm_docs` tool creates Helm chart documentation. The `generate_crd_docs` tool creates Kubernetes resource documentation. The `generate_bundle_openapi` tool bundles API documentation. The `generate_cloud_regions` tool creates cloud regions tables. The `review_generated_docs` tool checks generated documentation for quality issues. The `get_antora_structure` tool analyzes the documentation repository structure.
+
+Example conversation:
+
+```
+You: "What's the latest Redpanda version?"
+Claude: "Let me check... The latest version is v25.3.1"
+
+You: "Generate property docs for that version"
+Claude: "I'll generate the configuration property documentation for v25.3.1..."
+        [runs the command and shows you the results]
+```
+
+## Installation
+
+### Using these tools in your documentation project
+
+If you maintain a Redpanda documentation site and want to use these tools:
+
+```bash
+npm install @redpanda-data/docs-extensions-and-macros
+```
+
+### Setting up for development
+
+If you want to improve these tools or fix bugs, download the code and install dependencies:
+
+```bash
+# Download the code
+git clone git@github.com:redpanda-data/docs-extensions-and-macros.git
+cd docs-extensions-and-macros
+
+# Install dependencies
+npm install
+
+# Run tests to make sure everything works
+npm test
+```
+
+### Using your local changes in another project
+
+If you're working on these tools and want to test them in a documentation project, create a link in this repository, then use the link in your documentation project:
+
+```bash
+# In this repository, create a link
+cd docs-extensions-and-macros
+npm link
+
+# In your documentation project, use the link
+cd ../your-docs-repo
+npm link @redpanda-data/docs-extensions-and-macros
+```
+
+## Testing
+
+Run all tests:
+
+```bash
+npm test
+```
+
+Test only AI integration features:
+
+```bash
+npm test -- __tests__/mcp/
+```
+
+Test only documentation generators:
+
+```bash
+npm test -- __tests__/tools/
+```
+
+Run tests and see how much code is covered by tests:
+
+```bash
+npm run test:coverage
+```
+
+## How this repository is organized
+
+```
+docs-extensions-and-macros/
+├── bin/
+│   └── doc-tools.js          # Main command-line entry point
+├── extensions/               # Antora build system plugins
+│   ├── version-fetcher/      # Auto-fetch version numbers
+│   ├── config-ref/           # Link to config properties
+│   └── ...
+├── macros/                   # AsciiDoc shortcuts
+│   ├── glossary/             # Tooltip definitions
+│   ├── config-ref/           # Config property links
+│   └── ...
+├── mcp/                      # AI assistant integration
+│   ├── server.js             # MCP server implementation
+│   ├── USER_GUIDE.adoc       # How to use AI features
+│   ├── DEVELOPMENT.adoc      # How to build AI features
+│   └── ...
+├── tools/                    # Documentation generators
+│   ├── redpanda-connect/     # Connector docs automation
+│   ├── property-extractor/   # Config properties automation
+│   ├── metrics-extractor/    # Metrics automation
+│   ├── cloud-regions/        # Cloud regions table
+│   └── ...
+├── cli-utils/                # Shared command-line utilities
+├── __tests__/                # Automated tests
+├── CLI_REFERENCE.adoc        # Complete command reference
+└── README.adoc               # Main repository documentation
+```
+
+## Contributing
+
+See [CONTRIBUTING.adoc](CONTRIBUTING.adoc) for information on how to set up your development environment, coding standards to follow, how to write tests, and how to submit your changes.
+
+## Getting help
+
+Found a bug? [Report it on GitHub Issues](https://github.com/redpanda-data/docs-extensions-and-macros/issues).
+
+Have a question? [Ask on GitHub Issues](https://github.com/redpanda-data/docs-extensions-and-macros/issues).
+
+Want a new feature? [Suggest it on GitHub Issues](https://github.com/redpanda-data/docs-extensions-and-macros/issues).

--- a/CLI_REFERENCE.adoc
+++ b/CLI_REFERENCE.adoc
@@ -789,6 +789,12 @@ Cloud binary version (default: auto-detect latest)
 `--cgo-version <version>`::
 cgo binary version (default: same as cloud-version)
 
+`--skip-intermediate`::
+Skip intermediate release processing (legacy mode - only compare latest vs last documented)
+
+`--from-version <version>`::
+Override starting version instead of using antora.yml (useful for backfilling)
+
 `-h, --help`::
 display help for command
 

--- a/__tests__/tools/buildConfigYaml.test.js
+++ b/__tests__/tools/buildConfigYaml.test.js
@@ -1,0 +1,225 @@
+'use strict';
+
+const buildConfigYaml = require('../../tools/redpanda-connect/helpers/buildConfigYaml');
+
+describe('buildConfigYaml', () => {
+  const sampleChildren = [
+    {
+      name: 'host',
+      type: 'string',
+      kind: 'scalar',
+      description: 'The host to connect to.',
+      default: 'localhost'
+    },
+    {
+      name: 'port',
+      type: 'int',
+      kind: 'scalar',
+      description: 'The port number.',
+      default: 8080
+    }
+  ];
+
+  describe('label field inclusion', () => {
+    it('should include label for inputs', () => {
+      const result = buildConfigYaml('inputs', 'kafka', sampleChildren, false);
+      expect(result).toContain('inputs:');
+      expect(result).toContain('  label: ""');
+      expect(result).toContain('  kafka:');
+    });
+
+    it('should include label for outputs', () => {
+      const result = buildConfigYaml('outputs', 'kafka', sampleChildren, false);
+      expect(result).toContain('outputs:');
+      expect(result).toContain('  label: ""');
+      expect(result).toContain('  kafka:');
+    });
+
+    it('should include label for processors', () => {
+      const result = buildConfigYaml('processors', 'jq', sampleChildren, false);
+      expect(result).toContain('processors:');
+      expect(result).toContain('  label: ""');
+      expect(result).toContain('  jq:');
+    });
+
+    it('should NOT include label for metrics', () => {
+      const result = buildConfigYaml('metrics', 'prometheus', sampleChildren, false);
+      expect(result).toContain('metrics:');
+      expect(result).not.toContain('  label: ""');
+      expect(result).toContain('  prometheus:');
+    });
+
+    it('should NOT include label for caches', () => {
+      const result = buildConfigYaml('caches', 'memory', sampleChildren, false);
+      expect(result).toContain('caches:');
+      expect(result).not.toContain('  label: ""');
+      expect(result).toContain('  memory:');
+    });
+
+    it('should NOT include label for buffers', () => {
+      const result = buildConfigYaml('buffers', 'memory', sampleChildren, false);
+      expect(result).toContain('buffers:');
+      expect(result).not.toContain('  label: ""');
+      expect(result).toContain('  memory:');
+    });
+
+    it('should NOT include label for tracers', () => {
+      const result = buildConfigYaml('tracers', 'jaeger', sampleChildren, false);
+      expect(result).toContain('tracers:');
+      expect(result).not.toContain('  label: ""');
+      expect(result).toContain('  jaeger:');
+    });
+
+    it('should NOT include label for rate-limits', () => {
+      const result = buildConfigYaml('rate-limits', 'local', sampleChildren, false);
+      expect(result).toContain('rate-limits:');
+      expect(result).not.toContain('  label: ""');
+      expect(result).toContain('  local:');
+    });
+
+    it('should NOT include label for scanners', () => {
+      const result = buildConfigYaml('scanners', 'csv', sampleChildren, false);
+      expect(result).toContain('scanners:');
+      expect(result).not.toContain('  label: ""');
+      expect(result).toContain('  csv:');
+    });
+  });
+
+  describe('basic structure', () => {
+    it('should render children fields with correct indentation', () => {
+      const result = buildConfigYaml('inputs', 'kafka', sampleChildren, false);
+
+      // Check that children are rendered with 4-space indent
+      expect(result).toContain('    host:');
+      expect(result).toContain('    port:');
+    });
+
+    it('should filter out advanced fields when includeAdvanced is false', () => {
+      const fieldsWithAdvanced = [
+        ...sampleChildren,
+        {
+          name: 'advanced_option',
+          type: 'bool',
+          kind: 'scalar',
+          description: 'An advanced option.',
+          is_advanced: true
+        }
+      ];
+
+      const result = buildConfigYaml('inputs', 'kafka', fieldsWithAdvanced, false);
+      expect(result).not.toContain('advanced_option:');
+    });
+
+    it('should include advanced fields when includeAdvanced is true', () => {
+      const fieldsWithAdvanced = [
+        ...sampleChildren,
+        {
+          name: 'advanced_option',
+          type: 'bool',
+          kind: 'scalar',
+          description: 'An advanced option.',
+          is_advanced: true
+        }
+      ];
+
+      const result = buildConfigYaml('inputs', 'kafka', fieldsWithAdvanced, true);
+      expect(result).toContain('advanced_option:');
+    });
+
+    it('should filter out deprecated fields', () => {
+      const fieldsWithDeprecated = [
+        ...sampleChildren,
+        {
+          name: 'old_option',
+          type: 'string',
+          kind: 'scalar',
+          description: 'A deprecated option.',
+          is_deprecated: true
+        }
+      ];
+
+      const result = buildConfigYaml('inputs', 'kafka', fieldsWithDeprecated, true);
+      expect(result).not.toContain('old_option:');
+      // Ensure non-deprecated fields are still present
+      expect(result).toContain('host:');
+      expect(result).toContain('port:');
+    });
+  });
+
+  describe('complex field types', () => {
+    it('should render object fields with nested children', () => {
+      const fieldsWithObject = [
+        {
+          name: 'tls',
+          type: 'object',
+          kind: 'map',
+          description: 'TLS configuration.',
+          children: [
+            {
+              name: 'enabled',
+              type: 'bool',
+              kind: 'scalar',
+              default: false
+            },
+            {
+              name: 'skip_verify',
+              type: 'bool',
+              kind: 'scalar',
+              default: false
+            }
+          ]
+        }
+      ];
+
+      const result = buildConfigYaml('inputs', 'kafka', fieldsWithObject, false);
+      expect(result).toContain('tls:');
+      expect(result).toContain('enabled:');
+      expect(result).toContain('skip_verify:');
+    });
+
+    it('should render array-of-objects as empty array', () => {
+      const fieldsWithArrayOfObjects = [
+        {
+          name: 'client_certs',
+          type: 'object',
+          kind: 'array',
+          description: 'Client certificates.',
+          children: [
+            {
+              name: 'cert',
+              type: 'string',
+              kind: 'scalar'
+            },
+            {
+              name: 'key',
+              type: 'string',
+              kind: 'scalar'
+            }
+          ]
+        }
+      ];
+
+      const result = buildConfigYaml('inputs', 'kafka', fieldsWithArrayOfObjects, false);
+      // Array-of-objects should render as empty array, not expanded
+      expect(result).toContain('client_certs: []');
+      // Should NOT contain the child fields expanded
+      expect(result).not.toContain('cert:');
+      expect(result).not.toContain('key:');
+    });
+
+    it('should render simple arrays correctly', () => {
+      const fieldsWithArray = [
+        {
+          name: 'addresses',
+          type: 'string',
+          kind: 'array',
+          description: 'List of addresses.',
+          default: []
+        }
+      ];
+
+      const result = buildConfigYaml('inputs', 'kafka', fieldsWithArray, false);
+      expect(result).toContain('addresses:');
+    });
+  });
+});

--- a/__tests__/tools/buildConfigYaml.test.js
+++ b/__tests__/tools/buildConfigYaml.test.js
@@ -221,5 +221,38 @@ describe('buildConfigYaml', () => {
       const result = buildConfigYaml('inputs', 'kafka', fieldsWithArray, false);
       expect(result).toContain('addresses:');
     });
+
+    it('should handle empty children array for object map', () => {
+      const fieldsWithEmptyChildren = [
+        {
+          name: 'metadata',
+          type: 'object',
+          kind: 'map',
+          description: 'Metadata with no fields.',
+          children: []
+        }
+      ];
+
+      const result = buildConfigYaml('inputs', 'kafka', fieldsWithEmptyChildren, false);
+      expect(result).toContain('metadata:');
+      // Should not contain any child keys since children is empty
+      expect(result.split('\n').filter(line => line.includes('metadata:')).length).toBe(1);
+    });
+
+    it('should handle empty children array for object array', () => {
+      const fieldsWithEmptyChildren = [
+        {
+          name: 'items',
+          type: 'object',
+          kind: 'array',
+          description: 'Array of items with no fields.',
+          children: []
+        }
+      ];
+
+      const result = buildConfigYaml('inputs', 'kafka', fieldsWithEmptyChildren, false);
+      // Array-of-objects with empty children should render as empty array
+      expect(result).toContain('items: []');
+    });
   });
 });

--- a/__tests__/tools/github-release-utils.test.js
+++ b/__tests__/tools/github-release-utils.test.js
@@ -1,0 +1,300 @@
+'use strict';
+
+// Mock the shared Octokit client
+const mockPaginate = jest.fn();
+jest.mock('../../cli-utils/octokit-client', () => ({
+  rest: {
+    repos: {
+      listReleases: jest.fn()
+    }
+  },
+  get paginate() {
+    return mockPaginate;
+  }
+}));
+
+// Mock the GitHub token utility
+jest.mock('../../cli-utils/github-token', () => ({
+  hasGitHubToken: jest.fn(() => false),
+  getGitHubToken: jest.fn(() => null)
+}));
+
+const {
+  discoverIntermediateReleases,
+  parseVersionFromTag,
+  isPrerelease,
+  filterToStableReleases,
+  findCloudVersionForDate,
+  clearCache
+} = require('../../tools/redpanda-connect/github-release-utils');
+
+describe('GitHub Release Utils', () => {
+  beforeEach(() => {
+    // Clear cache before each test
+    clearCache();
+    jest.clearAllMocks();
+  });
+
+  describe('parseVersionFromTag', () => {
+    it('should parse version with v prefix', () => {
+      expect(parseVersionFromTag('v4.50.0')).toBe('4.50.0');
+    });
+
+    it('should parse version without v prefix', () => {
+      expect(parseVersionFromTag('4.50.0')).toBe('4.50.0');
+    });
+
+    it('should return null for invalid version', () => {
+      expect(parseVersionFromTag('invalid')).toBeNull();
+      expect(parseVersionFromTag('')).toBeNull();
+      expect(parseVersionFromTag(null)).toBeNull();
+    });
+
+    it('should parse beta versions', () => {
+      expect(parseVersionFromTag('v4.50.0-beta.1')).toBe('4.50.0-beta.1');
+    });
+
+    it('should parse RC versions', () => {
+      expect(parseVersionFromTag('v4.50.0-rc1')).toBe('4.50.0-rc1');
+    });
+  });
+
+  describe('isPrerelease', () => {
+    it('should identify beta versions as prerelease', () => {
+      expect(isPrerelease('4.50.0-beta.1')).toBe(true);
+    });
+
+    it('should identify RC versions as prerelease', () => {
+      expect(isPrerelease('4.50.0-rc1')).toBe(true);
+    });
+
+    it('should identify alpha versions as prerelease', () => {
+      expect(isPrerelease('4.50.0-alpha.1')).toBe(true);
+    });
+
+    it('should identify stable versions as NOT prerelease', () => {
+      expect(isPrerelease('4.50.0')).toBe(false);
+    });
+
+    it('should handle invalid versions', () => {
+      expect(isPrerelease('invalid')).toBe(false);
+    });
+  });
+
+  describe('filterToStableReleases', () => {
+    it('should filter out drafts', () => {
+      const releases = [
+        { draft: true, tag_name: 'v4.50.0', prerelease: false },
+        { draft: false, tag_name: 'v4.51.0', prerelease: false }
+      ];
+
+      const result = filterToStableReleases(releases);
+      expect(result).toHaveLength(1);
+      expect(result[0].tag_name).toBe('v4.51.0');
+    });
+
+    it('should filter out beta/RC versions', () => {
+      const releases = [
+        { draft: false, tag_name: 'v4.50.0', prerelease: false },
+        { draft: false, tag_name: 'v4.51.0-beta.1', prerelease: true },
+        { draft: false, tag_name: 'v4.51.0-rc1', prerelease: true },
+        { draft: false, tag_name: 'v4.51.0', prerelease: false }
+      ];
+
+      const result = filterToStableReleases(releases);
+      expect(result).toHaveLength(2);
+      expect(result[0].tag_name).toBe('v4.50.0');
+      expect(result[1].tag_name).toBe('v4.51.0');
+    });
+
+    it('should filter out invalid version tags', () => {
+      const releases = [
+        { draft: false, tag_name: 'v4.50.0', prerelease: false },
+        { draft: false, tag_name: 'invalid-tag', prerelease: false },
+        { draft: false, tag_name: 'v4.51.0', prerelease: false }
+      ];
+
+      const result = filterToStableReleases(releases);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('discoverIntermediateReleases', () => {
+    it('should discover releases between two versions', async () => {
+      const mockReleases = [
+        { draft: false, tag_name: 'v4.49.0', published_at: '2024-01-01', html_url: 'https://github.com/redpanda-data/connect/releases/tag/v4.49.0' },
+        { draft: false, tag_name: 'v4.50.0', published_at: '2024-01-08', html_url: 'https://github.com/redpanda-data/connect/releases/tag/v4.50.0' },
+        { draft: false, tag_name: 'v4.51.0', published_at: '2024-01-15', html_url: 'https://github.com/redpanda-data/connect/releases/tag/v4.51.0' },
+        { draft: false, tag_name: 'v4.52.0', published_at: '2024-01-22', html_url: 'https://github.com/redpanda-data/connect/releases/tag/v4.52.0' },
+        { draft: false, tag_name: 'v4.53.0', published_at: '2024-01-29', html_url: 'https://github.com/redpanda-data/connect/releases/tag/v4.53.0' }
+      ];
+
+      mockPaginate.mockResolvedValue(mockReleases);
+
+      const result = await discoverIntermediateReleases('4.50.0', '4.52.0', { useCache: false });
+
+      expect(result).toHaveLength(3);
+      expect(result[0].version).toBe('4.50.0');
+      expect(result[1].version).toBe('4.51.0');
+      expect(result[2].version).toBe('4.52.0');
+    });
+
+    it('should exclude prerelease versions by default', async () => {
+      const mockReleases = [
+        { draft: false, tag_name: 'v4.50.0', published_at: '2024-01-08', html_url: 'https://...' },
+        { draft: false, tag_name: 'v4.51.0-beta.1', published_at: '2024-01-12', html_url: 'https://...' },
+        { draft: false, tag_name: 'v4.51.0', published_at: '2024-01-15', html_url: 'https://...' }
+      ];
+
+      mockPaginate.mockResolvedValue(mockReleases);
+
+      const result = await discoverIntermediateReleases('4.50.0', '4.51.0', { useCache: false });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].version).toBe('4.50.0');
+      expect(result[1].version).toBe('4.51.0');
+      // Beta should be excluded
+      expect(result.find(r => r.version.includes('beta'))).toBeUndefined();
+    });
+
+    it('should include prerelease versions if requested', async () => {
+      const mockReleases = [
+        { draft: false, tag_name: 'v4.50.0', published_at: '2024-01-08', html_url: 'https://...' },
+        { draft: false, tag_name: 'v4.51.0-beta.1', published_at: '2024-01-12', html_url: 'https://...' },
+        { draft: false, tag_name: 'v4.51.0', published_at: '2024-01-15', html_url: 'https://...' }
+      ];
+
+      mockPaginate.mockResolvedValue(mockReleases);
+
+      const result = await discoverIntermediateReleases('4.50.0', '4.51.0', {
+        includePrerelease: true,
+        useCache: false
+      });
+
+      expect(result).toHaveLength(3);
+      expect(result[1].version).toBe('4.51.0-beta.1');
+      expect(result[1].isPrerelease).toBe(true);
+    });
+
+    it('should sort versions correctly', async () => {
+      const mockReleases = [
+        { draft: false, tag_name: 'v4.52.0', published_at: '2024-01-22', html_url: 'https://...' },
+        { draft: false, tag_name: 'v4.50.0', published_at: '2024-01-08', html_url: 'https://...' },
+        { draft: false, tag_name: 'v4.51.0', published_at: '2024-01-15', html_url: 'https://...' }
+      ];
+
+      mockPaginate.mockResolvedValue(mockReleases);
+
+      const result = await discoverIntermediateReleases('4.50.0', '4.52.0', { useCache: false });
+
+      expect(result[0].version).toBe('4.50.0');
+      expect(result[1].version).toBe('4.51.0');
+      expect(result[2].version).toBe('4.52.0');
+    });
+
+    it('should handle version with v prefix', async () => {
+      const mockReleases = [
+        { draft: false, tag_name: 'v4.50.0', published_at: '2024-01-08', html_url: 'https://...' },
+        { draft: false, tag_name: 'v4.51.0', published_at: '2024-01-15', html_url: 'https://...' }
+      ];
+
+      mockPaginate.mockResolvedValue(mockReleases);
+
+      const result = await discoverIntermediateReleases('v4.50.0', 'v4.51.0', { useCache: false });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].version).toBe('4.50.0');
+      expect(result[1].version).toBe('4.51.0');
+    });
+
+    it('should return empty array if no releases in range', async () => {
+      const mockReleases = [
+        { draft: false, tag_name: 'v4.40.0', published_at: '2024-01-01', html_url: 'https://...' },
+        { draft: false, tag_name: 'v4.60.0', published_at: '2024-03-01', html_url: 'https://...' }
+      ];
+
+      mockPaginate.mockResolvedValue(mockReleases);
+
+      const result = await discoverIntermediateReleases('4.50.0', '4.52.0', { useCache: false });
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should throw error for invalid starting version', async () => {
+      await expect(discoverIntermediateReleases('invalid', '4.52.0', { useCache: false }))
+        .rejects.toThrow('Invalid starting version');
+    });
+
+    it('should throw error for invalid ending version', async () => {
+      await expect(discoverIntermediateReleases('4.50.0', 'invalid', { useCache: false }))
+        .rejects.toThrow('Invalid ending version');
+    });
+  });
+
+  describe('findCloudVersionForDate', () => {
+    it('should find cloud version for a given date', async () => {
+      const mockReleases = [
+        { draft: false, tag_name: 'v4.50.0', published_at: '2024-01-08T00:00:00Z', html_url: 'https://...' },
+        { draft: false, tag_name: 'v4.51.0', published_at: '2024-01-15T00:00:00Z', html_url: 'https://...' },
+        { draft: false, tag_name: 'v4.52.0', published_at: '2024-01-22T00:00:00Z', html_url: 'https://...' }
+      ];
+
+      mockPaginate.mockResolvedValue(mockReleases);
+
+      // Date is 2024-01-20, should return 4.51.0 (most recent before that date)
+      const result = await findCloudVersionForDate('2024-01-20T00:00:00Z', { useCache: false });
+
+      expect(result).toBe('4.51.0');
+    });
+
+    it('should return most recent version when date is after all releases', async () => {
+      const mockReleases = [
+        { draft: false, tag_name: 'v4.50.0', published_at: '2024-01-08T00:00:00Z', html_url: 'https://...' },
+        { draft: false, tag_name: 'v4.51.0', published_at: '2024-01-15T00:00:00Z', html_url: 'https://...' }
+      ];
+
+      mockPaginate.mockResolvedValue(mockReleases);
+
+      // Date is after all releases
+      const result = await findCloudVersionForDate('2024-02-01T00:00:00Z', { useCache: false });
+
+      expect(result).toBe('4.51.0');
+    });
+
+    it('should return null when no releases exist before the date', async () => {
+      const mockReleases = [
+        { draft: false, tag_name: 'v4.52.0', published_at: '2024-01-22T00:00:00Z', html_url: 'https://...' }
+      ];
+
+      mockPaginate.mockResolvedValue(mockReleases);
+
+      // Date is before all releases
+      const result = await findCloudVersionForDate('2024-01-01T00:00:00Z', { useCache: false });
+
+      expect(result).toBeNull();
+    });
+
+    it('should exclude prerelease versions', async () => {
+      const mockReleases = [
+        { draft: false, tag_name: 'v4.50.0', published_at: '2024-01-08T00:00:00Z', html_url: 'https://...' },
+        { draft: false, tag_name: 'v4.51.0-beta.1', published_at: '2024-01-12T00:00:00Z', prerelease: true, html_url: 'https://...' },
+        { draft: false, tag_name: 'v4.51.0', published_at: '2024-01-15T00:00:00Z', html_url: 'https://...' }
+      ];
+
+      mockPaginate.mockResolvedValue(mockReleases);
+
+      // Date is 2024-01-14, should return 4.50.0 (skips beta)
+      const result = await findCloudVersionForDate('2024-01-14T00:00:00Z', { useCache: false });
+
+      expect(result).toBe('4.50.0');
+    });
+
+    it('should return null when API returns no releases', async () => {
+      mockPaginate.mockResolvedValue([]);
+
+      const result = await findCloudVersionForDate('2024-01-20T00:00:00Z', { useCache: false });
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/__tests__/tools/pr-summary-formatter.test.js
+++ b/__tests__/tools/pr-summary-formatter.test.js
@@ -1,0 +1,655 @@
+'use strict';
+
+const { generatePRSummary, generateMultiVersionPRSummary } = require('../../tools/redpanda-connect/pr-summary-formatter');
+
+describe('PR Summary - Platform Detection', () => {
+  // Base diff data structure
+  const createDiffData = (newComponents) => ({
+    comparison: {
+      oldVersion: '4.79.0',
+      newVersion: '4.81.0',
+      timestamp: '2026-04-01T00:00:00.000Z'
+    },
+    summary: {
+      newComponents: newComponents.length,
+      newFields: 0,
+      removedComponents: 0,
+      removedFields: 0,
+      deprecatedComponents: 0,
+      deprecatedFields: 0,
+      changedDefaults: 0
+    },
+    details: {
+      newComponents,
+      newFields: [],
+      removedComponents: [],
+      removedFields: [],
+      deprecatedComponents: [],
+      deprecatedFields: [],
+      changedDefaults: []
+    }
+  });
+
+  describe('Action Items - Self-Hosted Only Label', () => {
+    it('should label connectors in notInCloud as self-hosted only', () => {
+      const diffData = createDiffData([
+        { type: 'inputs', name: 'file', status: 'stable', description: 'A file input' }
+      ]);
+
+      const binaryAnalysis = {
+        cloudVersion: '4.82.0',
+        comparison: {
+          inCloud: [],
+          notInCloud: [
+            { type: 'inputs', name: 'file', status: 'stable' }
+          ],
+          cloudOnly: []
+        }
+      };
+
+      const summary = generatePRSummary(diffData, binaryAnalysis);
+
+      expect(summary).toContain('Document new `file` inputs (self-hosted only)');
+      expect(summary).toContain('[ ] Document new `file` inputs (self-hosted only)');
+    });
+
+    it('should NOT label connectors in cloudOnly as self-hosted only', () => {
+      const diffData = createDiffData([
+        { type: 'inputs', name: 'aws_cloudwatch_logs', status: 'stable', description: 'AWS CloudWatch Logs input' }
+      ]);
+
+      const binaryAnalysis = {
+        cloudVersion: '4.82.0',
+        comparison: {
+          inCloud: [],
+          notInCloud: [],
+          cloudOnly: [
+            { type: 'inputs', name: 'aws_cloudwatch_logs', status: 'stable' }
+          ]
+        }
+      };
+
+      const summary = generatePRSummary(diffData, binaryAnalysis);
+
+      // Should NOT contain self-hosted only label
+      expect(summary).not.toContain('(self-hosted only)');
+
+      // Should be listed in cloud docs update section
+      expect(summary).toContain('☁️ Cloud Docs Update Required');
+    });
+
+    it('should NOT label connectors in inCloud as self-hosted only', () => {
+      const diffData = createDiffData([
+        { type: 'inputs', name: 'kafka', status: 'stable', description: 'Kafka input' }
+      ]);
+
+      const binaryAnalysis = {
+        cloudVersion: '4.82.0',
+        comparison: {
+          inCloud: [
+            { type: 'inputs', name: 'kafka', status: 'stable' }
+          ],
+          notInCloud: [],
+          cloudOnly: []
+        }
+      };
+
+      const summary = generatePRSummary(diffData, binaryAnalysis);
+
+      // Should NOT contain self-hosted only label
+      expect(summary).not.toContain('(self-hosted only)');
+
+      // Should have cloud indicator
+      expect(summary).toContain('☁️ **CLOUD SUPPORTED**');
+    });
+  });
+
+  describe('Detailed Breakdown - Platform Categorization', () => {
+    it('should categorize connectors correctly in detailed breakdown', () => {
+      const diffData = createDiffData([
+        { type: 'inputs', name: 'kafka', status: 'stable', description: 'Kafka input' },
+        { type: 'inputs', name: 'file', status: 'stable', description: 'File input' },
+        { type: 'inputs', name: 'aws_cloudwatch_logs', status: 'stable', description: 'AWS CloudWatch Logs input' }
+      ]);
+
+      const binaryAnalysis = {
+        cloudVersion: '4.82.0',
+        comparison: {
+          inCloud: [
+            { type: 'inputs', name: 'kafka', status: 'stable' }
+          ],
+          notInCloud: [
+            { type: 'inputs', name: 'file', status: 'stable' }
+          ],
+          cloudOnly: [
+            { type: 'inputs', name: 'aws_cloudwatch_logs', status: 'stable' }
+          ]
+        }
+      };
+
+      const summary = generatePRSummary(diffData, binaryAnalysis);
+
+      // Should have both cloud supported and self-hosted sections in detailed breakdown
+      expect(summary).toContain('☁️ Cloud Supported:');
+      expect(summary).toContain('Self-Hosted Only:');
+
+      // Cloud supported should include both kafka (inCloud) and aws_cloudwatch_logs (cloudOnly)
+      const cloudSupportedMatch = summary.match(/\*\*☁️ Cloud Supported:\*\*[\s\S]*?(?=\*\*Self-Hosted Only:|####)/);
+      expect(cloudSupportedMatch).toBeTruthy();
+      const cloudSupportedSection = cloudSupportedMatch[0];
+      expect(cloudSupportedSection).toContain('kafka');
+      expect(cloudSupportedSection).toContain('aws_cloudwatch_logs');
+
+      // Self-hosted only should only include file
+      const selfHostedMatch = summary.match(/\*\*Self-Hosted Only:\*\*[\s\S]*?(?=####|<\/details>)/);
+      expect(selfHostedMatch).toBeTruthy();
+      const selfHostedSection = selfHostedMatch[0];
+      expect(selfHostedSection).toContain('file');
+      expect(selfHostedSection).not.toContain('kafka');
+      expect(selfHostedSection).not.toContain('aws_cloudwatch_logs');
+    });
+  });
+
+  describe('Draft Indicators - Cloud Symbol', () => {
+    it('should show cloud indicator for connectors in inCloud', () => {
+      const diffData = createDiffData([
+        { type: 'inputs', name: 'kafka', status: 'stable', description: 'Kafka input' }
+      ]);
+
+      const binaryAnalysis = {
+        cloudVersion: '4.82.0',
+        comparison: {
+          inCloud: [
+            { type: 'inputs', name: 'kafka', status: 'stable' }
+          ],
+          notInCloud: [],
+          cloudOnly: []
+        }
+      };
+
+      const draftedConnectors = [
+        {
+          path: 'modules/components/pages/inputs/kafka.adoc',
+          name: 'kafka',
+          type: 'inputs',
+          status: 'stable',
+          requiresCgo: false,
+          cloudOnly: false
+        }
+      ];
+
+      const summary = generatePRSummary(diffData, binaryAnalysis, draftedConnectors);
+
+      // Should have cloud indicator in drafted connectors section
+      const draftedMatch = summary.match(/📝 Newly Drafted[\s\S]*?(?=###|$)/);
+      expect(draftedMatch).toBeTruthy();
+      const draftedSection = draftedMatch[0];
+      expect(draftedSection).toContain('kafka');
+      expect(draftedSection).toContain('☁️');
+    });
+
+    it('should show cloud indicator for connectors in cloudOnly', () => {
+      const diffData = createDiffData([
+        { type: 'inputs', name: 'aws_cloudwatch_logs', status: 'stable', description: 'AWS CloudWatch Logs input' }
+      ]);
+
+      const binaryAnalysis = {
+        cloudVersion: '4.82.0',
+        comparison: {
+          inCloud: [],
+          notInCloud: [],
+          cloudOnly: [
+            { type: 'inputs', name: 'aws_cloudwatch_logs', status: 'stable' }
+          ]
+        }
+      };
+
+      const draftedConnectors = [
+        {
+          path: 'modules/components/partials/components/cloud-only/inputs/aws_cloudwatch_logs.adoc',
+          name: 'aws_cloudwatch_logs',
+          type: 'inputs',
+          status: 'stable',
+          requiresCgo: false,
+          cloudOnly: true
+        }
+      ];
+
+      const summary = generatePRSummary(diffData, binaryAnalysis, draftedConnectors);
+
+      // Should have cloud indicator in drafted connectors section
+      const draftedMatch = summary.match(/📝 Newly Drafted[\s\S]*?(?=###|$)/);
+      expect(draftedMatch).toBeTruthy();
+      const draftedSection = draftedMatch[0];
+      expect(draftedSection).toContain('aws_cloudwatch_logs');
+      expect(draftedSection).toContain('☁️');
+    });
+
+    it('should NOT show cloud indicator for self-hosted only connectors', () => {
+      const diffData = createDiffData([
+        { type: 'inputs', name: 'file', status: 'stable', description: 'File input' }
+      ]);
+
+      const binaryAnalysis = {
+        cloudVersion: '4.82.0',
+        comparison: {
+          inCloud: [],
+          notInCloud: [
+            { type: 'inputs', name: 'file', status: 'stable' }
+          ],
+          cloudOnly: []
+        }
+      };
+
+      const draftedConnectors = [
+        {
+          path: 'modules/components/pages/inputs/file.adoc',
+          name: 'file',
+          type: 'inputs',
+          status: 'stable',
+          requiresCgo: false,
+          cloudOnly: false
+        }
+      ];
+
+      const summary = generatePRSummary(diffData, binaryAnalysis, draftedConnectors);
+
+      // Get drafted section
+      const draftedMatch = summary.match(/📝 Newly Drafted[\s\S]*?(?=###|$)/);
+      expect(draftedMatch).toBeTruthy();
+      const draftedSection = draftedMatch[0];
+      expect(draftedSection).toContain('file');
+
+      // Should NOT have cloud indicator for file input
+      const fileMatch = draftedSection.match(/`file`[^\n]*/);
+      expect(fileMatch).toBeTruthy();
+      expect(fileMatch[0]).not.toContain('☁️');
+    });
+  });
+
+  describe('Cloud Docs Update Section', () => {
+    it('should list both inCloud and cloudOnly connectors', () => {
+      const diffData = createDiffData([
+        { type: 'inputs', name: 'kafka', status: 'stable', description: 'Kafka input' },
+        { type: 'inputs', name: 'aws_cloudwatch_logs', status: 'stable', description: 'AWS CloudWatch Logs input' }
+      ]);
+
+      const binaryAnalysis = {
+        cloudVersion: '4.82.0',
+        comparison: {
+          inCloud: [
+            { type: 'inputs', name: 'kafka', status: 'stable' }
+          ],
+          notInCloud: [],
+          cloudOnly: [
+            { type: 'inputs', name: 'aws_cloudwatch_logs', status: 'stable' }
+          ]
+        }
+      };
+
+      const summary = generatePRSummary(diffData, binaryAnalysis);
+
+      // Should mention 2 connectors available in cloud
+      expect(summary).toContain('☁️ Cloud Docs Update Required');
+      expect(summary).toContain('**2** new connectors are available in Redpanda Cloud');
+    });
+
+    it('should show different include syntax for cloud-only vs regular cloud connectors', () => {
+      const diffData = createDiffData([
+        { type: 'inputs', name: 'kafka', status: 'stable', description: 'Kafka input' },
+        { type: 'inputs', name: 'aws_cloudwatch_logs', status: 'stable', description: 'AWS CloudWatch Logs input' }
+      ]);
+
+      const binaryAnalysis = {
+        cloudVersion: '4.82.0',
+        comparison: {
+          inCloud: [
+            { type: 'inputs', name: 'kafka', status: 'stable' }
+          ],
+          notInCloud: [],
+          cloudOnly: [
+            { type: 'inputs', name: 'aws_cloudwatch_logs', status: 'stable' }
+          ]
+        }
+      };
+
+      const summary = generatePRSummary(diffData, binaryAnalysis);
+
+      // Should have both syntax examples
+      expect(summary).toContain('For connectors in pages:');
+      expect(summary).toContain('include::redpanda-connect:components:page$type/connector-name.adoc[tag=single-source]');
+
+      expect(summary).toContain('For cloud-only connectors (in partials):');
+      expect(summary).toContain('include::redpanda-connect:components:partial$components/cloud-only/type/connector-name.adoc[tag=single-source]');
+    });
+  });
+
+  describe('Regression Tests - Original Bug', () => {
+    it('should not create contradictory labels for aws_cloudwatch_logs', () => {
+      // This is the original bug scenario from the user's report
+      const diffData = createDiffData([
+        { type: 'inputs', name: 'aws_cloudwatch_logs', status: 'stable', description: 'AWS CloudWatch Logs input' }
+      ]);
+
+      const binaryAnalysis = {
+        cloudVersion: '4.82.0-rc2',
+        comparison: {
+          inCloud: [],
+          notInCloud: [],
+          cloudOnly: [
+            { type: 'inputs', name: 'aws_cloudwatch_logs', status: 'stable' }
+          ]
+        },
+        cgoOnly: [
+          { type: 'inputs', name: 'aws_cloudwatch_logs', status: 'stable' }
+        ]
+      };
+
+      const draftedConnectors = [
+        {
+          path: 'modules/components/partials/components/cloud-only/inputs/aws_cloudwatch_logs.adoc',
+          name: 'aws_cloudwatch_logs',
+          type: 'inputs',
+          status: 'stable',
+          requiresCgo: true,
+          cloudOnly: true
+        }
+      ];
+
+      const summary = generatePRSummary(diffData, binaryAnalysis, draftedConnectors);
+
+      // Should NOT say self-hosted only
+      expect(summary).not.toContain('aws_cloudwatch_logs inputs (self-hosted only)');
+
+      // Should say cloud docs update required
+      expect(summary).toContain('☁️ Cloud Docs Update Required');
+      expect(summary).toContain('**1** new connector is available in Redpanda Cloud');
+
+      // Draft should be in cloud-only directory
+      expect(summary).toContain('modules/components/partials/components/cloud-only/inputs/aws_cloudwatch_logs.adoc');
+
+      // Should have cloud indicator in drafted section
+      const draftedMatch = summary.match(/📝 Newly Drafted[\s\S]*?(?=###|$)/);
+      expect(draftedMatch).toBeTruthy();
+      const draftedSection = draftedMatch[0];
+      expect(draftedSection).toContain('☁️');
+      expect(draftedSection).toContain('🔧'); // cgo indicator
+    });
+  });
+});
+
+describe('Multi-Version PR Summary', () => {
+  // Helper to create a master diff structure
+  const createMasterDiff = (releases) => ({
+    metadata: {
+      generatedAt: new Date().toISOString(),
+      startVersion: releases[0]?.fromVersion || 'unknown',
+      endVersion: releases[releases.length - 1]?.toVersion || 'unknown',
+      processedReleases: releases.length
+    },
+    totalSummary: {
+      versions: releases.map(r => r.toVersion),
+      releaseCount: releases.length,
+      newComponents: releases.reduce((sum, r) => sum + (r.summary?.newComponents || 0), 0),
+      newFields: releases.reduce((sum, r) => sum + (r.summary?.newFields || 0), 0),
+      removedFields: releases.reduce((sum, r) => sum + (r.summary?.removedFields || 0), 0),
+      deprecatedFields: releases.reduce((sum, r) => sum + (r.summary?.deprecatedFields || 0), 0)
+    },
+    releases
+  });
+
+  // Helper to create a release entry
+  const createRelease = (fromVersion, toVersion, newComponents = [], options = {}) => ({
+    fromVersion,
+    toVersion,
+    date: new Date().toISOString(),
+    summary: {
+      newComponents: newComponents.length,
+      newFields: options.newFields || 0,
+      removedFields: options.removedFields || 0,
+      deprecatedFields: options.deprecatedFields || 0
+    },
+    details: {
+      newComponents,
+      newFields: [],
+      removedFields: [],
+      deprecatedFields: []
+    },
+    binaryAnalysis: options.binaryAnalysis || null
+  });
+
+  describe('Basic Summary Generation', () => {
+    it('should generate summary for multiple releases', () => {
+      const masterDiff = createMasterDiff([
+        createRelease('4.50.0', '4.51.0', [
+          { type: 'inputs', name: 'postgres_cdc', status: 'beta' }
+        ]),
+        createRelease('4.51.0', '4.52.0', [
+          { type: 'outputs', name: 'elasticsearch_v9', status: 'stable' }
+        ])
+      ]);
+
+      const summary = generateMultiVersionPRSummary(masterDiff);
+
+      expect(summary).toContain('Multi-Release Update');
+      expect(summary).toContain('4.50.0 → 4.52.0');
+      expect(summary).toContain('Releases Processed:** 2');
+    });
+
+    it('should show per-release breakdown', () => {
+      const masterDiff = createMasterDiff([
+        createRelease('4.50.0', '4.51.0', [
+          { type: 'inputs', name: 'postgres_cdc', status: 'beta' }
+        ]),
+        createRelease('4.51.0', '4.52.0', [
+          { type: 'outputs', name: 'elasticsearch_v9', status: 'stable' }
+        ])
+      ]);
+
+      const summary = generateMultiVersionPRSummary(masterDiff);
+
+      expect(summary).toContain('Version 4.51.0');
+      expect(summary).toContain('Version 4.52.0');
+      expect(summary).toContain('`postgres_cdc`');
+      expect(summary).toContain('`elasticsearch_v9`');
+    });
+
+    it('should aggregate totals across releases', () => {
+      const masterDiff = createMasterDiff([
+        createRelease('4.50.0', '4.51.0', [
+          { type: 'inputs', name: 'postgres_cdc', status: 'beta' }
+        ], { newFields: 5 }),
+        createRelease('4.51.0', '4.52.0', [
+          { type: 'outputs', name: 'elasticsearch_v9', status: 'stable' }
+        ], { newFields: 10 })
+      ]);
+
+      const summary = generateMultiVersionPRSummary(masterDiff);
+
+      expect(summary).toContain('**2** new connectors');
+      expect(summary).toContain('**15** new fields');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle empty releases array', () => {
+      const masterDiff = createMasterDiff([]);
+
+      const summary = generateMultiVersionPRSummary(masterDiff);
+
+      expect(summary).toContain('No releases to process');
+      expect(summary).toContain('PR_SUMMARY_END');
+    });
+
+    it('should handle releases with no changes', () => {
+      const masterDiff = createMasterDiff([
+        createRelease('4.50.0', '4.51.0', []),
+        createRelease('4.51.0', '4.52.0', [])
+      ]);
+
+      const summary = generateMultiVersionPRSummary(masterDiff);
+
+      expect(summary).toContain('No changes in this release');
+    });
+
+    it('should handle missing metadata gracefully', () => {
+      const masterDiff = {
+        totalSummary: { newComponents: 0, newFields: 0 },
+        releases: []
+      };
+
+      const summary = generateMultiVersionPRSummary(masterDiff);
+
+      expect(summary).toContain('unknown → unknown');
+      expect(summary).toContain('Releases Processed:** 0');
+    });
+
+    it('should handle missing binaryAnalysis gracefully', () => {
+      const masterDiff = createMasterDiff([
+        createRelease('4.50.0', '4.51.0', [
+          { type: 'inputs', name: 'test_connector', status: 'stable' }
+        ])
+      ]);
+
+      const summary = generateMultiVersionPRSummary(masterDiff);
+
+      // Should not crash and should not show cloud indicator
+      expect(summary).toContain('`test_connector`');
+      expect(summary).not.toContain('☁️');
+    });
+
+    it('should handle missing details gracefully', () => {
+      const masterDiff = {
+        metadata: {
+          startVersion: '4.50.0',
+          endVersion: '4.51.0',
+          processedReleases: 1
+        },
+        totalSummary: { newComponents: 1 },
+        releases: [{
+          fromVersion: '4.50.0',
+          toVersion: '4.51.0',
+          summary: { newComponents: 1 },
+          // details intentionally missing
+        }]
+      };
+
+      const summary = generateMultiVersionPRSummary(masterDiff);
+
+      // Should not crash
+      expect(summary).toContain('Version 4.51.0');
+    });
+  });
+
+  describe('Platform Indicators', () => {
+    it('should show cloud indicator for cloud-supported connectors', () => {
+      const masterDiff = createMasterDiff([
+        createRelease('4.50.0', '4.51.0', [
+          { type: 'inputs', name: 'kafka', status: 'stable' }
+        ], {
+          binaryAnalysis: {
+            comparison: {
+              inCloud: [{ type: 'inputs', name: 'kafka' }],
+              cloudOnly: [],
+              notInCloud: []
+            }
+          }
+        })
+      ]);
+
+      const summary = generateMultiVersionPRSummary(masterDiff);
+
+      expect(summary).toContain('`kafka` (inputs, stable) ☁️');
+    });
+
+    it('should show cgo indicator for cgo-only connectors', () => {
+      const masterDiff = createMasterDiff([
+        createRelease('4.50.0', '4.51.0', [
+          { type: 'inputs', name: 'zmq4', status: 'stable' }
+        ], {
+          binaryAnalysis: {
+            comparison: { inCloud: [], cloudOnly: [], notInCloud: [] },
+            cgoOnly: [{ type: 'inputs', name: 'zmq4' }]
+          }
+        })
+      ]);
+
+      const summary = generateMultiVersionPRSummary(masterDiff);
+
+      expect(summary).toContain('`zmq4` (inputs, stable) 🔧');
+    });
+  });
+
+  describe('Action Items', () => {
+    it('should generate action items with version attribution', () => {
+      const masterDiff = createMasterDiff([
+        createRelease('4.50.0', '4.51.0', [
+          { type: 'inputs', name: 'postgres_cdc', status: 'beta' }
+        ]),
+        createRelease('4.51.0', '4.52.0', [
+          { type: 'outputs', name: 'elasticsearch_v9', status: 'stable' }
+        ])
+      ]);
+
+      const summary = generateMultiVersionPRSummary(masterDiff);
+
+      expect(summary).toContain('Document new `postgres_cdc` inputs from **4.51.0**');
+      expect(summary).toContain('Document new `elasticsearch_v9` outputs from **4.52.0**');
+    });
+
+    it('should label self-hosted-only connectors in action items', () => {
+      const masterDiff = createMasterDiff([
+        createRelease('4.50.0', '4.51.0', [
+          { type: 'inputs', name: 'file', status: 'stable' }
+        ], {
+          binaryAnalysis: {
+            comparison: {
+              inCloud: [],
+              cloudOnly: [],
+              notInCloud: [{ type: 'inputs', name: 'file' }]
+            }
+          }
+        })
+      ]);
+
+      const summary = generateMultiVersionPRSummary(masterDiff);
+
+      expect(summary).toContain('Document new `file` inputs from **4.51.0** (self-hosted only)');
+    });
+
+    it('should show cloud indicator in action items for cloud connectors', () => {
+      const masterDiff = createMasterDiff([
+        createRelease('4.50.0', '4.51.0', [
+          { type: 'inputs', name: 'kafka', status: 'stable' }
+        ], {
+          binaryAnalysis: {
+            comparison: {
+              inCloud: [{ type: 'inputs', name: 'kafka' }],
+              cloudOnly: [],
+              notInCloud: []
+            }
+          }
+        })
+      ]);
+
+      const summary = generateMultiVersionPRSummary(masterDiff);
+
+      expect(summary).toContain('Document new `kafka` inputs from **4.51.0** ☁️');
+    });
+  });
+
+  describe('Auto-detection', () => {
+    it('should auto-detect multi-version format in generatePRSummary', () => {
+      const masterDiff = createMasterDiff([
+        createRelease('4.50.0', '4.51.0', [
+          { type: 'inputs', name: 'test', status: 'stable' }
+        ])
+      ]);
+
+      // Call generatePRSummary with a master diff (should auto-detect)
+      const summary = generatePRSummary(masterDiff);
+
+      expect(summary).toContain('Multi-Release Update');
+    });
+  });
+});

--- a/__tests__/tools/pr-summary-formatter.test.js
+++ b/__tests__/tools/pr-summary-formatter.test.js
@@ -489,7 +489,7 @@ describe('Multi-Version PR Summary', () => {
 
       const summary = generateMultiVersionPRSummary(masterDiff);
 
-      expect(summary).toContain('No changes in this release');
+      expect(summary).toContain('No documentation changes in this release');
     });
 
     it('should handle missing metadata gracefully', () => {
@@ -593,8 +593,9 @@ describe('Multi-Version PR Summary', () => {
 
       const summary = generateMultiVersionPRSummary(masterDiff);
 
-      expect(summary).toContain('Document new `postgres_cdc` inputs from **4.51.0**');
-      expect(summary).toContain('Document new `elasticsearch_v9` outputs from **4.52.0**');
+      // New format: `connector` type — introduced in **version**
+      expect(summary).toContain('`postgres_cdc` inputs — introduced in **4.51.0**');
+      expect(summary).toContain('`elasticsearch_v9` outputs — introduced in **4.52.0**');
     });
 
     it('should label self-hosted-only connectors in action items', () => {
@@ -614,7 +615,9 @@ describe('Multi-Version PR Summary', () => {
 
       const summary = generateMultiVersionPRSummary(masterDiff);
 
-      expect(summary).toContain('Document new `file` inputs from **4.51.0** (self-hosted only)');
+      // New format: grouped under "Self-hosted only:" with 🖥️ indicator
+      expect(summary).toContain('Self-hosted only:');
+      expect(summary).toContain('`file` inputs 🖥️ — introduced in **4.51.0**');
     });
 
     it('should show cloud indicator in action items for cloud connectors', () => {
@@ -634,7 +637,9 @@ describe('Multi-Version PR Summary', () => {
 
       const summary = generateMultiVersionPRSummary(masterDiff);
 
-      expect(summary).toContain('Document new `kafka` inputs from **4.51.0** ☁️');
+      // New format: grouped under "Cloud-supported (higher priority):" with ☁️
+      expect(summary).toContain('Cloud-supported (higher priority):');
+      expect(summary).toContain('`kafka` inputs ☁️ — introduced in **4.51.0**');
     });
   });
 

--- a/__tests__/tools/pr-summary-formatter.test.js
+++ b/__tests__/tools/pr-summary-formatter.test.js
@@ -513,9 +513,11 @@ describe('Multi-Version PR Summary', () => {
 
       const summary = generateMultiVersionPRSummary(masterDiff);
 
-      // Should not crash and should not show cloud indicator
+      // Should not crash and connector line should not show cloud indicator
       expect(summary).toContain('`test_connector`');
-      expect(summary).not.toContain('☁️');
+      const connectorLine = summary.split('\n').find(line => line.includes('`test_connector`'));
+      expect(connectorLine).toBeDefined();
+      expect(connectorLine).not.toContain('☁️');
     });
 
     it('should handle missing details gracefully', () => {

--- a/bin/doc-tools.js
+++ b/bin/doc-tools.js
@@ -705,6 +705,8 @@ automation
   .option('--include-bloblang', 'Include Bloblang functions and methods in generation')
   .option('--cloud-version <version>', 'Cloud binary version (default: auto-detect latest)')
   .option('--cgo-version <version>', 'cgo binary version (default: same as cloud-version)')
+  .option('--skip-intermediate', 'Skip intermediate release processing (legacy mode - only compare latest vs last documented)')
+  .option('--from-version <version>', 'Override starting version instead of using antora.yml (useful for backfilling)')
   .action(async (options) => {
     requireTool('rpk', {
       versionFlag: '--version',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.15.6",
+  "version": "4.15.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.15.6",
+      "version": "4.15.7",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.15.6",
+  "version": "4.15.7",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/redpanda-connect/AUTOMATION.md
+++ b/tools/redpanda-connect/AUTOMATION.md
@@ -1,0 +1,834 @@
+# Redpanda Connect Connector Documentation Automation
+
+## Overview
+
+This automation generates comprehensive reference documentation for Redpanda Connect connectors, including inputs, outputs, processors, buffers, caches, rate limiters, metrics, tracers, scanners, and optionally Bloblang functions/methods.
+
+The automation handles **multi-release attribution**, automatically detecting and processing intermediate releases that may have been missed, ensuring that changes are accurately attributed to their actual release version rather than being lumped together.
+
+## Goals
+
+### Primary Goals
+
+1. **Generate Comprehensive Reference Docs**: Create AsciiDoc documentation for all Redpanda Connect components with:
+   - Field descriptions with types, defaults, and options
+   - Working code examples (minimal and advanced configurations)
+   - Cross-references to related components
+   - Metadata (status badges: stable, beta, experimental, deprecated)
+
+2. **Accurate Version Attribution**: Track when each component and field was introduced:
+   - Detect releases between the last documented version and latest
+   - Process each release pair sequentially
+   - Generate per-version change tracking
+   - Maintain historical accuracy even when releases are skipped
+
+3. **Platform Support Detection**: Identify and document platform availability:
+   - **Cloud-supported**: Available in Redpanda Cloud (both serverless and BYOC)
+   - **Self-hosted only**: Available only in self-hosted deployments
+   - **Cloud-only**: Exclusive to Redpanda Cloud
+   - **Cgo-required**: Requires cgo-enabled builds
+
+4. **Change Detection & Reporting**: Generate detailed change reports:
+   - New connectors and fields
+   - Removed/deprecated components
+   - Changed default values
+   - Breaking changes (removed fields)
+
+## How It Works
+
+### Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 1. Version Detection                                            │
+│    • Read current version from antora.yml                       │
+│    • Detect latest version from GitHub releases or rpk          │
+│    • Discover all intermediate releases                         │
+└──────────────────────┬──────────────────────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ 2. Sequential Release Processing (for each version pair)        │
+│    ┌───────────────────────────────────────────────────────┐   │
+│    │ For each pair (v[n] → v[n+1]):                        │   │
+│    │   a. Fetch connector data for both versions           │   │
+│    │   b. Run binary analysis (OSS, Cloud, cgo)            │   │
+│    │   c. Generate version-specific diff                   │   │
+│    │   d. Track changes with version attribution           │   │
+│    └───────────────────────────────────────────────────────┘   │
+└──────────────────────┬──────────────────────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ 3. Final Version Processing                                     │
+│    • Generate AsciiDoc partials (fields & examples)             │
+│    • Create full page drafts for new connectors (optional)      │
+│    • Update navigation files                                    │
+│    • Create master diff aggregating all changes                 │
+└──────────────────────┬──────────────────────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ 4. Output Generation                                            │
+│    • Individual diffs: connect-diff-X.X.X_to_Y.Y.Y.json        │
+│    • Master diff: connect-diff-master-X.X.X_to_Z.Z.Z.json      │
+│    • PR summary with per-version attribution                    │
+│    • Writer action items                                        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Multi-Release Processing
+
+**Scenario**: antora.yml has version `4.50.0`, latest release is `4.54.0`
+
+**Without Multi-Release (OLD behavior)**:
+```
+4.50.0 ─────────────────────────► 4.54.0
+         (all changes lumped)
+```
+Result: All changes from 4.51.0, 4.52.0, 4.53.0, and 4.54.0 are attributed to 4.54.0 ❌
+
+**With Multi-Release (NEW behavior)**:
+```
+4.50.0 ──► 4.51.0 ──► 4.52.0 ──► 4.53.0 ──► 4.54.0
+   │          │          │          │          │
+   diff1      diff2      diff3      diff4      │
+   │          │          │          │          │
+   └──────────┴──────────┴──────────┴──────────┘
+                      │
+                      ▼
+              master-diff.json
+          (accurate attribution)
+```
+Result: Each change is attributed to its actual release version ✅
+
+### Version Detection Flow
+
+1. **Determine Starting Version**:
+   - Read `asciidoc.attributes.latest-connect-version` from `antora.yml`
+   - OR use `--from-version` flag override
+   - OR fallback to latest JSON file in `docs-data/`
+
+2. **Determine Target Version**:
+   - Use `--connect-version` flag (explicit version)
+   - OR auto-detect latest stable release from GitHub
+   - OR use local `rpk connect --version`
+
+3. **Discover Intermediate Releases**:
+   - Query GitHub Releases API: `repos/redpanda-data/connect/releases`
+   - Filter to stable releases (exclude beta, RC, alpha)
+   - Parse semver and find all versions between start and target
+   - Sort chronologically
+
+### Data Collection
+
+For each version being processed:
+
+1. **Connector Metadata** (via `rpk connect list`):
+   ```json
+   {
+     "name": "kafka",
+     "type": "inputs",
+     "status": "stable",
+     "description": "...",
+     "summary": "...",
+     "config": { /* full schema */ }
+   }
+   ```
+
+2. **Binary Analysis** (download and inspect binaries):
+   - **OSS binary**: Standard self-hosted build
+   - **Cloud binary**: Redpanda Cloud serverless/BYOC build
+   - **Cgo binary**: Build with cgo-enabled components
+
+   Compares which connectors exist in each binary to determine:
+   - `inCloud`: Present in both OSS and Cloud
+   - `notInCloud`: Only in OSS (self-hosted only)
+   - `cloudOnly`: Only in Cloud binary
+   - `cgoOnly`: Only in cgo-enabled binary
+
+3. **Metadata CSV** (optional, from GitHub):
+   - Commercial names for connectors
+   - Additional categorization info
+
+### Change Detection
+
+For each version pair `(oldVersion → newVersion)`:
+
+```javascript
+{
+  "comparison": {
+    "oldVersion": "4.50.0",
+    "newVersion": "4.51.0",
+    "timestamp": "2026-04-01T00:00:00.000Z"
+  },
+  "summary": {
+    "newComponents": 3,      // New connectors
+    "newFields": 15,          // New fields added to existing connectors
+    "removedComponents": 0,
+    "removedFields": 2,       // Breaking changes!
+    "deprecatedComponents": 0,
+    "deprecatedFields": 1,
+    "changedDefaults": 0
+  },
+  "details": {
+    "newComponents": [
+      {
+        "name": "postgres_cdc",
+        "type": "inputs",
+        "status": "beta",
+        "version": "4.51.0",    // Attribution!
+        "description": "..."
+      }
+    ],
+    "newFields": [
+      {
+        "component": "inputs:kafka",
+        "field": "rack_id",
+        "description": "..."
+      }
+    ],
+    // ... other change categories
+  },
+  "binaryAnalysis": {
+    "ossVersion": "4.51.0",
+    "cloudVersion": "4.52.0-rc1",
+    "comparison": {
+      "inCloud": [/*...*/],
+      "notInCloud": [/*...*/],
+      "cloudOnly": [/*...*/]
+    },
+    "cgoOnly": [/*...*/]
+  }
+}
+```
+
+## Output Specifications
+
+### 1. AsciiDoc Documentation Files
+
+#### Field Partials (`modules/components/partials/fields/{type}/{name}.adoc`)
+
+```asciidoc
+// This content is autogenerated. Do not edit manually.
+
+== Fields
+
+=== `field_name`
+
+Description of the field with details.
+
+*Type*: `string`
+
+*Default*: `"default_value"`
+
+*Options*: `option1`, `option2`, `option3`
+
+[source,yaml]
+----
+# Example:
+field_name: example_value
+----
+
+=== `another_field`
+
+...
+```
+
+**Requirements**:
+- All fields documented with type, default, options
+- Code examples in YAML
+- Cross-references using `xref:` syntax
+- Conditional content for deprecated/experimental fields
+
+#### Example Partials (`modules/components/partials/examples/{type}/{name}.adoc`)
+
+```asciidoc
+// This content is autogenerated. Do not edit manually.
+
+== Examples
+
+=== Minimal configuration
+
+Basic setup with required fields only
+
+[source,yaml]
+----
+input:
+  kafka:
+    addresses: ["localhost:9092"]
+    topics: ["my_topic"]
+----
+
+=== Advanced configuration
+
+Complete configuration with optional fields
+
+[source,yaml]
+----
+input:
+  kafka:
+    addresses: ["localhost:9092"]
+    topics: ["my_topic"]
+    consumer_group: "my_group"
+    checkpoint_limit: 1000
+    # ... all fields
+----
+```
+
+**Requirements**:
+- Minimal example (required fields only)
+- Advanced example (all meaningful fields)
+- **Only output one example if they're identical** (no tabs needed)
+- Use leading sentence: "Here's an example configuration:"
+- Real-world, working configurations
+
+#### Full Page Drafts (`modules/components/pages/{type}/{name}.adoc`)
+
+Generated with `--draft-missing` flag for NEW connectors:
+
+```asciidoc
+= Connector Name
+:type: input
+:status: beta
+:page-commercial-names: Commercial Name, Alternative Name
+
+// tag::single-source[]
+
+Brief summary of what this connector does.
+
+== Common Use Cases
+
+* Use case 1
+* Use case 2
+
+[tabs]
+====
+Common config::
++
+include::redpanda-connect:components:partial$examples/inputs/connector_name.adoc[tag=common]
+
+Advanced config::
++
+include::redpanda-connect:components:partial$examples/inputs/connector_name.adoc[tag=advanced]
+====
+
+include::redpanda-connect:components:partial$fields/inputs/connector_name.adoc[]
+
+// end::single-source[]
+```
+
+**Requirements**:
+- Frontmatter with metadata
+- Single-source tags for reuse in cloud docs
+- Tabs for common vs advanced configs (only if different)
+- Platform indicators (☁️ for cloud, 🔧 for cgo)
+
+### 2. Data Files
+
+#### Connector Data JSON (`docs-data/connect-{version}.json`)
+
+Complete connector metadata for a specific version:
+
+```json
+{
+  "inputs": [
+    {
+      "name": "kafka",
+      "status": "stable",
+      "plugin": true,
+      "description": "...",
+      "summary": "...",
+      "config": {
+        "type": "object",
+        "fields": [
+          {
+            "name": "addresses",
+            "type": "array",
+            "description": "...",
+            "default": [],
+            "kind": "scalar"
+          }
+        ]
+      },
+      "requiresCgo": false,
+      "cloudOnly": false
+    }
+  ],
+  "outputs": [...],
+  "processors": [...],
+  // ... other component types
+}
+```
+
+**Retention**: Only the latest version is kept after processing completes.
+
+#### Individual Diff JSON (`docs-data/connect-diff-{v1}_to_{v2}.json`)
+
+Changes between two consecutive versions:
+
+```json
+{
+  "comparison": {
+    "oldVersion": "4.50.0",
+    "newVersion": "4.51.0",
+    "timestamp": "2026-04-01T10:00:00.000Z"
+  },
+  "summary": {
+    "newComponents": 3,
+    "newFields": 15,
+    "removedFields": 2,
+    "deprecatedFields": 1
+  },
+  "details": {
+    "newComponents": [...],
+    "newFields": [...],
+    "removedFields": [...],
+    "deprecatedFields": [...],
+    "changedDefaults": [...]
+  },
+  "binaryAnalysis": {
+    "versions": {
+      "oss": "4.51.0",
+      "cloud": "4.52.0",
+      "cgo": "4.52.0"
+    },
+    "comparison": {
+      "inCloud": [...],
+      "notInCloud": [...],
+      "cloudOnly": [...]
+    },
+    "cgoOnly": [...],
+    "details": {
+      "cloudSupported": [...],
+      "selfHostedOnly": [...],
+      "cloudOnly": [...]
+    }
+  }
+}
+```
+
+**Retention**: Kept for intermediate versions during processing, cleaned up after master diff is created.
+
+#### Master Diff JSON (`docs-data/connect-diff-master-{v1}_to_{vN}.json`)
+
+Aggregated changes across multiple releases:
+
+```json
+{
+  "metadata": {
+    "generatedAt": "2026-04-01T10:00:00.000Z",
+    "startVersion": "4.50.0",
+    "endVersion": "4.54.0",
+    "processedReleases": 4
+  },
+  "totalSummary": {
+    "versions": ["4.51.0", "4.52.0", "4.53.0", "4.54.0"],
+    "releaseCount": 4,
+    "newComponents": 12,
+    "newFields": 45,
+    "removedFields": 5,
+    "deprecatedFields": 3
+  },
+  "releases": [
+    {
+      "fromVersion": "4.50.0",
+      "toVersion": "4.51.0",
+      "date": "2024-05-01T00:00:00.000Z",
+      "summary": {...},
+      "details": {...},
+      "binaryAnalysis": {...}
+    },
+    {
+      "fromVersion": "4.51.0",
+      "toVersion": "4.52.0",
+      // ...
+    }
+    // ... one entry per release
+  ]
+}
+```
+
+**Purpose**: Provides writers with accurate per-version attribution for changelog/release notes.
+
+### 3. PR Summary
+
+Automatically generated PR description with platform indicators and action items:
+
+```markdown
+## 📊 Redpanda Connect Documentation Update
+
+**📦 Multi-Release Update:** 4.50.0 → 4.54.0
+**Releases Processed:** 4
+**Cloud Version:** 4.55.0
+
+### Total Changes Across All Releases
+
+- **12** new connectors
+- **45** new fields across 4 release(s)
+- **5** removed fields ⚠️
+- **3** deprecated fields
+
+### Changes Per Release
+
+#### 🔖 Version 4.51.0
+
+**New Connectors (3):**
+- `postgres_cdc` (inputs, beta) ☁️
+- `tigerbeetle_cdc` (inputs, beta) 🔧
+- `mongodb_cdc` (inputs, stable) ☁️
+
+**New Fields:** 12 added
+**⚠️ Removed Fields:** 2
+
+#### 🔖 Version 4.52.0
+
+**New Connectors (5):**
+- `oracledb_cdc` (inputs, experimental) ☁️
+- `elasticsearch_v9` (outputs, stable)
+- ...
+
+**New Fields:** 18 added
+
+#### 🔖 Version 4.53.0
+
+_No changes in this release_
+
+#### 🔖 Version 4.54.0
+
+**New Connectors (4):**
+...
+
+### ✍️ Writer Action Items
+
+**Document New Connectors:**
+
+- [ ] Document new `postgres_cdc` inputs from **4.51.0** ☁️
+- [ ] Document new `tigerbeetle_cdc` inputs from **4.51.0** 🔧
+- [ ] Document new `mongodb_cdc` inputs from **4.51.0** ☁️
+- [ ] Document new `oracledb_cdc` inputs from **4.52.0** ☁️
+- [ ] Document new `a2a_message` processors from **4.54.0** ☁️
+
+### ☁️ Cloud Docs Update Required
+
+**12** new connectors are available in Redpanda Cloud.
+
+**Action:** Submit a separate PR to cloud-docs repository.
+
+**For connectors in pages:**
+\```asciidoc
+include::redpanda-connect:components:page$type/name.adoc[tag=single-source]
+\```
+
+**For cloud-only connectors (in partials):**
+\```asciidoc
+include::redpanda-connect:components:partial$components/cloud-only/type/name.adoc[tag=single-source]
+\```
+
+### 🔧 Cgo Requirements
+
+The following new connectors require cgo-enabled builds:
+
+- `tigerbeetle_cdc` (inputs)
+- `zmq4` (inputs, outputs)
+- `ffi` (processors)
+
+[Cgo installation instructions included]
+
+<details>
+<summary><strong>📋 Detailed Changes</strong> (click to expand)</summary>
+
+[Comprehensive breakdown of all changes]
+
+</details>
+```
+
+**Indicators**:
+- ☁️ = Cloud-supported (available in Redpanda Cloud)
+- 🔧 = Requires cgo-enabled build
+- ⚠️ = Breaking change (removed fields)
+
+## CLI Usage
+
+### Basic Usage
+
+```bash
+# Generate docs for latest version
+npx doc-tools generate rpcn-connector-docs --fetch-connectors
+
+# Generate docs for specific version
+npx doc-tools generate rpcn-connector-docs \
+  --fetch-connectors \
+  --connect-version 4.54.0
+
+# Process intermediate releases with custom starting version
+npx doc-tools generate rpcn-connector-docs \
+  --fetch-connectors \
+  --from-version 4.50.0 \
+  --connect-version 4.54.0
+```
+
+### CLI Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--fetch-connectors` | Fetch fresh connector data using rpk | - |
+| `--connect-version <version>` | Target Connect version to process | Auto-detect latest |
+| `--from-version <version>` | Override starting version (instead of antora.yml) | Read from antora.yml |
+| `--skip-intermediate` | Disable multi-release processing (legacy mode) | Multi-release enabled |
+| `--cloud-version <version>` | Specific cloud binary version | Auto-detect latest |
+| `--cgo-version <version>` | Specific cgo binary version | Same as cloud |
+| `--draft-missing` | Generate full page drafts for new connectors | false |
+| `--update-whats-new` | Update whats-new.adoc with changes | false |
+| `--include-bloblang` | Include Bloblang functions/methods | false |
+| `--overrides <path>` | JSON file with description overrides | `docs-data/overrides.json` |
+
+### Examples
+
+#### Catchup After Missed Releases
+
+```bash
+# antora.yml has 4.50.0, but latest is 4.54.0
+# This will process all 4 intermediate releases
+
+npx doc-tools generate rpcn-connector-docs \
+  --fetch-connectors \
+  --draft-missing \
+  --update-whats-new
+```
+
+**Output**:
+- Processes: 4.50.0→4.51.0, 4.51.0→4.52.0, 4.52.0→4.53.0, 4.53.0→4.54.0
+- Creates: 4 individual diffs + 1 master diff
+- Generates: Partials, drafts, PR summary with per-version attribution
+
+#### Legacy Single-Version Mode
+
+```bash
+# Disable multi-release processing (old behavior)
+
+npx doc-tools generate rpcn-connector-docs \
+  --fetch-connectors \
+  --skip-intermediate
+```
+
+#### Custom Version Range
+
+```bash
+# Process releases between specific versions
+
+npx doc-tools generate rpcn-connector-docs \
+  --fetch-connectors \
+  --from-version 4.52.0 \
+  --connect-version 4.54.0
+```
+
+## File Structure
+
+```
+docs-extensions-and-macros/
+├── tools/redpanda-connect/
+│   ├── rpcn-connector-docs-handler.js      # Main orchestration
+│   ├── generate-rpcn-connector-docs.js     # Doc generation logic
+│   ├── report-delta.js                     # Diff generation
+│   ├── pr-summary-formatter.js             # PR summary formatting
+│   ├── github-release-utils.js             # GitHub API integration
+│   ├── multi-version-summary.js            # Master diff aggregation
+│   ├── connector-binary-analyzer.js        # Binary download & analysis
+│   └── update-whats-new.js                 # Release notes updates
+│
+├── docs-data/                              # Generated data (gitignored)
+│   ├── connect-{version}.json              # Connector metadata (latest only)
+│   ├── connect-diff-{v1}_to_{v2}.json     # Individual diffs (intermediate)
+│   └── connect-diff-master-{v1}_to_{vN}.json  # Master diff (kept)
+│
+└── modules/components/
+    ├── pages/{type}/{name}.adoc            # Full pages (manually created or drafted)
+    └── partials/
+        ├── fields/{type}/{name}.adoc       # Auto-generated field docs
+        └── examples/{type}/{name}.adoc     # Auto-generated examples
+```
+
+## Testing
+
+### Unit Tests
+
+```bash
+# Run all tests
+npm test
+
+# Test specific modules
+npm test -- __tests__/tools/github-release-utils.test.js
+npm test -- __tests__/tools/pr-summary-formatter.test.js
+```
+
+**Coverage**:
+- ✅ Version parsing and semver comparisons
+- ✅ Prerelease filtering (beta/RC/alpha)
+- ✅ Intermediate release discovery
+- ✅ Platform detection (cloud vs self-hosted)
+- ✅ PR summary formatting (single and multi-version)
+- ✅ Diff generation and change detection
+
+### Integration Testing
+
+```bash
+# Create test environment
+mkdir -p /tmp/test-automation/{docs-data,modules/components/pages}
+
+# Create mock antora.yml
+echo 'name: test
+version: main
+asciidoc:
+  attributes:
+    latest-connect-version: "4.50.0"' > /tmp/test-automation/antora.yml
+
+# Run automation
+cd /tmp/test-automation
+npx doc-tools generate rpcn-connector-docs \
+  --from-version 4.50.0 \
+  --connect-version 4.54.0 \
+  --fetch-connectors
+```
+
+**Verify**:
+- ✅ Multiple diffs created (one per release pair)
+- ✅ Master diff with accurate attribution
+- ✅ AsciiDoc partials generated
+- ✅ antora.yml updated to latest version
+- ✅ Only latest JSON retained
+
+## Dependencies
+
+### Runtime Dependencies
+- `@octokit/rest` - GitHub API client for release discovery
+- `semver` - Semantic version parsing and comparison
+- `handlebars` - Template engine for doc generation
+- `js-yaml` - YAML parsing for antora.yml
+
+### External Tools
+- `rpk` - Redpanda CLI for fetching connector metadata
+- `git` - For cloning repositories to fetch binary versions
+
+## Error Handling
+
+### GitHub API Rate Limiting
+- **Without token**: 60 requests/hour
+- **With token**: 5,000 requests/hour
+- **Handling**: Cache responses, graceful degradation to single-version mode
+
+### Missing Intermediate Data
+- Automatically fetches from GitHub releases
+- Downloads binaries for specified versions
+- Falls back to rpk if available locally
+
+### Network Failures
+- Retries with exponential backoff
+- Continues processing with partial data
+- Logs warnings for manual review
+
+## Edge Cases
+
+### No Intermediate Releases
+- Behaves like legacy single-version mode
+- No master diff created
+- Standard PR summary generated
+
+### Beta/RC Versions
+- Automatically filtered out
+- Only stable GA releases processed
+- Explicit override with `--include-prerelease` (not yet implemented)
+
+### Identical Consecutive Versions
+- Skips diff generation
+- Logs "No changes detected"
+- Updates metadata only
+
+### Binary Unavailability
+- Continues without binary analysis
+- Platform indicators omitted from output
+- Warning logged for manual verification
+
+## Future Enhancements
+
+1. **Bloblang Full Support**: Currently optional, could be made default
+2. **Automated PR Creation**: Auto-submit PRs with generated content
+3. **CI/CD Integration**: GitHub Actions workflow for weekly runs
+4. **Historical Backfill**: Process all historical releases for complete attribution
+5. **Diff Visualization**: Web UI to browse changes across versions
+6. **Custom Templates**: User-provided Handlebars templates for docs
+
+## Maintenance
+
+### Updating Templates
+Templates are in `tools/redpanda-connect/templates/`:
+- `connector-fields.hbs` - Field documentation template
+- `connector-examples.hbs` - Examples template
+- `connector-full.hbs` - Full page draft template
+
+### Updating Overrides
+Override file: `docs-data/overrides.json` (or `--overrides` flag)
+
+```json
+{
+  "inputs": {
+    "kafka": {
+      "fields": {
+        "addresses": {
+          "description": "Custom description override",
+          "examples": ["localhost:9092"]
+        }
+      }
+    }
+  }
+}
+```
+
+Supports `$ref` syntax for deduplication:
+```json
+{
+  "inputs": {
+    "kafka": {
+      "fields": {
+        "tls": { "$ref": "#/common/tls" }
+      }
+    }
+  },
+  "common": {
+    "tls": {
+      "description": "TLS configuration (reused across components)"
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### "No releases found in the specified range"
+- **Cause**: Invalid version range or no releases exist between versions
+- **Fix**: Verify versions exist on GitHub, check semver format
+
+### "GitHub API rate limit exceeded"
+- **Cause**: Too many API requests without authentication
+- **Fix**: Set `GITHUB_TOKEN` environment variable
+
+### "Binary analysis failed"
+- **Cause**: Unable to download binaries (network, permissions, etc.)
+- **Fix**: Check network, ensure write permissions to temp directories
+
+### "Versions match, skipping diff"
+- **Cause**: Already at target version, no work needed
+- **Fix**: This is expected behavior, no action needed
+
+## Contact & Support
+
+For issues or questions:
+- **GitHub Issues**: [docs-extensions-and-macros repository](https://github.com/redpanda-data/docs-extensions-and-macros/issues)
+- **Slack**: #docs channel
+- **Docs**: Internal Confluence documentation
+
+---
+
+**Last Updated**: 2026-04-01
+**Version**: 1.0.0
+**Maintainers**: Redpanda Docs Team

--- a/tools/redpanda-connect/AUTOMATION.md
+++ b/tools/redpanda-connect/AUTOMATION.md
@@ -38,7 +38,7 @@ The automation handles **multi-release attribution**, automatically detecting an
 
 ### Architecture Overview
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │ 1. Version Detection                                            │
 │    • Read current version from antora.yml                       │
@@ -82,14 +82,14 @@ The automation handles **multi-release attribution**, automatically detecting an
 **Scenario**: antora.yml has version `4.50.0`, latest release is `4.54.0`
 
 **Without Multi-Release (OLD behavior)**:
-```
+```text
 4.50.0 ─────────────────────────► 4.54.0
          (all changes lumped)
 ```
 Result: All changes from 4.51.0, 4.52.0, 4.53.0, and 4.54.0 are attributed to 4.54.0 ❌
 
 **With Multi-Release (NEW behavior)**:
-```
+```text
 4.50.0 ──► 4.51.0 ──► 4.52.0 ──► 4.53.0 ──► 4.54.0
    │          │          │          │          │
    diff1      diff2      diff3      diff4      │

--- a/tools/redpanda-connect/generate-rpcn-connector-docs.js
+++ b/tools/redpanda-connect/generate-rpcn-connector-docs.js
@@ -244,7 +244,8 @@ async function generateRpcnConnectorDocs(options) {
     templateBloblang,
     writeFullDrafts,
     cgoOnly = [],        // Array of cgo-only connectors from cgo binary inspection
-    cloudOnly = []       // Array of cloud-only connectors from cloud binary inspection
+    cloudOnly = [],      // Array of cloud-only connectors from cloud binary inspection
+    csvMetadata = []     // Array of CSV metadata with support levels
   } = options;
 
   // Read connector index (JSON or YAML)
@@ -270,6 +271,16 @@ async function generateRpcnConnectorDocs(options) {
     cloudOnly.forEach(connector => {
       if (connector.type && connector.name) {
         cloudOnlySet.add(`${connector.type}:${connector.name}`);
+      }
+    });
+  }
+
+  // Build a Map of CSV metadata for fast support level lookup
+  const csvMetadataMap = new Map();
+  if (Array.isArray(csvMetadata)) {
+    csvMetadata.forEach(item => {
+      if (item.type && item.name) {
+        csvMetadataMap.set(`${item.type}:${item.name}`, item);
       }
     });
   }
@@ -395,7 +406,8 @@ async function generateRpcnConnectorDocs(options) {
         }
 
         // Check if this connector is cgo-only or cloud-only and mark it
-        const connectorKey = `${type}:${name}`;
+        // Use item.type (singular) not type (plural) for CSV lookup
+        const connectorKey = `${item.type}:${name}`;
         const isCloudOnly = cloudOnlySet.has(connectorKey);
         const isCgoOnly = cgoOnlySet.has(connectorKey);
 
@@ -409,6 +421,12 @@ async function generateRpcnConnectorDocs(options) {
 
         if (isCloudOnly) {
           item.cloudOnly = true;
+        }
+
+        // Lookup support level from CSV metadata
+        const csvData = csvMetadataMap.get(connectorKey);
+        if (csvData && csvData.support) {
+          item.support = csvData.support;
         }
 
         let content;

--- a/tools/redpanda-connect/generate-rpcn-connector-docs.js
+++ b/tools/redpanda-connect/generate-rpcn-connector-docs.js
@@ -406,8 +406,8 @@ async function generateRpcnConnectorDocs(options) {
         }
 
         // Check if this connector is cgo-only or cloud-only and mark it
-        // Use item.type (singular) not type (plural) for CSV lookup
-        const connectorKey = `${item.type}:${name}`;
+        // Use plural type for CGO/cloud detection (matches test expectations)
+        const connectorKey = `${type}:${name}`;
         const isCloudOnly = cloudOnlySet.has(connectorKey);
         const isCgoOnly = cgoOnlySet.has(connectorKey);
 
@@ -423,8 +423,9 @@ async function generateRpcnConnectorDocs(options) {
           item.cloudOnly = true;
         }
 
-        // Lookup support level from CSV metadata
-        const csvData = csvMetadataMap.get(connectorKey);
+        // Lookup support level from CSV metadata using singular type
+        const csvKey = `${item.type}:${name}`;
+        const csvData = csvMetadataMap.get(csvKey);
         if (csvData && csvData.support) {
           item.support = csvData.support;
         }

--- a/tools/redpanda-connect/github-release-utils.js
+++ b/tools/redpanda-connect/github-release-utils.js
@@ -141,6 +141,14 @@ async function discoverIntermediateReleases(fromVersion, toVersion, options = {}
     useCache = true
   } = options;
 
+  // Validate versions are strings
+  if (typeof fromVersion !== 'string') {
+    throw new Error(`Invalid starting version: ${fromVersion}`);
+  }
+  if (typeof toVersion !== 'string') {
+    throw new Error(`Invalid ending version: ${toVersion}`);
+  }
+
   // Normalize versions (remove 'v' prefix if present)
   const normalizedFrom = fromVersion.startsWith('v') ? fromVersion.slice(1) : fromVersion;
   const normalizedTo = toVersion.startsWith('v') ? toVersion.slice(1) : toVersion;

--- a/tools/redpanda-connect/github-release-utils.js
+++ b/tools/redpanda-connect/github-release-utils.js
@@ -1,0 +1,267 @@
+'use strict';
+
+const octokit = require('../../cli-utils/octokit-client');
+const { hasGitHubToken } = require('../../cli-utils/github-token');
+const semver = require('semver');
+
+/**
+ * GitHub release discovery utilities for Redpanda Connect
+ *
+ * Provides functions to discover and filter GitHub releases between versions.
+ */
+
+// Cache for GitHub releases to avoid repeated API calls
+let releaseCache = null;
+let cacheTimestamp = null;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Fetch all releases from redpanda-data/connect repository
+ * @param {boolean} useCache - Whether to use cached results
+ * @returns {Promise<Array>} Array of release objects
+ */
+async function fetchAllReleases(useCache = true) {
+  // Check cache
+  if (useCache && releaseCache && cacheTimestamp) {
+    const age = Date.now() - cacheTimestamp;
+    if (age < CACHE_TTL_MS) {
+      console.log(`✓ Using cached releases (${Math.round(age / 1000)}s old)`);
+      return releaseCache;
+    }
+  }
+
+  console.log('Fetching releases from GitHub...');
+
+  // Warn if no token available (only once per execution)
+  if (!hasGitHubToken() && !fetchAllReleases._warnedAboutToken) {
+    console.warn('⚠️  No GitHub token found. API rate limits will be more restrictive.');
+    console.warn('   Set GITHUB_TOKEN or GH_TOKEN environment variable for higher limits.');
+    fetchAllReleases._warnedAboutToken = true;
+  }
+
+  try {
+    // Fetch all releases (paginated)
+    const releases = await octokit.paginate(
+      octokit.rest.repos.listReleases,
+      {
+        owner: 'redpanda-data',
+        repo: 'connect',
+        per_page: 100
+      }
+    );
+
+    console.log(`✓ Fetched ${releases.length} releases from GitHub`);
+
+    // Update cache
+    releaseCache = releases;
+    cacheTimestamp = Date.now();
+
+    return releases;
+  } catch (error) {
+    if (error.status === 403 && error.response?.headers?.['x-ratelimit-remaining'] === '0') {
+      const resetTime = new Date(parseInt(error.response.headers['x-ratelimit-reset']) * 1000);
+      throw new Error(
+        `GitHub API rate limit exceeded. Resets at ${resetTime.toLocaleTimeString()}. ` +
+        `Consider setting GITHUB_TOKEN environment variable for higher limits.`
+      );
+    }
+
+    throw new Error(`Failed to fetch GitHub releases: ${error.message}`);
+  }
+}
+
+/**
+ * Parse version from GitHub release tag
+ * Handles formats: "v4.50.0", "4.50.0", "v4.50.0-beta.1"
+ * @param {string} tag - Release tag name
+ * @returns {string|null} Normalized version string or null if invalid
+ */
+function parseVersionFromTag(tag) {
+  if (!tag) return null;
+
+  // Remove 'v' prefix if present
+  const normalized = tag.startsWith('v') ? tag.slice(1) : tag;
+
+  // Validate semver format
+  const version = semver.valid(normalized);
+  return version;
+}
+
+/**
+ * Check if a version is a pre-release (beta, RC, alpha, etc.)
+ * @param {string} version - Semver version string
+ * @returns {boolean} True if pre-release
+ */
+function isPrerelease(version) {
+  const parsed = semver.parse(version);
+  if (!parsed) return false;
+
+  return parsed.prerelease.length > 0;
+}
+
+/**
+ * Filter releases to stable GA releases only
+ * @param {Array} releases - Array of GitHub release objects
+ * @returns {Array} Filtered releases with only stable versions
+ */
+function filterToStableReleases(releases) {
+  return releases.filter(release => {
+    // Skip drafts
+    if (release.draft) {
+      return false;
+    }
+
+    // Parse version
+    const version = parseVersionFromTag(release.tag_name);
+    if (!version) {
+      return false;
+    }
+
+    // Skip pre-releases (beta, RC, etc.)
+    if (isPrerelease(version)) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+/**
+ * Discover all intermediate releases between two versions
+ * @param {string} fromVersion - Starting version (e.g., "4.50.0")
+ * @param {string} toVersion - Ending version (e.g., "4.54.0")
+ * @param {Object} options - Optional configuration
+ * @param {boolean} options.includePrerelease - Include beta/RC versions (default: false)
+ * @param {boolean} options.useCache - Use cached GitHub data (default: true)
+ * @returns {Promise<Array>} Array of version objects: [{version, tag, date, url}]
+ */
+async function discoverIntermediateReleases(fromVersion, toVersion, options = {}) {
+  const {
+    includePrerelease = false,
+    useCache = true
+  } = options;
+
+  // Normalize versions (remove 'v' prefix if present)
+  const normalizedFrom = fromVersion.startsWith('v') ? fromVersion.slice(1) : fromVersion;
+  const normalizedTo = toVersion.startsWith('v') ? toVersion.slice(1) : toVersion;
+
+  // Validate versions
+  if (!semver.valid(normalizedFrom)) {
+    throw new Error(`Invalid starting version: ${fromVersion}`);
+  }
+  if (!semver.valid(normalizedTo)) {
+    throw new Error(`Invalid ending version: ${toVersion}`);
+  }
+
+  console.log('');
+  console.log(`Discovering releases between ${normalizedFrom} and ${normalizedTo}...`);
+
+  // Fetch all releases
+  const allReleases = await fetchAllReleases(useCache);
+
+  // Filter to stable releases unless includePrerelease is true
+  const filteredReleases = includePrerelease
+    ? allReleases.filter(r => !r.draft && parseVersionFromTag(r.tag_name))
+    : filterToStableReleases(allReleases);
+
+  // Parse and filter versions in range
+  const versionsInRange = [];
+
+  for (const release of filteredReleases) {
+    const version = parseVersionFromTag(release.tag_name);
+    if (!version) continue;
+
+    // Check if version is in range (inclusive)
+    if (
+      semver.gte(version, normalizedFrom) &&
+      semver.lte(version, normalizedTo)
+    ) {
+      versionsInRange.push({
+        version,
+        tag: release.tag_name,
+        date: release.published_at,
+        url: release.html_url,
+        isPrerelease: isPrerelease(version)
+      });
+    }
+  }
+
+  // Sort by semver (oldest to newest)
+  versionsInRange.sort((a, b) => semver.compare(a.version, b.version));
+
+  console.log(`✓ Found ${versionsInRange.length} release(s) in range`);
+
+  if (versionsInRange.length === 0) {
+    console.warn('⚠️  No releases found in the specified range');
+    return [];
+  }
+
+  // Log the discovered versions
+  console.log('');
+  console.log('Releases to process:');
+  versionsInRange.forEach((v, i) => {
+    const prereleaseTag = v.isPrerelease ? ' (pre-release)' : '';
+    const date = new Date(v.date).toLocaleDateString();
+    console.log(`  ${i + 1}. ${v.version}${prereleaseTag} - ${date}`);
+  });
+  console.log('');
+
+  return versionsInRange;
+}
+
+/**
+ * Find the appropriate cloud version for a given OSS release date
+ * Returns the latest stable cloud version published on or before the OSS release date
+ * @param {string} ossReleaseDate - ISO date string of the OSS release
+ * @param {Object} options - Optional configuration
+ * @param {boolean} options.useCache - Use cached GitHub data (default: true)
+ * @returns {Promise<string|null>} Cloud version string or null if not found
+ */
+async function findCloudVersionForDate(ossReleaseDate, options = {}) {
+  const { useCache = true } = options;
+
+  // Fetch all releases from the main connect repo (includes cloud builds)
+  const allReleases = await fetchAllReleases(useCache);
+
+  // Filter to stable releases
+  const stableReleases = filterToStableReleases(allReleases);
+
+  // Filter to releases on or before the OSS release date
+  const ossDate = new Date(ossReleaseDate);
+  const eligibleReleases = stableReleases.filter(release => {
+    const releaseDate = new Date(release.published_at);
+    return releaseDate <= ossDate;
+  });
+
+  if (eligibleReleases.length === 0) {
+    return null;
+  }
+
+  // Sort by date (most recent first)
+  eligibleReleases.sort((a, b) => {
+    return new Date(b.published_at) - new Date(a.published_at);
+  });
+
+  // Return the most recent version
+  const cloudVersion = parseVersionFromTag(eligibleReleases[0].tag_name);
+  return cloudVersion;
+}
+
+/**
+ * Clear the release cache
+ * Useful for testing or when you need fresh data
+ */
+function clearCache() {
+  releaseCache = null;
+  cacheTimestamp = null;
+}
+
+module.exports = {
+  discoverIntermediateReleases,
+  fetchAllReleases,
+  parseVersionFromTag,
+  isPrerelease,
+  filterToStableReleases,
+  findCloudVersionForDate,
+  clearCache
+};

--- a/tools/redpanda-connect/helpers/buildConfigYaml.js
+++ b/tools/redpanda-connect/helpers/buildConfigYaml.js
@@ -1,11 +1,14 @@
 const renderLeafField = require('./renderLeafField');
 const renderObjectField = require('./renderObjectField');
 
+// Component types that support the 'label' field
+const TYPES_WITH_LABEL = new Set(['inputs', 'outputs', 'processors']);
+
 /**
- * Builds either “Common” or “Advanced” YAML for one connector.
+ * Builds either "Common" or "Advanced" YAML for one connector.
  *
- * - type            = “input” or “output” (or whatever type)
- * - connectorName   = such as “amqp_1”
+ * - type            = "input" or "output" (or whatever type)
+ * - connectorName   = such as "amqp_1"
  * - children        = the array of field‐definitions (entry.config.children)
  * - includeAdvanced = if false → only fields where is_advanced !== true
  *                      if true  → all fields (except deprecated)
@@ -13,18 +16,20 @@ const renderObjectField = require('./renderObjectField');
  * Structure produced:
  *
  *   type:
- *     label: ""
+ *     label: ""          (only for inputs, outputs, processors)
  *     connectorName:
- *       ...child fields (with comments for “no default”)
+ *       ...child fields (with comments for "no default")
  */
 module.exports = function buildConfigYaml(type, connectorName, children, includeAdvanced) {
   const lines = [];
 
-  // “type:” top‐level
+  // "type:" top‐level
   lines.push(`${type}:`);
 
-  // Two‐space indent for “label”
-  lines.push(`  label: ""`);
+  // Two‐space indent for "label" (only for types that support it)
+  if (TYPES_WITH_LABEL.has(type)) {
+    lines.push(`  label: ""`);
+  }
 
   // Two‐space indent for connectorName heading
   lines.push(`  ${connectorName}:`);

--- a/tools/redpanda-connect/multi-version-summary.js
+++ b/tools/redpanda-connect/multi-version-summary.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Create a master diff JSON that aggregates changes across multiple releases
+ *
+ * @param {Array} intermediateResults - Array of {fromVersion, toVersion, diffPath, success}
+ * @param {string} finalDiffPath - Path to the final diff JSON
+ * @param {string} outputPath - Where to write the master diff
+ * @returns {Object} Master diff object
+ */
+function createMasterDiff(intermediateResults, finalDiffPath, outputPath) {
+  const releases = [];
+
+  // Add all intermediate releases
+  for (const result of intermediateResults) {
+    if (!result.success) continue;
+
+    try {
+      const diffData = JSON.parse(fs.readFileSync(result.diffPath, 'utf8'));
+      releases.push({
+        fromVersion: result.fromVersion,
+        toVersion: result.toVersion,
+        date: diffData.comparison?.timestamp || new Date().toISOString(),
+        summary: diffData.summary || {},
+        details: diffData.details || {},
+        binaryAnalysis: diffData.binaryAnalysis || null
+      });
+    } catch (err) {
+      console.warn(`Warning: Failed to load ${result.diffPath}: ${err.message}`);
+    }
+  }
+
+  // Add the final release
+  if (finalDiffPath && fs.existsSync(finalDiffPath)) {
+    try {
+      const diffData = JSON.parse(fs.readFileSync(finalDiffPath, 'utf8'));
+      const finalFromVersion = diffData.comparison?.oldVersion;
+      const finalToVersion = diffData.comparison?.newVersion;
+
+      releases.push({
+        fromVersion: finalFromVersion,
+        toVersion: finalToVersion,
+        date: diffData.comparison?.timestamp || new Date().toISOString(),
+        summary: diffData.summary || {},
+        details: diffData.details || {},
+        binaryAnalysis: diffData.binaryAnalysis || null
+      });
+    } catch (err) {
+      console.warn(`Warning: Failed to load ${finalDiffPath}: ${err.message}`);
+    }
+  }
+
+  // Calculate total summary across all releases
+  const totalSummary = {
+    versions: releases.map(r => r.toVersion),
+    releaseCount: releases.length,
+    newComponents: releases.reduce((sum, r) => sum + (r.summary.newComponents || 0), 0),
+    newFields: releases.reduce((sum, r) => sum + (r.summary.newFields || 0), 0),
+    removedComponents: releases.reduce((sum, r) => sum + (r.summary.removedComponents || 0), 0),
+    removedFields: releases.reduce((sum, r) => sum + (r.summary.removedFields || 0), 0),
+    deprecatedComponents: releases.reduce((sum, r) => sum + (r.summary.deprecatedComponents || 0), 0),
+    deprecatedFields: releases.reduce((sum, r) => sum + (r.summary.deprecatedFields || 0), 0),
+    changedDefaults: releases.reduce((sum, r) => sum + (r.summary.changedDefaults || 0), 0)
+  };
+
+  const masterDiff = {
+    metadata: {
+      generatedAt: new Date().toISOString(),
+      startVersion: releases[0]?.fromVersion,
+      endVersion: releases[releases.length - 1]?.toVersion,
+      processedReleases: releases.length
+    },
+    totalSummary,
+    releases
+  };
+
+  // Write to file
+  if (outputPath) {
+    fs.writeFileSync(outputPath, JSON.stringify(masterDiff, null, 2), 'utf8');
+    console.log(`✓ Created master diff: ${path.basename(outputPath)}`);
+    console.log(`   Spans ${releases.length} release(s): ${releases[0]?.fromVersion} → ${releases[releases.length - 1]?.toVersion}`);
+  }
+
+  return masterDiff;
+}
+
+module.exports = {
+  createMasterDiff
+};

--- a/tools/redpanda-connect/parse-csv-connectors.js
+++ b/tools/redpanda-connect/parse-csv-connectors.js
@@ -48,6 +48,7 @@ async function parseCSVConnectors(localCsvPath, logger) {
         return {
           name: trimmed.name,
           type: trimmed.type,
+          support: trimmed.support || 'community', // certified, community, enterprise
           is_cloud_supported: (trimmed.cloud || '').toLowerCase() === 'y' ? 'y' : 'n'
         };
       })

--- a/tools/redpanda-connect/pr-summary-formatter.js
+++ b/tools/redpanda-connect/pr-summary-formatter.js
@@ -281,7 +281,8 @@ function generateMultiVersionPRSummary(masterDiff, binaryAnalysis = null, drafte
       lines.push('');
     }
 
-    if (otherConnectors.length > 0 && cloudConnectors.length === 0 && selfHostedConnectors.length === 0) {
+    if (otherConnectors.length > 0) {
+      lines.push('_Other connectors:_');
       otherConnectors.forEach(conn => {
         lines.push(`- [ ] \`${conn.name}\` ${conn.type} — introduced in **${conn.version}**`);
       });
@@ -394,11 +395,13 @@ function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = 
   if (stats.newComponents > 0) {
     lines.push(`- **${stats.newComponents}** new connector${stats.newComponents !== 1 ? 's' : ''}`);
 
-    if (binaryAnalysis) {
+    if (binaryAnalysis && binaryAnalysis.comparison) {
       const newConnectorKeys = diffData.details.newComponents.map(c => `${c.type}:${c.name}`);
       const cloudSupported = newConnectorKeys.filter(key => {
         const inCloud = binaryAnalysis.comparison.inCloud.some(c => `${c.type}:${c.name}` === key);
-        return inCloud;
+        const cloudOnly = binaryAnalysis.comparison.cloudOnly &&
+                         binaryAnalysis.comparison.cloudOnly.some(c => `${c.type}:${c.name}` === key);
+        return inCloud || cloudOnly;
       }).length;
 
       const needsCloudDocs = cloudSupported;

--- a/tools/redpanda-connect/pr-summary-formatter.js
+++ b/tools/redpanda-connect/pr-summary-formatter.js
@@ -43,17 +43,22 @@ function generateMultiVersionPRSummary(masterDiff, binaryAnalysis = null, drafte
   if (total.newFields > 0) {
     lines.push(`- **${total.newFields}** new fields across ${total.releaseCount || 0} release(s)`);
   }
+  if (total.removedComponents > 0) {
+    lines.push(`- **${total.removedComponents}** removed connectors ⚠️`);
+  }
   if (total.removedFields > 0) {
     lines.push(`- **${total.removedFields}** removed fields ⚠️`);
+  }
+  if (total.deprecatedComponents > 0) {
+    lines.push(`- **${total.deprecatedComponents}** deprecated connectors`);
   }
   if (total.deprecatedFields > 0) {
     lines.push(`- **${total.deprecatedFields}** deprecated fields`);
   }
+  if (total.changedDefaults > 0) {
+    lines.push(`- **${total.changedDefaults}** changed default values ⚠️`);
+  }
 
-  lines.push('');
-
-  // Per-release breakdown
-  lines.push('### Changes Per Release');
   lines.push('');
 
   // Guard: ensure releases array exists
@@ -65,65 +70,145 @@ function generateMultiVersionPRSummary(masterDiff, binaryAnalysis = null, drafte
     return lines.join('\n');
   }
 
+  // Per-release detailed breakdown
+  lines.push('### Changes Per Release');
+  lines.push('');
+
   for (const release of releases) {
+    const releaseNotesUrl = `https://github.com/redpanda-data/connect/releases/tag/v${release.toVersion}`;
     lines.push(`#### 🔖 Version ${release.toVersion}`);
+    lines.push(`> [Release notes](${releaseNotesUrl})`);
     lines.push('');
 
     const summary = release.summary || {};
+    const details = release.details || {};
     const hasChanges = Object.values(summary).some(v => v > 0);
 
     if (!hasChanges) {
-      lines.push('_No changes in this release_');
+      lines.push('_No documentation changes in this release_');
       lines.push('');
       continue;
     }
 
-    // Show what changed in this specific release
-    const newComponents = release.details?.newComponents || [];
+    // New connectors with descriptions
+    const newComponents = details.newComponents || [];
     if (summary.newComponents > 0 && newComponents.length > 0) {
       lines.push(`**New Connectors (${summary.newComponents}):**`);
       lines.push('');
       const inCloud = release.binaryAnalysis?.comparison?.inCloud || [];
       const cloudOnly = release.binaryAnalysis?.comparison?.cloudOnly || [];
+      const notInCloud = release.binaryAnalysis?.comparison?.notInCloud || [];
       const cgoOnly = release.binaryAnalysis?.cgoOnly || [];
+
       newComponents.forEach(comp => {
-        const cloudIndicator = inCloud.some(c => c.type === comp.type && c.name === comp.name) ||
-          cloudOnly.some(c => c.type === comp.type && c.name === comp.name) ? ' ☁️' : '';
-        const cgoIndicator = cgoOnly.some(c => c.type === comp.type && c.name === comp.name) ? ' 🔧' : '';
-        lines.push(`- \`${comp.name}\` (${comp.type}, ${comp.status})${cloudIndicator}${cgoIndicator}`);
+        const isInCloud = inCloud.some(c => c.type === comp.type && c.name === comp.name) ||
+          cloudOnly.some(c => c.type === comp.type && c.name === comp.name);
+        const isSelfHostedOnly = notInCloud.some(c => c.type === comp.type && c.name === comp.name);
+        const isCgoOnly = cgoOnly.some(c => c.type === comp.type && c.name === comp.name);
+
+        let platformIndicator = '';
+        if (isInCloud) platformIndicator = ' ☁️';
+        else if (isSelfHostedOnly) platformIndicator = ' 🖥️';
+        if (isCgoOnly) platformIndicator += ' 🔧';
+
+        lines.push(`##### \`${comp.name}\` (${comp.type}, ${comp.status})${platformIndicator}`);
+
+        // Add description (truncated to 2 sentences)
+        if (comp.description) {
+          const shortDesc = truncateToSentence(comp.description, 2);
+          lines.push(`> ${shortDesc}`);
+        }
+        lines.push('');
+      });
+    }
+
+    // New fields with details
+    const newFields = details.newFields || [];
+    if (summary.newFields > 0 && newFields.length > 0) {
+      lines.push(`**New Fields (${summary.newFields}):**`);
+      lines.push('');
+      lines.push('| Component | Field | Description |');
+      lines.push('|-----------|-------|-------------|');
+
+      newFields.forEach(field => {
+        const desc = field.description ? truncateToSentence(field.description, 1).replace(/\|/g, '\\|') : '_No description_';
+        lines.push(`| \`${field.component}\` | \`${field.field}\` | ${desc} |`);
       });
       lines.push('');
     }
 
-    if (summary.newFields > 0) {
-      lines.push(`**New Fields:** ${summary.newFields} added`);
+    // Removed components
+    const removedComponents = details.removedComponents || [];
+    if (summary.removedComponents > 0 && removedComponents.length > 0) {
+      lines.push(`**⚠️ Removed Connectors (${summary.removedComponents}):**`);
+      lines.push('');
+      removedComponents.forEach(comp => {
+        lines.push(`- \`${comp.name}\` (${comp.type})`);
+      });
       lines.push('');
     }
 
-    if (summary.removedFields > 0) {
-      lines.push(`**⚠️ Removed Fields:** ${summary.removedFields}`);
+    // Removed fields
+    const removedFields = details.removedFields || [];
+    if (summary.removedFields > 0 && removedFields.length > 0) {
+      lines.push(`**⚠️ Removed Fields (${summary.removedFields}):**`);
+      lines.push('');
+      lines.push('| Component | Field |');
+      lines.push('|-----------|-------|');
+      removedFields.forEach(field => {
+        lines.push(`| \`${field.component}\` | \`${field.field}\` |`);
+      });
       lines.push('');
     }
 
-    if (summary.deprecatedFields > 0) {
-      lines.push(`**Deprecated Fields:** ${summary.deprecatedFields}`);
+    // Deprecated fields with migration guidance
+    const deprecatedFields = details.deprecatedFields || [];
+    if (summary.deprecatedFields > 0 && deprecatedFields.length > 0) {
+      lines.push(`**Deprecated Fields (${summary.deprecatedFields}):**`);
+      lines.push('');
+      deprecatedFields.forEach(field => {
+        const guidance = field.description ? ` — ${truncateToSentence(field.description, 1)}` : '';
+        lines.push(`- \`${field.component}.${field.field}\`${guidance}`);
+      });
+      lines.push('');
+    }
+
+    // Changed defaults
+    const changedDefaults = details.changedDefaults || [];
+    if (summary.changedDefaults > 0 && changedDefaults.length > 0) {
+      lines.push(`**⚠️ Changed Defaults (${summary.changedDefaults}):**`);
+      lines.push('');
+      lines.push('| Component | Field | Old Default | New Default |');
+      lines.push('|-----------|-------|-------------|-------------|');
+      changedDefaults.forEach(change => {
+        const oldVal = change.oldDefault !== undefined ? `\`${JSON.stringify(change.oldDefault)}\`` : '_none_';
+        const newVal = change.newDefault !== undefined ? `\`${JSON.stringify(change.newDefault)}\`` : '_none_';
+        lines.push(`| \`${change.component}\` | \`${change.field}\` | ${oldVal} | ${newVal} |`);
+      });
       lines.push('');
     }
   }
 
   // Writer action items (aggregate)
+  lines.push('---');
+  lines.push('');
   lines.push('### ✍️ Writer Action Items');
   lines.push('');
 
-  // Collect all new connectors across all releases
+  // Collect all new connectors across all releases with full details
   const allNewConnectors = [];
+  const allRemovedConnectors = [];
+  const allDeprecatedFields = [];
+  const allChangedDefaults = [];
+
   releases.forEach(release => {
-    const releaseNewComponents = release.details?.newComponents || [];
+    const details = release.details || {};
     const releaseInCloud = release.binaryAnalysis?.comparison?.inCloud || [];
     const releaseCloudOnly = release.binaryAnalysis?.comparison?.cloudOnly || [];
     const releaseNotInCloud = release.binaryAnalysis?.comparison?.notInCloud || [];
 
-    releaseNewComponents.forEach(comp => {
+    // New connectors
+    (details.newComponents || []).forEach(comp => {
       const isCloud = releaseInCloud.some(c => c.type === comp.type && c.name === comp.name) ||
         releaseCloudOnly.some(c => c.type === comp.type && c.name === comp.name);
       const isSelfHostedOnly = releaseNotInCloud.some(c => c.type === comp.type && c.name === comp.name);
@@ -132,20 +217,122 @@ function generateMultiVersionPRSummary(masterDiff, binaryAnalysis = null, drafte
         name: comp.name,
         type: comp.type,
         status: comp.status,
+        description: comp.description,
         version: release.toVersion,
         isCloud,
         isSelfHostedOnly
       });
     });
+
+    // Removed connectors
+    (details.removedComponents || []).forEach(comp => {
+      allRemovedConnectors.push({
+        name: comp.name,
+        type: comp.type,
+        version: release.toVersion
+      });
+    });
+
+    // Deprecated fields
+    (details.deprecatedFields || []).forEach(field => {
+      allDeprecatedFields.push({
+        component: field.component,
+        field: field.field,
+        description: field.description,
+        version: release.toVersion
+      });
+    });
+
+    // Changed defaults
+    (details.changedDefaults || []).forEach(change => {
+      allChangedDefaults.push({
+        component: change.component,
+        field: change.field,
+        oldDefault: change.oldDefault,
+        newDefault: change.newDefault,
+        version: release.toVersion
+      });
+    });
   });
 
+  // Priority 1: New connectors needing documentation
   if (allNewConnectors.length > 0) {
-    lines.push('**Document New Connectors:**');
+    lines.push('**📝 Document New Connectors:**');
     lines.push('');
-    allNewConnectors.forEach(conn => {
-      const cloudLabel = conn.isSelfHostedOnly ? ' (self-hosted only)' : conn.isCloud ? ' ☁️' : '';
-      lines.push(`- [ ] Document new \`${conn.name}\` ${conn.type} from **${conn.version}**${cloudLabel}`);
+
+    // Group by cloud vs self-hosted
+    const cloudConnectors = allNewConnectors.filter(c => c.isCloud);
+    const selfHostedConnectors = allNewConnectors.filter(c => c.isSelfHostedOnly);
+    const otherConnectors = allNewConnectors.filter(c => !c.isCloud && !c.isSelfHostedOnly);
+
+    if (cloudConnectors.length > 0) {
+      lines.push('_Cloud-supported (higher priority):_');
+      cloudConnectors.forEach(conn => {
+        lines.push(`- [ ] \`${conn.name}\` ${conn.type} ☁️ — introduced in **${conn.version}**`);
+      });
+      lines.push('');
+    }
+
+    if (selfHostedConnectors.length > 0) {
+      lines.push('_Self-hosted only:_');
+      selfHostedConnectors.forEach(conn => {
+        lines.push(`- [ ] \`${conn.name}\` ${conn.type} 🖥️ — introduced in **${conn.version}**`);
+      });
+      lines.push('');
+    }
+
+    if (otherConnectors.length > 0 && cloudConnectors.length === 0 && selfHostedConnectors.length === 0) {
+      otherConnectors.forEach(conn => {
+        lines.push(`- [ ] \`${conn.name}\` ${conn.type} — introduced in **${conn.version}**`);
+      });
+      lines.push('');
+    }
+  }
+
+  // Priority 2: Removed connectors needing migration docs
+  if (allRemovedConnectors.length > 0) {
+    lines.push('**⚠️ Update Migration Guide for Removed Connectors:**');
+    lines.push('');
+    allRemovedConnectors.forEach(conn => {
+      lines.push(`- [ ] \`${conn.name}\` ${conn.type} — removed in **${conn.version}**`);
     });
+    lines.push('');
+  }
+
+  // Priority 3: Deprecated fields needing docs update
+  if (allDeprecatedFields.length > 0) {
+    lines.push('**📋 Update Docs for Deprecated Fields:**');
+    lines.push('');
+    allDeprecatedFields.forEach(field => {
+      const guidance = field.description ? ` (${truncateToSentence(field.description, 1)})` : '';
+      lines.push(`- [ ] \`${field.component}.${field.field}\`${guidance} — deprecated in **${field.version}**`);
+    });
+    lines.push('');
+  }
+
+  // Priority 4: Changed defaults that may affect users
+  if (allChangedDefaults.length > 0) {
+    lines.push('**⚠️ Review Changed Defaults for Breaking Changes:**');
+    lines.push('');
+    allChangedDefaults.forEach(change => {
+      const oldVal = change.oldDefault !== undefined ? JSON.stringify(change.oldDefault) : 'none';
+      const newVal = change.newDefault !== undefined ? JSON.stringify(change.newDefault) : 'none';
+      lines.push(`- [ ] \`${change.component}.${change.field}\`: \`${oldVal}\` → \`${newVal}\` — changed in **${change.version}**`);
+    });
+    lines.push('');
+  }
+
+  // Add commercial name reminder if there are new connectors
+  if (allNewConnectors.length > 0) {
+    lines.push('---');
+    lines.push('');
+    lines.push('**💡 Reminder:** For each new connector, add the `:page-commercial-names:` attribute:');
+    lines.push('');
+    lines.push('```asciidoc');
+    lines.push('= Connector Name');
+    lines.push(':type: input');
+    lines.push(':page-commercial-names: Commercial Name, Alternative Name');
+    lines.push('```');
     lines.push('');
   }
 

--- a/tools/redpanda-connect/pr-summary-formatter.js
+++ b/tools/redpanda-connect/pr-summary-formatter.js
@@ -4,19 +4,181 @@
  */
 
 /**
- * Generate a PR-friendly summary for connector changes
- * @param {object} diffData - Diff data from generateConnectorDiffJson
- * @param {object} binaryAnalysis - Cloud support data from getCloudSupport
+ * Generate PR summary for multiple releases
+ * @param {object} masterDiff - Master diff with releases array
+ * @param {object} binaryAnalysis - Cloud support data (from latest release)
  * @param {array} draftedConnectors - Array of newly drafted connectors
  * @returns {string} Formatted summary
  */
-function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = null) {
+function generateMultiVersionPRSummary(masterDiff, binaryAnalysis = null, draftedConnectors = null) {
+  const lines = [];
+
+  // Defensive: ensure metadata exists
+  const metadata = masterDiff?.metadata || {};
+  const startVersion = metadata.startVersion || 'unknown';
+  const endVersion = metadata.endVersion || 'unknown';
+  const processedReleases = metadata.processedReleases || 0;
+
+  lines.push('<!-- PR_SUMMARY_START -->');
+  lines.push('');
+  lines.push('## 📊 Redpanda Connect Documentation Update');
+  lines.push('');
+  lines.push(`**📦 Multi-Release Update:** ${startVersion} → ${endVersion}`);
+  lines.push(`**Releases Processed:** ${processedReleases}`);
+
+  if (binaryAnalysis) {
+    lines.push(`**Cloud Version:** ${binaryAnalysis.cloudVersion}`);
+  }
+
+  lines.push('');
+
+  // Total summary across all releases
+  lines.push('### Total Changes Across All Releases');
+  lines.push('');
+  const total = masterDiff?.totalSummary || {};
+
+  if (total.newComponents > 0) {
+    lines.push(`- **${total.newComponents}** new connectors`);
+  }
+  if (total.newFields > 0) {
+    lines.push(`- **${total.newFields}** new fields across ${total.releaseCount || 0} release(s)`);
+  }
+  if (total.removedFields > 0) {
+    lines.push(`- **${total.removedFields}** removed fields ⚠️`);
+  }
+  if (total.deprecatedFields > 0) {
+    lines.push(`- **${total.deprecatedFields}** deprecated fields`);
+  }
+
+  lines.push('');
+
+  // Per-release breakdown
+  lines.push('### Changes Per Release');
+  lines.push('');
+
+  // Guard: ensure releases array exists
+  const releases = masterDiff?.releases || [];
+  if (releases.length === 0) {
+    lines.push('_No releases to process_');
+    lines.push('');
+    lines.push('<!-- PR_SUMMARY_END -->');
+    return lines.join('\n');
+  }
+
+  for (const release of releases) {
+    lines.push(`#### 🔖 Version ${release.toVersion}`);
+    lines.push('');
+
+    const summary = release.summary || {};
+    const hasChanges = Object.values(summary).some(v => v > 0);
+
+    if (!hasChanges) {
+      lines.push('_No changes in this release_');
+      lines.push('');
+      continue;
+    }
+
+    // Show what changed in this specific release
+    const newComponents = release.details?.newComponents || [];
+    if (summary.newComponents > 0 && newComponents.length > 0) {
+      lines.push(`**New Connectors (${summary.newComponents}):**`);
+      lines.push('');
+      const inCloud = release.binaryAnalysis?.comparison?.inCloud || [];
+      const cloudOnly = release.binaryAnalysis?.comparison?.cloudOnly || [];
+      const cgoOnly = release.binaryAnalysis?.cgoOnly || [];
+      newComponents.forEach(comp => {
+        const cloudIndicator = inCloud.some(c => c.type === comp.type && c.name === comp.name) ||
+          cloudOnly.some(c => c.type === comp.type && c.name === comp.name) ? ' ☁️' : '';
+        const cgoIndicator = cgoOnly.some(c => c.type === comp.type && c.name === comp.name) ? ' 🔧' : '';
+        lines.push(`- \`${comp.name}\` (${comp.type}, ${comp.status})${cloudIndicator}${cgoIndicator}`);
+      });
+      lines.push('');
+    }
+
+    if (summary.newFields > 0) {
+      lines.push(`**New Fields:** ${summary.newFields} added`);
+      lines.push('');
+    }
+
+    if (summary.removedFields > 0) {
+      lines.push(`**⚠️ Removed Fields:** ${summary.removedFields}`);
+      lines.push('');
+    }
+
+    if (summary.deprecatedFields > 0) {
+      lines.push(`**Deprecated Fields:** ${summary.deprecatedFields}`);
+      lines.push('');
+    }
+  }
+
+  // Writer action items (aggregate)
+  lines.push('### ✍️ Writer Action Items');
+  lines.push('');
+
+  // Collect all new connectors across all releases
+  const allNewConnectors = [];
+  releases.forEach(release => {
+    const releaseNewComponents = release.details?.newComponents || [];
+    const releaseInCloud = release.binaryAnalysis?.comparison?.inCloud || [];
+    const releaseCloudOnly = release.binaryAnalysis?.comparison?.cloudOnly || [];
+    const releaseNotInCloud = release.binaryAnalysis?.comparison?.notInCloud || [];
+
+    releaseNewComponents.forEach(comp => {
+      const isCloud = releaseInCloud.some(c => c.type === comp.type && c.name === comp.name) ||
+        releaseCloudOnly.some(c => c.type === comp.type && c.name === comp.name);
+      const isSelfHostedOnly = releaseNotInCloud.some(c => c.type === comp.type && c.name === comp.name);
+
+      allNewConnectors.push({
+        name: comp.name,
+        type: comp.type,
+        status: comp.status,
+        version: release.toVersion,
+        isCloud,
+        isSelfHostedOnly
+      });
+    });
+  });
+
+  if (allNewConnectors.length > 0) {
+    lines.push('**Document New Connectors:**');
+    lines.push('');
+    allNewConnectors.forEach(conn => {
+      const cloudLabel = conn.isSelfHostedOnly ? ' (self-hosted only)' : conn.isCloud ? ' ☁️' : '';
+      lines.push(`- [ ] Document new \`${conn.name}\` ${conn.type} from **${conn.version}**${cloudLabel}`);
+    });
+    lines.push('');
+  }
+
+  lines.push('<!-- PR_SUMMARY_END -->');
+  return lines.join('\n');
+}
+
+/**
+ * Generate a PR-friendly summary for connector changes
+ * @param {object} diffData - Diff data from generateConnectorDiffJson OR master diff with multiple releases
+ * @param {object} binaryAnalysis - Cloud support data from getCloudSupport
+ * @param {array} draftedConnectors - Array of newly drafted connectors
+ * @param {boolean} isMultiVersion - Whether diffData is a master diff with multiple releases
+ * @returns {string} Formatted summary
+ */
+function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = null, isMultiVersion = false) {
   const lines = [];
 
   // Header with delimiters for GitHub Action parsing
   lines.push('<!-- PR_SUMMARY_START -->');
   lines.push('');
 
+  // Detect if this is a master diff
+  if (!isMultiVersion && diffData.releases && diffData.totalSummary) {
+    isMultiVersion = true;
+  }
+
+  if (isMultiVersion) {
+    // Multi-version format
+    return generateMultiVersionPRSummary(diffData, binaryAnalysis, draftedConnectors);
+  }
+
+  // Single version format (original logic)
   // Quick Summary Section
   lines.push('## 📊 Redpanda Connect Documentation Update');
   lines.push('');
@@ -199,9 +361,15 @@ function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = 
     Object.entries(draftsByType).forEach(([type, drafts]) => {
       lines.push(`**${type}:**`);
       drafts.forEach(draft => {
-        const cloudIndicator = binaryAnalysis?.comparison.inCloud.some(c =>
+        // Check both inCloud (OSS+Cloud) and cloudOnly (Cloud-only)
+        const isInCloud = binaryAnalysis?.comparison.inCloud.some(c =>
           c.type === type && c.name === draft.name
-        ) ? ' ☁️' : '';
+        );
+        const isCloudOnly = binaryAnalysis?.comparison.cloudOnly &&
+          binaryAnalysis.comparison.cloudOnly.some(c =>
+            c.type === type && c.name === draft.name
+          );
+        const cloudIndicator = (isInCloud || isCloudOnly) ? ' ☁️' : '';
         const cgoIndicator = draft.requiresCgo ? ' 🔧' : '';
         const statusBadge = draft.status && draft.status !== 'stable' ? ` (${draft.status})` : '';
         lines.push(`- \`${draft.name}\`${statusBadge}${cloudIndicator}${cgoIndicator} → \`${draft.path}\``);
@@ -304,13 +472,16 @@ function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = 
     });
   }
 
-  // New connectors without cloud support
-  if (stats.newComponents > 0) {
+  // New connectors without cloud support (self-hosted only)
+  if (binaryAnalysis && stats.newComponents > 0) {
     diffData.details.newComponents.forEach(connector => {
       const key = `${connector.type}:${connector.name}`;
-      const inCloud = binaryAnalysis?.comparison.inCloud.some(c => `${c.type}:${c.name}` === key);
 
-      if (!inCloud) {
+      // Check if it's explicitly in the self-hosted only list
+      const isSelfHostedOnly = binaryAnalysis.comparison.notInCloud &&
+        binaryAnalysis.comparison.notInCloud.some(c => `${c.type}:${c.name}` === key);
+
+      if (isSelfHostedOnly) {
         actionItems.push({
           priority: 2,
           text: `Document new \`${connector.name}\` ${connector.type} (self-hosted only)`
@@ -376,7 +547,13 @@ function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = 
 
       diffData.details.newComponents.forEach(connector => {
         const key = `${connector.type}:${connector.name}`;
+
+        // Check explicit categories
         const inCloud = binaryAnalysis.comparison.inCloud.some(c => `${c.type}:${c.name}` === key);
+        const isSelfHostedOnly = binaryAnalysis.comparison.notInCloud &&
+          binaryAnalysis.comparison.notInCloud.some(c => `${c.type}:${c.name}` === key);
+        const isCloudOnly = binaryAnalysis.comparison.cloudOnly &&
+          binaryAnalysis.comparison.cloudOnly.some(c => `${c.type}:${c.name}` === key);
 
         const entry = {
           name: connector.name,
@@ -385,9 +562,10 @@ function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = 
           description: connector.description
         };
 
-        if (inCloud) {
+        // Use explicit positive checks instead of !inCloud
+        if (inCloud || isCloudOnly) {
           cloudSupportedNew.push(entry);
-        } else {
+        } else if (isSelfHostedOnly) {
           selfHostedOnlyNew.push(entry);
         }
       });
@@ -661,6 +839,7 @@ function printPRSummary(diffData, binaryAnalysis = null, draftedConnectors = nul
 
 module.exports = {
   generatePRSummary,
+  generateMultiVersionPRSummary,
   printPRSummary,
   truncateToSentence
 };

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -487,6 +487,38 @@ function logCollapsed (label, filesArray, maxToShow = 10) {
 }
 
 /**
+ * Strip augmentation fields from connector data to ensure clean comparisons
+ * Removes cloudSupported, requiresCgo, cloudOnly fields and filters out cloud-only connectors
+ * @param {object} data - Connector index data
+ * @returns {object} Clean connector data without augmentation
+ */
+function stripAugmentationFields(data) {
+  const cleanData = JSON.parse(JSON.stringify(data));
+  const connectorTypes = ['inputs', 'outputs', 'processors', 'caches', 'rate_limits',
+    'buffers', 'metrics', 'scanners', 'tracers', 'config', 'bloblang-methods'];
+
+  for (const type of connectorTypes) {
+    if (Array.isArray(cleanData[type])) {
+      // Remove connectors that were added by augmentation (cloudOnly or requiresCgo without OSS data)
+      cleanData[type] = cleanData[type].filter(c => {
+        // Keep if it's not marked as cloudOnly
+        // OR if it has a config/fields (meaning it came from OSS, not just binary analysis)
+        return !c.cloudOnly || c.config || c.fields;
+      });
+
+      // Remove augmentation fields
+      cleanData[type].forEach(c => {
+        delete c.cloudSupported;
+        delete c.requiresCgo;
+        delete c.cloudOnly;
+      });
+    }
+  }
+
+  return cleanData;
+}
+
+/**
  * Load or fetch connector data for a specific version
  * @param {string} version - Version to load (e.g., "4.50.0")
  * @param {string} dataDir - Directory where JSON files are stored
@@ -499,7 +531,12 @@ async function loadConnectorDataForVersion(version, dataDir, options = {}) {
   // If file exists, load it
   if (fs.existsSync(dataFile)) {
     console.log(`✓ Using existing data file: connect-${version}.json`);
-    return JSON.parse(fs.readFileSync(dataFile, 'utf8'));
+    const data = JSON.parse(fs.readFileSync(dataFile, 'utf8'));
+
+    // Strip augmentation fields to ensure clean comparisons
+    // Augmentation adds CGO/cloud-only components that shouldn't affect version diffs
+    const cleanData = stripAugmentationFields(data);
+    return cleanData;
   }
 
   // If not, fetch it
@@ -903,32 +940,22 @@ async function handleRpcnConnectorDocs (options) {
       if (oldVersion) {
         const oldPath = path.join(dataDir, `connect-${oldVersion}.json`)
         if (fs.existsSync(oldPath)) {
-          oldIndex = JSON.parse(fs.readFileSync(oldPath, 'utf8'))
+          // Strip augmentation fields to ensure clean comparisons
+          oldIndex = stripAugmentationFields(JSON.parse(fs.readFileSync(oldPath, 'utf8')))
         }
       }
     }
   }
 
-  let newIndex = JSON.parse(fs.readFileSync(dataFile, 'utf8'))
+  // Load and strip augmentation fields for clean comparisons
+  let newIndex = stripAugmentationFields(JSON.parse(fs.readFileSync(dataFile, 'utf8')))
 
   // Save a clean copy of OSS data for binary analysis (before augmentation)
   // This ensures the binary analyzer compares actual binaries, not augmented data
   const cleanOssDataPath = path.join(dataDir, `._connect-${newVersion}-clean.json`)
 
-  // Strip augmentation fields to create clean data for comparison
+  // Use the already-stripped newIndex for clean data
   const cleanData = JSON.parse(JSON.stringify(newIndex))
-  const connectorTypes = ['inputs', 'outputs', 'processors', 'caches', 'rate_limits', 'buffers', 'metrics', 'scanners', 'tracers']
-
-  for (const type of connectorTypes) {
-    if (Array.isArray(cleanData[type])) {
-      cleanData[type] = cleanData[type].filter(c => !c.cloudOnly) // Remove cloud-only connectors added by augmentation
-      cleanData[type].forEach(c => {
-        delete c.cloudSupported
-        delete c.requiresCgo
-        delete c.cloudOnly
-      })
-    }
-  }
 
   fs.writeFileSync(cleanOssDataPath, JSON.stringify(cleanData, null, 2), 'utf8')
 
@@ -1181,8 +1208,9 @@ async function handleRpcnConnectorDocs (options) {
         }
       }
 
-      // Reload newIndex after augmentation so diff generation uses augmented data
-      newIndex = JSON.parse(fs.readFileSync(dataFile, 'utf8'))
+      // NOTE: We do NOT reload newIndex after augmentation
+      // Diff generation should use clean OSS data to avoid false positives from CGO/cloud-only components
+      // The augmented data is saved to disk but not used for version comparisons
     } catch (err) {
       console.error(`Warning: Failed to augment data file: ${err.message}`)
     }

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -501,9 +501,9 @@ function stripAugmentationFields(data) {
     if (Array.isArray(cleanData[type])) {
       // Remove connectors that were added by augmentation (cloudOnly or requiresCgo without OSS data)
       cleanData[type] = cleanData[type].filter(c => {
-        // Keep if it's not marked as cloudOnly
+        // Keep if it's not marked as cloudOnly or requiresCgo
         // OR if it has a config/fields (meaning it came from OSS, not just binary analysis)
-        return !c.cloudOnly || c.config || c.fields;
+        return (!(c.cloudOnly || c.requiresCgo) || c.config || c.fields);
       });
 
       // Remove augmentation fields
@@ -702,19 +702,22 @@ async function handleRpcnConnectorDocs (options) {
       process.exit(1)
     }
   } else {
-    const candidates = fs.readdirSync(dataDir).filter(f => /^connect-\d+\.\d+\.\d+\.json$/.test(f))
+    const candidates = fs.readdirSync(dataDir)
+      .filter(f => /^connect-(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)\.json$/.test(f))
+      .map(f => {
+        const match = f.match(/^connect-(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)\.json$/)
+        return match ? match[1] : null
+      })
+      .filter(v => v && semver.valid(v))
+
     if (candidates.length === 0) {
-      console.error('Error: No connect-<version>.json found. Use --fetch-connectors.')
+      console.error('Error: No valid connect-<version>.json found. Use --fetch-connectors.')
       process.exit(1)
     }
-    candidates.sort()
-    dataFile = path.join(dataDir, candidates[candidates.length - 1])
-    const versionMatch = candidates[candidates.length - 1].match(/connect-(\d+\.\d+\.\d+)\.json/)
-    if (!versionMatch || !semver.valid(versionMatch[1])) {
-      console.error(`Error: Invalid version format in filename: ${candidates[candidates.length - 1]}`)
-      process.exit(1)
-    }
-    newVersion = versionMatch[1]
+
+    const sortedVersions = semver.rsort(candidates)
+    newVersion = sortedVersions[0]
+    dataFile = path.join(dataDir, `connect-${newVersion}.json`)
   }
 
   // ========================================================================
@@ -741,14 +744,18 @@ async function handleRpcnConnectorDocs (options) {
 
       // Fallback: check existing data files
       if (!startVersion) {
-        const existingDataFiles = fs.readdirSync(dataDir)
-          .filter(f => /^connect-\d+\.\d+\.\d+\.json$/.test(f))
+        const existingVersions = fs.readdirSync(dataDir)
+          .filter(f => /^connect-(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)\.json$/.test(f))
           .filter(f => f !== path.basename(dataFile))
-          .sort()
+          .map(f => {
+            const match = f.match(/^connect-(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)\.json$/)
+            return match ? match[1] : null
+          })
+          .filter(v => v && semver.valid(v))
 
-        if (existingDataFiles.length > 0) {
-          const oldFile = existingDataFiles[existingDataFiles.length - 1]
-          startVersion = oldFile.match(/connect-(\d+\.\d+\.\d+)\.json/)[1]
+        if (existingVersions.length > 0) {
+          const sortedVersions = semver.rsort(existingVersions)
+          startVersion = sortedVersions[0]
         }
       }
     }
@@ -920,20 +927,27 @@ async function handleRpcnConnectorDocs (options) {
   let oldIndex = {}
   let oldVersion = null
   if (options.oldData && fs.existsSync(options.oldData)) {
-    oldIndex = JSON.parse(fs.readFileSync(options.oldData, 'utf8'))
+    // Strip augmentation fields to ensure clean comparisons
+    oldIndex = stripAugmentationFields(JSON.parse(fs.readFileSync(options.oldData, 'utf8')))
     const m = options.oldData.match(/connect-([\d.]+)\.json$/)
     if (m) oldVersion = m[1]
   } else {
-    const existingDataFiles = fs.readdirSync(dataDir)
-      .filter(f => /^connect-\d+\.\d+\.\d+\.json$/.test(f))
+    const existingVersions = fs.readdirSync(dataDir)
+      .filter(f => /^connect-(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)\.json$/.test(f))
       .filter(f => f !== path.basename(dataFile))
-      .sort()
+      .map(f => {
+        const match = f.match(/^connect-(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)\.json$/)
+        return match ? match[1] : null
+      })
+      .filter(v => v && semver.valid(v))
 
-    if (existingDataFiles.length > 0) {
-      const oldFile = existingDataFiles[existingDataFiles.length - 1]
-      oldVersion = oldFile.match(/connect-(\d+\.\d+\.\d+)\.json/)[1]
+    if (existingVersions.length > 0) {
+      const sortedVersions = semver.rsort(existingVersions)
+      oldVersion = sortedVersions[0]
+      const oldFile = `connect-${oldVersion}.json`
       const oldPath = path.join(dataDir, oldFile)
-      oldIndex = JSON.parse(fs.readFileSync(oldPath, 'utf8'))
+      // Strip augmentation fields to ensure clean comparisons
+      oldIndex = stripAugmentationFields(JSON.parse(fs.readFileSync(oldPath, 'utf8')))
       console.log(`📋 Using old version data: ${oldFile}`)
     } else {
       oldVersion = getAntoraValue('asciidoc.attributes.latest-connect-version')
@@ -979,11 +993,18 @@ async function handleRpcnConnectorDocs (options) {
       const attachmentsRoot = path.resolve(process.cwd(), 'modules/components/attachments')
       fs.mkdirSync(attachmentsRoot, { recursive: true })
 
-      const existingFiles = fs.readdirSync(attachmentsRoot)
-        .filter(f => /^connect-\d+\.\d+\.\d+\.json$/.test(f))
-        .sort()
+      const existingVersions = fs.readdirSync(attachmentsRoot)
+        .filter(f => /^connect-(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)\.json$/.test(f))
+        .map(f => {
+          const match = f.match(/^connect-(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)\.json$/)
+          return match ? match[1] : null
+        })
+        .filter(v => v && semver.valid(v))
 
-      for (const oldFile of existingFiles) {
+      const sortedVersions = semver.sort(existingVersions) // ascending order
+
+      for (const version of sortedVersions) {
+        const oldFile = `connect-${version}.json`
         const oldFilePath = path.join(attachmentsRoot, oldFile)
         fs.unlinkSync(oldFilePath)
         console.log(`🧹 Deleted old version: ${oldFile}`)
@@ -1041,14 +1062,14 @@ async function handleRpcnConnectorDocs (options) {
     }
   }
 
+  // Always use clean OSS data for comparison
+  // Temporarily rename the file so the analyzer finds it
+  const expectedPath = path.join(dataDir, `connect-${newVersion}.json`)
+  let tempRenamed = false
+
   try {
     console.log('\nAnalyzing connector binaries...')
     const { analyzeAllBinaries } = require('./connector-binary-analyzer.js')
-
-    // Always use clean OSS data for comparison
-    // Temporarily rename the file so the analyzer finds it
-    const expectedPath = path.join(dataDir, `connect-${newVersion}.json`)
-    let tempRenamed = false
 
     if (fs.existsSync(cleanOssDataPath)) {
       if (fs.existsSync(expectedPath)) {
@@ -1071,13 +1092,6 @@ async function handleRpcnConnectorDocs (options) {
       analysisOptions
     )
 
-    // Restore the augmented file
-    if (tempRenamed) {
-      const expectedPath = path.join(dataDir, `connect-${newVersion}.json`)
-      fs.unlinkSync(expectedPath)
-      fs.renameSync(path.join(dataDir, `._connect-${newVersion}-augmented.json.tmp`), expectedPath)
-    }
-
     console.log('Done: Binary analysis complete:')
     console.log(`   • OSS version: ${binaryAnalysis.ossVersion}`)
 
@@ -1099,6 +1113,17 @@ async function handleRpcnConnectorDocs (options) {
   } catch (err) {
     console.error(`Warning: Binary analysis failed: ${err.message}`)
     console.error('   Continuing without binary analysis data...')
+  } finally {
+    // Restore the augmented file regardless of success or failure
+    if (tempRenamed) {
+      if (fs.existsSync(expectedPath)) {
+        fs.unlinkSync(expectedPath)
+      }
+      const tmpPath = path.join(dataDir, `._connect-${newVersion}-augmented.json.tmp`)
+      if (fs.existsSync(tmpPath)) {
+        fs.renameSync(tmpPath, expectedPath)
+      }
+    }
   }
 
   // Augment data file
@@ -1181,9 +1206,13 @@ async function handleRpcnConnectorDocs (options) {
 
       // Keep only the latest version (delete all older versions)
       // BUT preserve any files from intermediate processing during this run
-      const dataFiles = fs.readdirSync(dataDir)
-        .filter(f => /^connect-\d+\.\d+\.\d+\.json$/.test(f))
-        .sort()
+      const dataVersions = fs.readdirSync(dataDir)
+        .filter(f => /^connect-(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)\.json$/.test(f))
+        .map(f => {
+          const match = f.match(/^connect-(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)\.json$/)
+          return match ? match[1] : null
+        })
+        .filter(v => v && semver.valid(v))
 
       // Build list of versions we need to keep for this run
       const versionsToKeep = new Set([newVersion]); // Always keep the latest
@@ -1199,9 +1228,9 @@ async function handleRpcnConnectorDocs (options) {
       }
 
       // Delete only files that are NOT needed for this run
-      for (const dataFile of dataFiles) {
-        const versionMatch = dataFile.match(/connect-(\d+\.\d+\.\d+)\.json/);
-        if (versionMatch && !versionsToKeep.has(versionMatch[1])) {
+      for (const version of dataVersions) {
+        if (!versionsToKeep.has(version)) {
+          const dataFile = `connect-${version}.json`
           const dataPath = path.join(dataDir, dataFile);
           fs.unlinkSync(dataPath);
           console.log(`🧹 Deleted old version from docs-data: ${dataFile}`);
@@ -1730,6 +1759,18 @@ async function handleRpcnConnectorDocs (options) {
     printPRSummary(masterDiff || diffJson, binaryAnalysis, draftFiles, masterDiff ? true : false)
   } catch (err) {
     console.error(`Warning: Failed to generate PR summary: ${err.message}`)
+  }
+
+  // Check for failures in intermediate processing before updating Antora version
+  if (intermediateProcessingResults.length > 0) {
+    const failures = intermediateProcessingResults.filter(r => !r.success)
+    if (failures.length > 0) {
+      console.error(`\n❌ Cannot update Antora version: ${failures.length} intermediate release(s) failed to process`)
+      failures.forEach(f => {
+        console.error(`   • ${f.fromVersion} → ${f.toVersion}: ${f.error}`)
+      })
+      process.exit(1)
+    }
   }
 
   const wrote = setAntoraValue('asciidoc.attributes.latest-connect-version', newVersion)

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -9,6 +9,7 @@ const fetchFromGithub = require('../fetch-from-github.js')
 const { generateRpcnConnectorDocs } = require('./generate-rpcn-connector-docs.js')
 const { getRpkConnectVersion, printDeltaReport } = require('./report-delta')
 const { discoverIntermediateReleases } = require('./github-release-utils')
+const parseCSVConnectors = require('./parse-csv-connectors.js')
 const semver = require('semver')
 
 /**
@@ -596,6 +597,7 @@ async function handleRpcnConnectorDocs (options) {
   let draftsWritten = 0
   let draftFiles = []
   let needsAugmentation = false
+  let csvMetadata = []
 
   if (options.fetchConnectors) {
     try {
@@ -654,6 +656,16 @@ async function handleRpcnConnectorDocs (options) {
         }
       } catch (csvErr) {
         console.warn(`Warning: Failed to fetch info.csv: ${csvErr.message}`)
+      }
+
+      // Parse CSV metadata
+      try {
+        const csvFile = path.join(dataDir, `connect-info-${newVersion}.csv`)
+        if (fs.existsSync(csvFile)) {
+          csvMetadata = await parseCSVConnectors(csvFile, console)
+        }
+      } catch (csvParseErr) {
+        console.warn(`Warning: Failed to parse info.csv: ${csvParseErr.message}`)
       }
 
       // Fetch Bloblang examples
@@ -915,7 +927,8 @@ async function handleRpcnConnectorDocs (options) {
       templateExamples: options.templateExamples,
       templateBloblang: options.templateBloblang,
       writeFullDrafts: false,
-      includeBloblang: !!options.includeBloblang
+      includeBloblang: !!options.includeBloblang,
+      csvMetadata
     })
     partialsWritten = result.partialsWritten
     partialFiles = result.partialFiles
@@ -1702,7 +1715,8 @@ async function handleRpcnConnectorDocs (options) {
           templateIntro: options.templateIntro,
           writeFullDrafts: true,
           cgoOnly: binaryAnalysis?.cgoOnly || [],
-          cloudOnly: binaryAnalysis?.comparison?.cloudOnly || []
+          cloudOnly: binaryAnalysis?.comparison?.cloudOnly || [],
+          csvMetadata
         })
 
         fs.unlinkSync(tempDataPath)

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -8,6 +8,8 @@ const { getAntoraValue, setAntoraValue } = require('../../cli-utils/antora-utils
 const fetchFromGithub = require('../fetch-from-github.js')
 const { generateRpcnConnectorDocs } = require('./generate-rpcn-connector-docs.js')
 const { getRpkConnectVersion, printDeltaReport } = require('./report-delta')
+const { discoverIntermediateReleases } = require('./github-release-utils')
+const semver = require('semver')
 
 /**
  * Cap description to two sentences
@@ -485,6 +487,63 @@ function logCollapsed (label, filesArray, maxToShow = 10) {
 }
 
 /**
+ * Load or fetch connector data for a specific version
+ * @param {string} version - Version to load (e.g., "4.50.0")
+ * @param {string} dataDir - Directory where JSON files are stored
+ * @param {Object} options - Options for fetching if needed
+ * @returns {Promise<Object>} Parsed connector data
+ */
+async function loadConnectorDataForVersion(version, dataDir, options = {}) {
+  const dataFile = path.join(dataDir, `connect-${version}.json`);
+
+  // If file exists, load it
+  if (fs.existsSync(dataFile)) {
+    console.log(`✓ Using existing data file: connect-${version}.json`);
+    return JSON.parse(fs.readFileSync(dataFile, 'utf8'));
+  }
+
+  // If not, fetch it
+  console.log(`📥 Data file not found for ${version}, attempting to fetch...`);
+
+  try {
+    // Try installing that specific version and fetching data
+    console.log(`   Installing Redpanda Connect version ${version}...`);
+    const installResult = spawnSync('rpk', ['connect', 'install', '--connect-version', version, '--force'], {
+      stdio: 'pipe'
+    });
+
+    if (installResult.status !== 0) {
+      throw new Error(`Failed to install Connect version ${version}`);
+    }
+
+    // Fetch connector list
+    const tmpFile = path.join(dataDir, `connect-${version}.tmp.json`);
+    const fd = fs.openSync(tmpFile, 'w');
+    const listResult = spawnSync('rpk', ['connect', 'list', '--format', 'json-full'], {
+      stdio: ['ignore', fd, 'pipe']
+    });
+    fs.closeSync(fd);
+
+    if (listResult.status !== 0) {
+      throw new Error(`Failed to fetch connector list for version ${version}`);
+    }
+
+    // Parse and validate
+    const rawJson = fs.readFileSync(tmpFile, 'utf8');
+    const parsed = JSON.parse(rawJson);
+
+    // Move to final location
+    fs.renameSync(tmpFile, dataFile);
+
+    console.log(`✓ Successfully fetched data for version ${version}`);
+    return parsed;
+  } catch (error) {
+    console.error(`❌ Failed to fetch data for version ${version}: ${error.message}`);
+    throw new Error(`Cannot process version ${version} - data unavailable`);
+  }
+}
+
+/**
  * Main handler for rpcn-connector-docs command
  * @param {Object} options - Command options
  */
@@ -504,6 +563,11 @@ async function handleRpcnConnectorDocs (options) {
   if (options.fetchConnectors) {
     try {
       if (options.connectVersion) {
+        if (!semver.valid(options.connectVersion)) {
+          console.error(`Error: Invalid --connect-version format: ${options.connectVersion}`)
+          console.error('Expected format: X.Y.Z (e.g., 4.50.0)')
+          process.exit(1)
+        }
         console.log(`Installing Redpanda Connect version ${options.connectVersion}...`)
         const installResult = spawnSync('rpk', ['connect', 'install', '--connect-version', options.connectVersion, '--force'], {
           stdio: 'inherit'
@@ -608,8 +672,191 @@ async function handleRpcnConnectorDocs (options) {
     }
     candidates.sort()
     dataFile = path.join(dataDir, candidates[candidates.length - 1])
-    newVersion = candidates[candidates.length - 1].match(/connect-(\d+\.\d+\.\d+)\.json/)[1]
+    const versionMatch = candidates[candidates.length - 1].match(/connect-(\d+\.\d+\.\d+)\.json/)
+    if (!versionMatch || !semver.valid(versionMatch[1])) {
+      console.error(`Error: Invalid version format in filename: ${candidates[candidates.length - 1]}`)
+      process.exit(1)
+    }
+    newVersion = versionMatch[1]
   }
+
+  // ========================================================================
+  // Multi-Release Processing: Discover and process intermediate releases
+  // ========================================================================
+
+  const processIntermediate = !options.skipIntermediate && !options.oldData
+  let versionsToProcess = []
+  let intermediateProcessingResults = []
+
+  if (processIntermediate) {
+    // Determine starting version
+    let startVersion = options.fromVersion
+
+    if (startVersion && !semver.valid(startVersion)) {
+      console.error(`Error: Invalid --from-version format: ${startVersion}`)
+      console.error('Expected format: X.Y.Z (e.g., 4.50.0)')
+      process.exit(1)
+    }
+
+    if (!startVersion) {
+      // Try antora.yml first
+      startVersion = getAntoraValue('asciidoc.attributes.latest-connect-version')
+
+      // Fallback: check existing data files
+      if (!startVersion) {
+        const existingDataFiles = fs.readdirSync(dataDir)
+          .filter(f => /^connect-\d+\.\d+\.\d+\.json$/.test(f))
+          .filter(f => f !== path.basename(dataFile))
+          .sort()
+
+        if (existingDataFiles.length > 0) {
+          const oldFile = existingDataFiles[existingDataFiles.length - 1]
+          startVersion = oldFile.match(/connect-(\d+\.\d+\.\d+)\.json/)[1]
+        }
+      }
+    }
+
+    if (startVersion && startVersion !== newVersion) {
+      console.log(`\n${'='.repeat(80)}`)
+      console.log(`🔍 Checking for intermediate releases between ${startVersion} and ${newVersion}...`)
+      console.log('='.repeat(80))
+
+      try {
+        const intermediateReleases = await discoverIntermediateReleases(
+          startVersion,
+          newVersion,
+          { includePrerelease: false, useCache: true }
+        )
+
+        versionsToProcess = intermediateReleases.map(r => r.version)
+
+        // Process all version pairs EXCEPT the last one (which will be handled by the main flow)
+        if (versionsToProcess.length > 2) {
+          console.log(`\n📦 Processing ${versionsToProcess.length - 2} intermediate release(s)...\n`)
+
+          for (let i = 0; i < versionsToProcess.length - 2; i++) {
+            const fromVer = versionsToProcess[i]
+            const toVer = versionsToProcess[i + 1]
+
+            console.log(`\n${'─'.repeat(80)}`)
+            console.log(`📋 Processing intermediate release: ${fromVer} → ${toVer}`)
+            console.log('─'.repeat(80) + '\n')
+
+            try {
+              // Load data for both versions
+              console.log(`Loading connector data for ${fromVer}...`)
+              const oldData = await loadConnectorDataForVersion(fromVer, dataDir)
+
+              console.log(`Loading connector data for ${toVer}...`)
+              const newData = await loadConnectorDataForVersion(toVer, dataDir)
+
+              // Determine the appropriate cloud version for this release date
+              const releaseInfo = intermediateReleases.find(r => r.version === toVer)
+              let cloudVersionForRelease = options.cloudVersion || null
+
+              if (!options.cloudVersion && releaseInfo && releaseInfo.date) {
+                const { findCloudVersionForDate } = require('./github-release-utils')
+                cloudVersionForRelease = await findCloudVersionForDate(releaseInfo.date, { useCache: true })
+                if (cloudVersionForRelease) {
+                  console.log(`   Using cloud version ${cloudVersionForRelease} (current at ${new Date(releaseInfo.date).toLocaleDateString()})`)
+                } else {
+                  console.log(`   No cloud version found for release date, using OSS version ${toVer}`)
+                  cloudVersionForRelease = toVer
+                }
+              }
+
+              // Run binary analysis for the new version
+              console.log(`\nAnalyzing binaries for version ${toVer}...`)
+              const { analyzeAllBinaries } = require('./connector-binary-analyzer.js')
+
+              const analysisOptions = {
+                skipCloud: false,
+                skipCgo: false,
+                cgoVersion: options.cgoVersion || null
+              }
+
+              const intermediateAnalysis = await analyzeAllBinaries(
+                toVer,
+                cloudVersionForRelease,
+                dataDir,
+                analysisOptions
+              )
+
+              console.log('✓ Binary analysis complete:')
+              console.log(`   • OSS version: ${intermediateAnalysis.ossVersion}`)
+              if (intermediateAnalysis.cloudVersion) {
+                console.log(`   • Cloud version: ${intermediateAnalysis.cloudVersion}`)
+              }
+              if (intermediateAnalysis.comparison) {
+                console.log(`   • Connectors in cloud: ${intermediateAnalysis.comparison.inCloud.length}`)
+                console.log(`   • Self-hosted only: ${intermediateAnalysis.comparison.notInCloud.length}`)
+                if (intermediateAnalysis.comparison.cloudOnly) {
+                  console.log(`   • Cloud-only: ${intermediateAnalysis.comparison.cloudOnly.length}`)
+                }
+              }
+
+              // Generate diff
+              console.log(`\nGenerating diff: ${fromVer} → ${toVer}...`)
+              const { generateConnectorDiffJson } = require('./report-delta.js')
+
+              const diffData = generateConnectorDiffJson(
+                oldData,
+                newData,
+                {
+                  oldVersion: fromVer,
+                  newVersion: toVer,
+                  timestamp,
+                  binaryAnalysis: intermediateAnalysis
+                }
+              )
+
+              // Save diff
+              const diffPath = path.join(dataDir, `connect-diff-${fromVer}_to_${toVer}.json`)
+              fs.writeFileSync(diffPath, JSON.stringify(diffData, null, 2), 'utf8')
+              console.log(`✓ Diff saved: ${path.basename(diffPath)}`)
+
+              // Update what's-new if requested
+              if (options.updateWhatsNew) {
+                console.log(`Updating what's-new.adoc for ${toVer}...`)
+                updateWhatsNew({ dataDir, oldVersion: fromVer, newVersion: toVer, binaryAnalysis: intermediateAnalysis })
+              }
+
+              intermediateProcessingResults.push({
+                fromVersion: fromVer,
+                toVersion: toVer,
+                diffPath,
+                success: true
+              })
+
+              console.log(`✅ Completed processing: ${fromVer} → ${toVer}\n`)
+            } catch (err) {
+              console.error(`❌ Error processing ${fromVer} → ${toVer}: ${err.message}`)
+              console.error('   Continuing with next version...\n')
+
+              intermediateProcessingResults.push({
+                fromVersion: fromVer,
+                toVersion: toVer,
+                error: err.message,
+                success: false
+              })
+            }
+          }
+
+          console.log(`\n${'='.repeat(80)}`)
+          console.log(`✓ Intermediate release processing complete`)
+          console.log(`   Processed: ${intermediateProcessingResults.filter(r => r.success).length}/${intermediateProcessingResults.length} version pairs`)
+          console.log('='.repeat(80) + '\n')
+        }
+      } catch (err) {
+        console.warn(`\n⚠️  Warning: Failed to discover intermediate releases: ${err.message}`)
+        console.warn('   Falling back to single version comparison...\n')
+      }
+    }
+  }
+
+  // ========================================================================
+  // Main Processing: Handle the latest version (final iteration)
+  // ========================================================================
 
   console.log('Generating connector partials...')
   let partialsWritten, partialFiles
@@ -905,16 +1152,33 @@ async function handleRpcnConnectorDocs (options) {
         console.log(`   • Added ${addedCloudOnlyCount} cloud-only connectors to data file`)
       }
 
-      // Keep only 2 most recent versions
+      // Keep only the latest version (delete all older versions)
+      // BUT preserve any files from intermediate processing during this run
       const dataFiles = fs.readdirSync(dataDir)
         .filter(f => /^connect-\d+\.\d+\.\d+\.json$/.test(f))
         .sort()
 
-      while (dataFiles.length > 2) {
-        const oldestFile = dataFiles.shift()
-        const oldestPath = path.join(dataDir, oldestFile)
-        fs.unlinkSync(oldestPath)
-        console.log(`🧹 Deleted old version from docs-data: ${oldestFile}`)
+      // Build list of versions we need to keep for this run
+      const versionsToKeep = new Set([newVersion]); // Always keep the latest
+      if (intermediateProcessingResults.length > 0) {
+        // Keep intermediate versions from this run
+        intermediateProcessingResults.forEach(r => {
+          versionsToKeep.add(r.fromVersion);
+          versionsToKeep.add(r.toVersion);
+        });
+      }
+      if (oldVersion) {
+        versionsToKeep.add(oldVersion); // Keep old version for diff
+      }
+
+      // Delete only files that are NOT needed for this run
+      for (const dataFile of dataFiles) {
+        const versionMatch = dataFile.match(/connect-(\d+\.\d+\.\d+)\.json/);
+        if (versionMatch && !versionsToKeep.has(versionMatch[1])) {
+          const dataPath = path.join(dataDir, dataFile);
+          fs.unlinkSync(dataPath);
+          console.log(`🧹 Deleted old version from docs-data: ${dataFile}`);
+        }
       }
 
       // Reload newIndex after augmentation so diff generation uses augmented data
@@ -1038,21 +1302,40 @@ async function handleRpcnConnectorDocs (options) {
       console.log(`   • Includes binary analysis: OSS ${diffJson.binaryAnalysis.versions.oss}, Cloud ${diffJson.binaryAnalysis.versions.cloud || 'N/A'}, cgo ${diffJson.binaryAnalysis.versions.cgo || 'N/A'}`)
     }
 
-    // Cleanup old diff files
+    // Cleanup only individual diff files from THIS run (not master diff or diffs from intermediate processing)
+    // We keep intermediate diffs to build the master diff at the end
     try {
+      const currentRunDiffs = new Set();
+
+      // Collect diffs from this run
+      if (intermediateProcessingResults.length > 0) {
+        intermediateProcessingResults.forEach(r => {
+          if (r.diffPath) {
+            currentRunDiffs.add(path.basename(r.diffPath));
+          }
+        });
+      }
+      currentRunDiffs.add(path.basename(diffPath)); // Current final diff
+
+      // Find old diff files (not from this run, not master-diff)
       const oldDiffFiles = fs.readdirSync(dataDir)
-        .filter(f => f.startsWith('connect-diff-') && f.endsWith('.json') && f !== path.basename(diffPath))
+        .filter(f =>
+          f.startsWith('connect-diff-') &&
+          f.endsWith('.json') &&
+          !f.startsWith('connect-diff-master-') &&
+          !currentRunDiffs.has(f)
+        );
 
       if (oldDiffFiles.length > 0) {
-        console.log(`🧹 Cleaning up ${oldDiffFiles.length} old diff files...`)
+        console.log(`🧹 Cleaning up ${oldDiffFiles.length} old diff file(s) from previous runs...`);
         oldDiffFiles.forEach(f => {
-          const oldDiffPath = path.join(dataDir, f)
-          fs.unlinkSync(oldDiffPath)
-          console.log(`   • Deleted: ${f}`)
-        })
+          const oldDiffPath = path.join(dataDir, f);
+          fs.unlinkSync(oldDiffPath);
+          console.log(`   • Deleted: ${f}`);
+        });
       }
     } catch (err) {
-      console.warn(`Warning: Failed to clean up old diff files: ${err.message}`)
+      console.warn(`Warning: Failed to clean up old diff files: ${err.message}`);
     }
   }
 
@@ -1399,10 +1682,24 @@ async function handleRpcnConnectorDocs (options) {
     }
   }
 
+  // Create master diff if we processed intermediate releases
+  let masterDiff = null
+  if (intermediateProcessingResults.length > 0) {
+    try {
+      const { createMasterDiff } = require('./multi-version-summary.js')
+      const masterDiffPath = path.join(dataDir, `connect-diff-master-${intermediateProcessingResults[0].fromVersion}_to_${newVersion}.json`)
+      const finalDiffPath = path.join(dataDir, `connect-diff-${oldVersion}_to_${newVersion}.json`)
+      masterDiff = createMasterDiff(intermediateProcessingResults, finalDiffPath, masterDiffPath)
+    } catch (err) {
+      console.error(`Warning: Failed to create master diff: ${err.message}`)
+    }
+  }
+
   // Generate PR summary
   try {
     const { printPRSummary } = require('./pr-summary-formatter.js')
-    printPRSummary(diffJson, binaryAnalysis, draftFiles)
+    // Use master diff if available, otherwise use single diff
+    printPRSummary(masterDiff || diffJson, binaryAnalysis, draftFiles, masterDiff ? true : false)
   } catch (err) {
     console.error(`Warning: Failed to generate PR summary: ${err.message}`)
   }
@@ -1438,6 +1735,22 @@ async function handleRpcnConnectorDocs (options) {
   console.log('\n📄 Summary:')
   console.log(`   • Run time: ${timestamp}`)
   console.log(`   • Version used: ${newVersion}`)
+
+  if (intermediateProcessingResults.length > 0) {
+    const successCount = intermediateProcessingResults.filter(r => r.success).length
+    console.log(`   • Intermediate releases processed: ${successCount}/${intermediateProcessingResults.length}`)
+
+    if (successCount < intermediateProcessingResults.length) {
+      console.log('   ⚠️  Some intermediate releases failed:')
+      intermediateProcessingResults.filter(r => !r.success).forEach(r => {
+        console.log(`      - ${r.fromVersion} → ${r.toVersion}: ${r.error}`)
+      })
+    }
+  }
+
+  // Note: Version cleanup is handled earlier in the augmentation phase (versionsToKeep logic)
+  // This preserves intermediate versions needed for diff generation while removing unneeded files
+
   process.exit(0)
 }
 

--- a/tools/redpanda-connect/templates/connector.hbs
+++ b/tools/redpanda-connect/templates/connector.hbs
@@ -2,6 +2,7 @@
 // tag::single-source[]
 :type: {{type}}
 :status: {{status}}
+{{#if support}}:support: {{support}}{{/if}}
 :categories: [{{join categories ", "}}]
 :description: {{#if summary}}{{{summary}}}{{else if description}}{{description}}{{else}}TODO: Missing description. Add a description in the overrides file or source data.{{/if}}
 


### PR DESCRIPTION
## Summary

This PR adds multi-release attribution to the Redpanda Connect connector documentation automation. When releases are missed, the automation now processes each intermediate release separately instead of lumping all changes into the latest version.

**Key improvements:**
- Sequential processing of intermediate releases for accurate version attribution
- Cloud binary version matching for each release date
- CGO-only component false positive elimination
- Enhanced configuration YAML generation
- Comprehensive documentation for the automation system

## Multi-Release Attribution

### Problem
When the automation missed weekly releases (e.g., 4.81.0 through 4.85.0), all changes were attributed to version 4.85.0 instead of their actual release version. Writers couldn't tell which features appeared in which version.

### Solution
- Automatically discovers intermediate releases via GitHub API
- Processes each version pair sequentially (4.81→4.82, 4.82→4.83, etc.)
- Generates separate diff files for each release
- Creates master diff aggregating all changes with per-version breakdown
- Matches correct cloud binary version to each release date

### New CLI Flags
- `--skip-intermediate`: Legacy mode (single comparison only)
- `--from-version <version>`: Override starting version instead of using antora.yml

## Bug Fixes

### CGO-Only Component False Positives
**Problem**: Components like `tigerbeetle_cdc`, `zmq4`, `ffi` existed in OSS binaries all along but showed as "new" in 4.85.0 because augmented data was used for diff generation.

**Fix**: Added `stripAugmentationFields()` function that removes cloud/CGO augmentation before version comparisons. This ensures diffs compare clean OSS-to-OSS data.

**Result**: 4.85.0 now shows 2 new components (correct) instead of 7 (eliminated 5 false positives).

### Cloud Binary Version Mismatch
**Problem**: When processing intermediate releases, automation used latest cloud version (4.85.0) for ALL comparisons, causing incorrect platform attribution.

**Fix**: Added `findCloudVersionForDate()` function that finds the appropriate cloud version for each OSS release date.

**Result**: Each intermediate release now uses its contemporary cloud version (4.82.0 uses cloud 4.82.0, 4.83.0 uses cloud 4.83.0, etc.).

### Cloud-Only Connector Labeling
**Problem**: `aws_cloudwatch_logs` was placed in cloud-only directory but PR summary labeled it "self-hosted only".

**Fix**: Changed from negative checks (`!inCloud`) to explicit positive checks for `isSelfHostedOnly` and `isCloudOnly`.

### Configuration YAML Improvements
**Label field restriction**: The `label` field is now only added for components that support it (inputs, outputs, processors). Previously it was added for all types including caches and metrics where it's invalid.

**Common vs Advanced deduplication**: When common and advanced configurations are identical, only the common config is shown with a leading sentence. No tabs are generated for duplicate content.

## Enhanced PR Summary

The multi-version PR summary now includes:
- **Release notes links** for each version
- **New connector descriptions** (2-sentence summaries from connector metadata)
- **New fields table** with component, field path, and description
- **Removed connectors/fields** with version attribution
- **Deprecated fields** with migration guidance
- **Changed defaults table** (old → new values)
- **Prioritized action items** (cloud connectors first, self-hosted second)
- **Per-version breakdown** showing which connectors appeared in which release

## New Files

| File | Purpose |
|------|---------|
| `tools/redpanda-connect/github-release-utils.js` | GitHub API integration for release discovery and cloud version matching |
| `tools/redpanda-connect/multi-version-summary.js` | Master diff aggregation across multiple releases |
| `tools/redpanda-connect/AUTOMATION.md` | Comprehensive documentation explaining what the automation does and what outputs it creates |
| `CLAUDE.md` | AI-optimized repository overview following Redpanda documentation standards |
| `__tests__/tools/github-release-utils.test.js` | Tests for release discovery and version matching |
| `__tests__/tools/buildConfigYaml.test.js` | Tests for YAML generation (label field, deprecated fields, object/array rendering) |

## Modified Files

| File | Changes |
|------|---------|
| `rpcn-connector-docs-handler.js` | Added `stripAugmentationFields()`, intermediate release processing loop, cloud version detection |
| `pr-summary-formatter.js` | Fixed cloud-only detection logic, added multi-version summary support |
| `buildConfigYaml.js` | Conditional label field (only for inputs/outputs/processors) |
| `bin/doc-tools.js` | Added `--skip-intermediate` and `--from-version` flags |

## Test Coverage

**66 tests across 3 test files (all passing)**

- `buildConfigYaml.test.js`: Label inclusion, deprecated fields, object/array rendering
- `github-release-utils.test.js`: Version parsing, release discovery, `findCloudVersionForDate()`
- `pr-summary-formatter.test.js`: Platform detection, multi-version summary, action items

## Test plan

- [x] Run `npm test` - all 66 tests pass
- [x] Test single-version mode with `--skip-intermediate`
- [x] Test multi-version mode (4.81.0 → 4.85.0)
- [x] Verify PR summary includes all version-specific details for writers
- [x] Verify field partials and draft pages generate correctly
- [x] Verify CGO false positives eliminated
- [x] Verify cloud version matching for intermediate releases
- [x] Cross-reference output against GitHub release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)