### PR TITLE
fix: prevent false removed connectors in diff by stripping augmentation fields

### DIFF
--- a/__tests__/tools/cgo-detection.test.js
+++ b/__tests__/tools/cgo-detection.test.js
@@ -18,6 +18,9 @@ const { execSync, spawnSync } = require('child_process');
 const os = require('os');
 
 // Test configuration
+// Using 4.75.1 as a stable version for integration testing
+// Note: This test is run separately via `npm run test:cgo` (not in regular test suite)
+// because it downloads real binaries from GitHub releases
 const TEST_VERSION = '4.75.1';
 const TEST_DIR = path.join(__dirname, '../.test-cgo-detection');
 const REPO_ROOT = path.resolve(__dirname, '../..');

--- a/__tests__/tools/connector-binary-analyzer.test.js
+++ b/__tests__/tools/connector-binary-analyzer.test.js
@@ -1,0 +1,242 @@
+'use strict';
+
+/**
+ * Tests for connector binary analyzer platform detection
+ * Tests Docker vs native execution logic
+ */
+
+const os = require('os');
+
+describe('Platform Detection for Binary Execution', () => {
+  // Save original platform
+  const originalPlatform = os.platform();
+
+  test('should require Docker for Linux binaries on macOS', () => {
+    const isLinuxBinary = true;
+    const platform = 'darwin';
+    const needsDocker = isLinuxBinary && platform !== 'linux';
+
+    expect(needsDocker).toBe(true);
+  });
+
+  test('should require Docker for Linux binaries on Windows', () => {
+    const isLinuxBinary = true;
+    const platform = 'win32';
+    const needsDocker = isLinuxBinary && platform !== 'linux';
+
+    expect(needsDocker).toBe(true);
+  });
+
+  test('should NOT require Docker for Linux binaries on Linux', () => {
+    const isLinuxBinary = true;
+    const platform = 'linux';
+    const needsDocker = isLinuxBinary && platform !== 'linux';
+
+    expect(needsDocker).toBe(false);
+  });
+
+  test('should detect Linux binary by filename', () => {
+    const binaryName = 'redpanda-connect-cgo-4.86.0-linux-amd64';
+    const isLinuxBinary = binaryName.includes('linux');
+
+    expect(isLinuxBinary).toBe(true);
+  });
+
+  test('should detect non-Linux binary by filename', () => {
+    const binaryName = 'redpanda-connect-cloud-4.86.0-darwin-arm64';
+    const isLinuxBinary = binaryName.includes('linux');
+
+    expect(isLinuxBinary).toBe(false);
+  });
+
+  test('current system should match actual platform', () => {
+    // This validates our test assumptions match reality
+    expect(['darwin', 'linux', 'win32']).toContain(os.platform());
+  });
+});
+
+describe('CGO Binary Analysis Failure Detection', () => {
+  test('should detect CGO failure when cgoIndex is undefined', () => {
+    const binaryAnalysis = {
+      ossVersion: '4.86.0',
+      cloudVersion: '4.86.0',
+      cloudIndex: { inputs: [] },
+      cgoIndex: undefined // CGO analysis failed
+    };
+
+    const cgoAnalysisFailed = !binaryAnalysis || !binaryAnalysis.ossVersion || !binaryAnalysis.cgoIndex;
+
+    expect(cgoAnalysisFailed).toBe(true);
+  });
+
+  test('should detect CGO success when cgoIndex exists', () => {
+    const binaryAnalysis = {
+      ossVersion: '4.86.0',
+      cloudVersion: '4.86.0',
+      cloudIndex: { inputs: [] },
+      cgoIndex: { inputs: [] } // CGO analysis succeeded
+    };
+
+    const cgoAnalysisFailed = !binaryAnalysis || !binaryAnalysis.ossVersion || !binaryAnalysis.cgoIndex;
+
+    expect(cgoAnalysisFailed).toBe(false);
+  });
+
+  test('should detect failure when binaryAnalysis is null', () => {
+    const binaryAnalysis = null;
+
+    const cgoAnalysisFailed = !binaryAnalysis || !binaryAnalysis.ossVersion || !binaryAnalysis.cgoIndex;
+
+    expect(cgoAnalysisFailed).toBe(true);
+  });
+
+  test('should detect failure when ossVersion is missing', () => {
+    const binaryAnalysis = {
+      cloudVersion: '4.86.0',
+      cgoIndex: { inputs: [] }
+    };
+
+    const cgoAnalysisFailed = !binaryAnalysis || !binaryAnalysis.ossVersion || !binaryAnalysis.cgoIndex;
+
+    expect(cgoAnalysisFailed).toBe(true);
+  });
+});
+
+describe('Fallback Stripping Logic', () => {
+  test('should strip CGO connectors from old data when CGO analysis fails', () => {
+    const oldIndex = {
+      inputs: [
+        { name: 'kafka', type: 'input', status: 'stable', config: {} },
+        { name: 'tigerbeetle_cdc', type: 'input', status: 'stable', requiresCgo: true, config: {} },
+        { name: 'zmq4', type: 'input', status: 'stable', requiresCgo: true, config: {} }
+      ],
+      processors: [
+        { name: 'mapping', type: 'processor', status: 'stable', config: {} },
+        { name: 'ffi', type: 'processor', status: 'stable', requiresCgo: true, config: {} }
+      ]
+    };
+
+    // Simulate fallback stripping
+    const strippedIndex = JSON.parse(JSON.stringify(oldIndex));
+    const connectorTypes = ['inputs', 'processors'];
+
+    for (const type of connectorTypes) {
+      if (Array.isArray(strippedIndex[type])) {
+        strippedIndex[type] = strippedIndex[type].filter(c => {
+          return !(c.requiresCgo || c.cloudOnly);
+        });
+      }
+    }
+
+    expect(strippedIndex.inputs).toHaveLength(1);
+    expect(strippedIndex.inputs[0].name).toBe('kafka');
+    expect(strippedIndex.processors).toHaveLength(1);
+    expect(strippedIndex.processors[0].name).toBe('mapping');
+  });
+
+  test('should strip cloud-only connectors from old data', () => {
+    const oldIndex = {
+      inputs: [
+        { name: 'kafka', type: 'input', status: 'stable', config: {} },
+        { name: 'cloud_special', type: 'input', status: 'stable', cloudOnly: true, config: {} }
+      ]
+    };
+
+    const strippedIndex = JSON.parse(JSON.stringify(oldIndex));
+    strippedIndex.inputs = strippedIndex.inputs.filter(c => {
+      return !(c.requiresCgo || c.cloudOnly);
+    });
+
+    expect(strippedIndex.inputs).toHaveLength(1);
+    expect(strippedIndex.inputs[0].name).toBe('kafka');
+  });
+
+  test('should remove platform metadata from remaining connectors', () => {
+    const oldIndex = {
+      inputs: [
+        { name: 'kafka', type: 'input', status: 'stable', cloudSupported: true, config: {} }
+      ]
+    };
+
+    const strippedIndex = JSON.parse(JSON.stringify(oldIndex));
+    strippedIndex.inputs.forEach(c => {
+      delete c.cloudSupported;
+      delete c.requiresCgo;
+      delete c.cloudOnly;
+    });
+
+    expect(strippedIndex.inputs[0].cloudSupported).toBeUndefined();
+    expect(strippedIndex.inputs[0].requiresCgo).toBeUndefined();
+    expect(strippedIndex.inputs[0].cloudOnly).toBeUndefined();
+  });
+
+  test('should handle empty connector arrays gracefully', () => {
+    const oldIndex = {
+      inputs: [],
+      outputs: []
+    };
+
+    const strippedIndex = JSON.parse(JSON.stringify(oldIndex));
+    const connectorTypes = ['inputs', 'outputs'];
+
+    for (const type of connectorTypes) {
+      if (Array.isArray(strippedIndex[type])) {
+        strippedIndex[type] = strippedIndex[type].filter(c => {
+          return !(c.requiresCgo || c.cloudOnly);
+        });
+      }
+    }
+
+    expect(strippedIndex.inputs).toHaveLength(0);
+    expect(strippedIndex.outputs).toHaveLength(0);
+  });
+
+  test('should keep connectors with both requiresCgo false and cloudOnly false', () => {
+    const oldIndex = {
+      inputs: [
+        { name: 'kafka', type: 'input', status: 'stable', requiresCgo: false, cloudOnly: false, config: {} },
+        { name: 'http', type: 'input', status: 'stable', config: {} }
+      ]
+    };
+
+    const strippedIndex = JSON.parse(JSON.stringify(oldIndex));
+    strippedIndex.inputs = strippedIndex.inputs.filter(c => {
+      return !(c.requiresCgo || c.cloudOnly);
+    });
+
+    expect(strippedIndex.inputs).toHaveLength(2);
+  });
+});
+
+describe('Binary Analysis Integration', () => {
+  test('should count correct number of CGO-only connectors', () => {
+    const binaryAnalysis = {
+      ossVersion: '4.86.0',
+      cloudVersion: '4.86.0',
+      cgoIndex: { inputs: [] },
+      cgoOnly: [
+        { name: 'tigerbeetle_cdc', type: 'input', status: 'stable' },
+        { name: 'zmq4', type: 'input', status: 'stable' },
+        { name: 'zmq4', type: 'output', status: 'stable' },
+        { name: 'ffi', type: 'processor', status: 'stable' }
+      ]
+    };
+
+    expect(binaryAnalysis.cgoOnly).toHaveLength(4);
+  });
+
+  test('should structure cloud-only connector data correctly', () => {
+    const cloudOnlyConnector = {
+      name: 'cloud_special',
+      type: 'input',
+      status: 'stable',
+      cloudOnly: true,
+      cloudSupported: true,
+      requiresCgo: false
+    };
+
+    expect(cloudOnlyConnector.cloudOnly).toBe(true);
+    expect(cloudOnlyConnector.cloudSupported).toBe(true);
+    expect(cloudOnlyConnector.requiresCgo).toBe(false);
+  });
+});

--- a/__tests__/tools/connector-diff-cgo.test.js
+++ b/__tests__/tools/connector-diff-cgo.test.js
@@ -1,0 +1,382 @@
+'use strict';
+
+/**
+ * Tests for CGO connector diff logic
+ * Covers the fix for false "removed connectors" reports
+ */
+
+const { generateConnectorDiffJson } = require('../../tools/redpanda-connect/report-delta');
+
+describe('CGO Connector Diff - Platform Metadata Preservation', () => {
+  test('should preserve requiresCgo metadata in buildComponentMap', () => {
+    const oldIndex = {
+      inputs: [
+        {
+          name: 'tigerbeetle_cdc',
+          type: 'input',
+          status: 'stable',
+          requiresCgo: true,
+          cloudSupported: false,
+          config: { children: [] }
+        }
+      ]
+    };
+
+    const newIndex = {
+      inputs: [
+        {
+          name: 'tigerbeetle_cdc',
+          type: 'input',
+          status: 'stable',
+          requiresCgo: true,
+          cloudSupported: false,
+          config: { children: [] }
+        }
+      ]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.85.0',
+      newVersion: '4.86.0'
+    });
+
+    // Should not report as removed when metadata matches
+    expect(diff.summary.removedComponents).toBe(0);
+    expect(diff.details.removedComponents).toHaveLength(0);
+  });
+
+  test('should not report CGO connectors as removed when both versions have them', () => {
+    const cgoConnectors = [
+      { name: 'tigerbeetle_cdc', type: 'input', status: 'stable', requiresCgo: true, config: { children: [] } },
+      { name: 'zmq4', type: 'input', status: 'stable', requiresCgo: true, config: { children: [] } },
+      { name: 'ffi', type: 'processor', status: 'stable', requiresCgo: true, config: { children: [] } }
+    ];
+
+    const oldIndex = {
+      inputs: cgoConnectors.filter(c => c.type === 'input'),
+      processors: cgoConnectors.filter(c => c.type === 'processor')
+    };
+
+    const newIndex = {
+      inputs: cgoConnectors.filter(c => c.type === 'input'),
+      processors: cgoConnectors.filter(c => c.type === 'processor')
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.85.0',
+      newVersion: '4.86.0'
+    });
+
+    expect(diff.summary.removedComponents).toBe(0);
+  });
+
+  test('should detect new connector correctly with platform metadata', () => {
+    const oldIndex = {
+      processors: [
+        { name: 'split', type: 'processor', status: 'stable', config: { children: [] } }
+      ]
+    };
+
+    const newIndex = {
+      processors: [
+        { name: 'split', type: 'processor', status: 'stable', config: { children: [] } },
+        { name: 'string_split', type: 'processor', status: 'stable', cloudSupported: true, config: { children: [] } }
+      ]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.85.0',
+      newVersion: '4.86.0'
+    });
+
+    expect(diff.summary.newComponents).toBe(1);
+    expect(diff.details.newComponents).toHaveLength(1);
+    expect(diff.details.newComponents[0].name).toBe('string_split');
+  });
+
+  test('should detect actual removals correctly', () => {
+    const oldIndex = {
+      inputs: [
+        { name: 'deprecated_input', type: 'input', status: 'stable', config: { children: [] } },
+        { name: 'kafka', type: 'input', status: 'stable', config: { children: [] } }
+      ]
+    };
+
+    const newIndex = {
+      inputs: [
+        { name: 'kafka', type: 'input', status: 'stable', config: { children: [] } }
+      ]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.85.0',
+      newVersion: '4.86.0'
+    });
+
+    expect(diff.summary.removedComponents).toBe(1);
+    expect(diff.details.removedComponents).toHaveLength(1);
+    expect(diff.details.removedComponents[0].name).toBe('deprecated_input');
+  });
+
+  test('should preserve cloudSupported and cloudOnly metadata', () => {
+    const oldIndex = {
+      processors: [
+        { name: 'cloud_only_processor', type: 'processor', status: 'stable', cloudOnly: true, config: { children: [] } }
+      ]
+    };
+
+    const newIndex = {
+      processors: [
+        { name: 'cloud_only_processor', type: 'processor', status: 'stable', cloudOnly: true, config: { children: [] } }
+      ]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.85.0',
+      newVersion: '4.86.0'
+    });
+
+    expect(diff.summary.removedComponents).toBe(0);
+  });
+
+  test('should handle mixed CGO and OSS connectors correctly', () => {
+    const oldIndex = {
+      inputs: [
+        { name: 'kafka', type: 'input', status: 'stable', cloudSupported: true, config: { children: [] } },
+        { name: 'tigerbeetle_cdc', type: 'input', status: 'stable', requiresCgo: true, config: { children: [] } },
+        { name: 'http_server', type: 'input', status: 'stable', cloudSupported: true, config: { children: [] } }
+      ]
+    };
+
+    const newIndex = {
+      inputs: [
+        { name: 'kafka', type: 'input', status: 'stable', cloudSupported: true, config: { children: [] } },
+        { name: 'tigerbeetle_cdc', type: 'input', status: 'stable', requiresCgo: true, config: { children: [] } },
+        { name: 'http_server', type: 'input', status: 'stable', cloudSupported: true, config: { children: [] } }
+      ]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.85.0',
+      newVersion: '4.86.0'
+    });
+
+    expect(diff.summary.removedComponents).toBe(0);
+    expect(diff.summary.newComponents).toBe(0);
+  });
+});
+
+describe('CGO Connector Diff - Asymmetric Augmentation Scenario', () => {
+  test('should handle old augmented vs new non-augmented correctly (the original bug)', () => {
+    // Scenario: Old data has CGO metadata, new data doesn't (CGO analysis failed)
+    const oldIndex = {
+      inputs: [
+        { name: 'kafka', type: 'input', status: 'stable', config: { children: [] } },
+        { name: 'tigerbeetle_cdc', type: 'input', status: 'stable', requiresCgo: true, config: { children: [] } }
+      ]
+    };
+
+    const newIndex = {
+      inputs: [
+        { name: 'kafka', type: 'input', status: 'stable', config: { children: [] } }
+        // tigerbeetle_cdc not in new because it wasn't augmented
+      ]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.85.0',
+      newVersion: '4.86.0'
+    });
+
+    // This would have reported tigerbeetle_cdc as removed (the bug)
+    // After fix, we handle this via fallback stripping in the handler
+    expect(diff.summary.removedComponents).toBe(1);
+  });
+
+  test('should detect new field additions correctly', () => {
+    const oldIndex = {
+      inputs: [
+        {
+          name: 'kafka',
+          type: 'input',
+          status: 'stable',
+          config: {
+            children: [
+              { name: 'address', type: 'string' }
+            ]
+          }
+        }
+      ]
+    };
+
+    const newIndex = {
+      inputs: [
+        {
+          name: 'kafka',
+          type: 'input',
+          status: 'stable',
+          config: {
+            children: [
+              { name: 'address', type: 'string' },
+              { name: 'timeout', type: 'string' }
+            ]
+          }
+        }
+      ]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.85.0',
+      newVersion: '4.86.0'
+    });
+
+    expect(diff.summary.newFields).toBe(1);
+  });
+});
+
+describe('CGO Connector Diff - Edge Cases', () => {
+  test('should handle empty old index (all new connectors)', () => {
+    const oldIndex = { inputs: [] };
+    const newIndex = {
+      inputs: [
+        { name: 'kafka', type: 'input', status: 'stable', config: { children: [] } }
+      ]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.85.0',
+      newVersion: '4.86.0'
+    });
+
+    expect(diff.summary.newComponents).toBe(1);
+    expect(diff.summary.removedComponents).toBe(0);
+  });
+
+  test('should handle empty new index (all removed connectors)', () => {
+    const oldIndex = {
+      inputs: [
+        { name: 'kafka', type: 'input', status: 'stable', config: { children: [] } }
+      ]
+    };
+    const newIndex = { inputs: [] };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.85.0',
+      newVersion: '4.86.0'
+    });
+
+    expect(diff.summary.newComponents).toBe(0);
+    expect(diff.summary.removedComponents).toBe(1);
+  });
+
+  test('should handle missing config/fields gracefully', () => {
+    const oldIndex = {
+      inputs: [
+        { name: 'test_input', type: 'input', status: 'stable' }
+      ]
+    };
+    const newIndex = {
+      inputs: [
+        { name: 'test_input', type: 'input', status: 'stable' }
+      ]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.85.0',
+      newVersion: '4.86.0'
+    });
+
+    expect(diff.summary.removedComponents).toBe(0);
+    expect(diff.summary.newComponents).toBe(0);
+  });
+
+  test('should handle multiple connector types simultaneously', () => {
+    const oldIndex = {
+      inputs: [{ name: 'kafka', type: 'input', status: 'stable', config: { children: [] } }],
+      outputs: [{ name: 's3', type: 'output', status: 'stable', config: { children: [] } }],
+      processors: [{ name: 'mapping', type: 'processor', status: 'stable', config: { children: [] } }]
+    };
+
+    const newIndex = {
+      inputs: [
+        { name: 'kafka', type: 'input', status: 'stable', config: { children: [] } },
+        { name: 'mqtt', type: 'input', status: 'stable', config: { children: [] } }
+      ],
+      outputs: [{ name: 's3', type: 'output', status: 'stable', config: { children: [] } }],
+      processors: [
+        { name: 'mapping', type: 'processor', status: 'stable', config: { children: [] } },
+        { name: 'string_split', type: 'processor', status: 'stable', config: { children: [] } }
+      ]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.85.0',
+      newVersion: '4.86.0'
+    });
+
+    expect(diff.summary.newComponents).toBe(2); // mqtt input + string_split processor
+    expect(diff.summary.removedComponents).toBe(0);
+  });
+});
+
+describe('CGO Connector Diff - Deprecation Detection', () => {
+  test('should detect deprecated connectors', () => {
+    const oldIndex = {
+      inputs: [
+        { name: 'kafka', type: 'input', status: 'stable', config: { children: [] } }
+      ]
+    };
+
+    const newIndex = {
+      inputs: [
+        { name: 'kafka', type: 'input', status: 'deprecated', config: { children: [] } }
+      ]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.85.0',
+      newVersion: '4.86.0'
+    });
+
+    expect(diff.summary.deprecatedComponents).toBe(1);
+  });
+
+  test('should detect deprecated fields', () => {
+    const oldIndex = {
+      inputs: [
+        {
+          name: 'kafka',
+          type: 'input',
+          status: 'stable',
+          config: {
+            children: [
+              { name: 'address', type: 'string', status: 'stable' }
+            ]
+          }
+        }
+      ]
+    };
+
+    const newIndex = {
+      inputs: [
+        {
+          name: 'kafka',
+          type: 'input',
+          status: 'stable',
+          config: {
+            children: [
+              { name: 'address', type: 'string', status: 'deprecated' }
+            ]
+          }
+        }
+      ]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.85.0',
+      newVersion: '4.86.0'
+    });
+
+    expect(diff.summary.deprecatedFields).toBe(1);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.15.8",
+  "version": "4.15.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.15.8",
+      "version": "4.15.9",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.15.8",
+  "version": "4.15.9",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/property-extractor/property_extractor.py
+++ b/tools/property-extractor/property_extractor.py
@@ -991,6 +991,14 @@ def _apply_override_to_existing_property(property_dict, override, overrides_file
     if "category" in override:
         property_dict["category"] = override["category"]
 
+    # Apply accepted_values override - replaces enum field to filter displayed values
+    # Use case: Exclude internal-only enum values (e.g., greedy mode for leader_balancer_mode)
+    if "accepted_values" in override:
+        if isinstance(override["accepted_values"], list):
+            property_dict["enum"] = override["accepted_values"]
+        else:
+            logger.warning(f"accepted_values for property must be an array")
+
 
 def _create_property_from_override(prop_name, override, overrides_file_path):
     """Create a new property from override specification."""
@@ -1025,9 +1033,10 @@ def _create_property_from_override(prop_name, override, overrides_file_path):
     
     # Add any other custom fields from override
     for key, value in override.items():
-        if key not in ["description", "type", "default", "config_scope", "version", 
-                       "example", "example_file", "example_yaml", "related_topics", 
-                       "is_deprecated", "visibility"]:
+        if key not in ["description", "type", "default", "config_scope", "version",
+                       "example", "example_file", "example_yaml", "related_topics",
+                       "is_deprecated", "visibility", "exclude_from_docs", "category",
+                       "accepted_values", "_comment"]:
             new_property[key] = value
 
     # Add exclude_from_docs if specified
@@ -1037,7 +1046,14 @@ def _create_property_from_override(prop_name, override, overrides_file_path):
     # Add category if specified
     if "category" in override:
         new_property["category"] = override["category"]
-    
+
+    # Add accepted_values as enum field if specified
+    if "accepted_values" in override:
+        if isinstance(override["accepted_values"], list):
+            new_property["enum"] = override["accepted_values"]
+        else:
+            logger.warning(f"accepted_values for property '{prop_name}' must be an array")
+
     return new_property
 
 

--- a/tools/redpanda-connect/connector-binary-analyzer.js
+++ b/tools/redpanda-connect/connector-binary-analyzer.js
@@ -247,6 +247,7 @@ function getConnectorList(binaryPath) {
 
     let result;
     if (needsDocker) {
+      console.log(`   Using Docker to run Linux binary on ${os.platform()}`);
       // Use Docker to run Linux binaries on macOS/Windows
       const binaryDir = path.dirname(binaryPath);
       const binaryFile = path.basename(binaryPath);
@@ -268,6 +269,7 @@ function getConnectorList(binaryPath) {
         maxBuffer: 10 * 1024 * 1024 // 10MB buffer
       });
     } else {
+      console.log(`   Running natively on ${os.platform()}`);
       // Run natively
       result = spawnSync(binaryPath, ['list', '--format', 'json-full'], {
         stdio: ['ignore', 'pipe', 'ignore'],

--- a/tools/redpanda-connect/report-delta.js
+++ b/tools/redpanda-connect/report-delta.js
@@ -2,6 +2,7 @@ const { execSync } = require('child_process');
 
 /**
  * Generate a JSON diff report between two connector index objects.
+ * Includes platform metadata (CGO, cloud-only) to detect transitions.
  * @param {object} oldIndex - Previous version connector index
  * @param {object} newIndex - Current version connector index
  * @param {object} opts - { oldVersion, newVersion, timestamp, binaryAnalysis, oldBinaryAnalysis }
@@ -11,31 +12,39 @@ function generateConnectorDiffJson(oldIndex, newIndex, opts = {}) {
   const oldMap = buildComponentMap(oldIndex);
   const newMap = buildComponentMap(newIndex);
 
-  // New components
+  // New components (include platform metadata)
   const newComponentKeys = Object.keys(newMap).filter(k => !(k in oldMap));
   const newComponents = newComponentKeys.map(key => {
     const [type, name] = key.split(':');
     const raw = newMap[key].raw;
+    const metadata = newMap[key].metadata || {};
     return {
       name,
       type,
       status: raw.status || raw.type || '',
       version: raw.version || raw.introducedInVersion || '',
-      description: raw.description || ''
+      description: raw.description || '',
+      requiresCgo: metadata.requiresCgo || false,
+      cloudOnly: metadata.cloudOnly || false,
+      cloudSupported: metadata.cloudSupported || false
     };
   });
 
-  // Removed components
+  // Removed components (include platform metadata to understand why removed)
   const removedComponentKeys = Object.keys(oldMap).filter(k => !(k in newMap));
   const removedComponents = removedComponentKeys.map(key => {
     const [type, name] = key.split(':');
     const raw = oldMap[key].raw;
+    const metadata = oldMap[key].metadata || {};
     return {
       name,
       type,
       status: raw.status || raw.type || '',
       version: raw.version || raw.introducedInVersion || '',
-      description: raw.description || ''
+      description: raw.description || '',
+      requiresCgo: metadata.requiresCgo || false,
+      cloudOnly: metadata.cloudOnly || false,
+      cloudSupported: metadata.cloudSupported || false
     };
   });
 
@@ -95,6 +104,57 @@ function generateConnectorDiffJson(oldIndex, newIndex, opts = {}) {
         status: raw.status || raw.type || '',
         version: raw.version || raw.introducedInVersion || '',
         description: raw.description || ''
+      });
+    }
+  });
+
+  // Platform transitions (CGO, cloud support changes)
+  const platformTransitions = [];
+  Object.keys(newMap).forEach(cKey => {
+    if (!(cKey in oldMap)) return;
+
+    const oldMeta = oldMap[cKey].metadata || {};
+    const newMeta = newMap[cKey].metadata || {};
+    const [type, name] = cKey.split(':');
+
+    const transitions = [];
+
+    // CGO requirement changes
+    if (!oldMeta.requiresCgo && newMeta.requiresCgo) {
+      transitions.push('became_cgo_only');
+    } else if (oldMeta.requiresCgo && !newMeta.requiresCgo) {
+      transitions.push('no_longer_cgo_only');
+    }
+
+    // Cloud support changes
+    if (!oldMeta.cloudSupported && newMeta.cloudSupported) {
+      transitions.push('added_cloud_support');
+    } else if (oldMeta.cloudSupported && !newMeta.cloudSupported) {
+      transitions.push('removed_cloud_support');
+    }
+
+    // Cloud-only status changes
+    if (!oldMeta.cloudOnly && newMeta.cloudOnly) {
+      transitions.push('became_cloud_only');
+    } else if (oldMeta.cloudOnly && !newMeta.cloudOnly) {
+      transitions.push('no_longer_cloud_only');
+    }
+
+    if (transitions.length > 0) {
+      platformTransitions.push({
+        name,
+        type,
+        transitions,
+        oldPlatform: {
+          requiresCgo: oldMeta.requiresCgo || false,
+          cloudSupported: oldMeta.cloudSupported || false,
+          cloudOnly: oldMeta.cloudOnly || false
+        },
+        newPlatform: {
+          requiresCgo: newMeta.requiresCgo || false,
+          cloudSupported: newMeta.cloudSupported || false,
+          cloudOnly: newMeta.cloudOnly || false
+        }
       });
     }
   });
@@ -221,6 +281,7 @@ function generateConnectorDiffJson(oldIndex, newIndex, opts = {}) {
       deprecatedComponents: deprecatedComponents.length,
       deprecatedFields: deprecatedFields.length,
       changedDefaults: changedDefaults.length,
+      platformTransitions: platformTransitions.length,
       newBloblangMethods: newBloblangMethods.length,
       removedBloblangMethods: removedBloblangMethods.length,
       newBloblangFunctions: newBloblangFunctions.length,
@@ -236,6 +297,7 @@ function generateConnectorDiffJson(oldIndex, newIndex, opts = {}) {
       deprecatedComponents,
       deprecatedFields,
       changedDefaults,
+      platformTransitions,
       newBloblangMethods,
       removedBloblangMethods,
       newBloblangFunctions,
@@ -341,7 +403,19 @@ function buildComponentMap(indexObj) {
       }
 
       const fieldNames = childArray.map(f => f.name);
-      map[lookupKey] = { raw: component, fields: fieldNames };
+
+      // Preserve platform metadata for accurate diff comparison
+      const metadata = {
+        requiresCgo: component.requiresCgo || false,
+        cloudSupported: component.cloudSupported || false,
+        cloudOnly: component.cloudOnly || false
+      };
+
+      map[lookupKey] = {
+        raw: component,
+        fields: fieldNames,
+        metadata: metadata
+      };
     });
   });
 

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -1232,9 +1232,10 @@ async function handleRpcnConnectorDocs (options) {
         }
       }
 
-      // NOTE: We do NOT reload newIndex after augmentation
-      // Diff generation should use clean OSS data to avoid false positives from CGO/cloud-only components
-      // The augmented data is saved to disk but not used for version comparisons
+      // IMPORTANT: Reload newIndex with augmented data for unified diff
+      // The unified diff approach compares platform metadata to detect transitions
+      newIndex = connectorData
+      console.log(`✓ Reloaded newIndex with augmented data for diff comparison`)
     } catch (err) {
       console.error(`Warning: Failed to augment data file: ${err.message}`)
     }

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -487,37 +487,6 @@ function logCollapsed (label, filesArray, maxToShow = 10) {
   console.log('')
 }
 
-/**
- * Strip augmentation fields from connector data to ensure clean comparisons
- * Removes cloudSupported, requiresCgo, cloudOnly fields and filters out cloud-only connectors
- * @param {object} data - Connector index data
- * @returns {object} Clean connector data without augmentation
- */
-function stripAugmentationFields(data) {
-  const cleanData = JSON.parse(JSON.stringify(data));
-  const connectorTypes = ['inputs', 'outputs', 'processors', 'caches', 'rate_limits',
-    'buffers', 'metrics', 'scanners', 'tracers', 'config', 'bloblang-methods'];
-
-  for (const type of connectorTypes) {
-    if (Array.isArray(cleanData[type])) {
-      // Remove connectors that were added by augmentation (cloudOnly or requiresCgo without OSS data)
-      cleanData[type] = cleanData[type].filter(c => {
-        // Keep if it's not marked as cloudOnly or requiresCgo
-        // OR if it has a config/fields (meaning it came from OSS, not just binary analysis)
-        return (!(c.cloudOnly || c.requiresCgo) || c.config || c.fields);
-      });
-
-      // Remove augmentation fields
-      cleanData[type].forEach(c => {
-        delete c.cloudSupported;
-        delete c.requiresCgo;
-        delete c.cloudOnly;
-      });
-    }
-  }
-
-  return cleanData;
-}
 
 /**
  * Load or fetch connector data for a specific version
@@ -529,15 +498,11 @@ function stripAugmentationFields(data) {
 async function loadConnectorDataForVersion(version, dataDir, options = {}) {
   const dataFile = path.join(dataDir, `connect-${version}.json`);
 
-  // If file exists, load it
+  // If file exists, load it (with platform metadata intact)
   if (fs.existsSync(dataFile)) {
     console.log(`✓ Using existing data file: connect-${version}.json`);
     const data = JSON.parse(fs.readFileSync(dataFile, 'utf8'));
-
-    // Strip augmentation fields to ensure clean comparisons
-    // Augmentation adds CGO/cloud-only components that shouldn't affect version diffs
-    const cleanData = stripAugmentationFields(data);
-    return cleanData;
+    return data;
   }
 
   // If not, fetch it
@@ -940,8 +905,8 @@ async function handleRpcnConnectorDocs (options) {
   let oldIndex = {}
   let oldVersion = null
   if (options.oldData && fs.existsSync(options.oldData)) {
-    // Strip augmentation fields to ensure clean comparisons
-    oldIndex = stripAugmentationFields(JSON.parse(fs.readFileSync(options.oldData, 'utf8')))
+    // Load with platform metadata intact for accurate diff
+    oldIndex = JSON.parse(fs.readFileSync(options.oldData, 'utf8'))
     const m = options.oldData.match(/connect-([\d.]+)\.json$/)
     if (m) oldVersion = m[1]
   } else {
@@ -959,30 +924,47 @@ async function handleRpcnConnectorDocs (options) {
       oldVersion = sortedVersions[0]
       const oldFile = `connect-${oldVersion}.json`
       const oldPath = path.join(dataDir, oldFile)
-      // Strip augmentation fields to ensure clean comparisons
-      oldIndex = stripAugmentationFields(JSON.parse(fs.readFileSync(oldPath, 'utf8')))
+      // Load with platform metadata intact for accurate diff
+      oldIndex = JSON.parse(fs.readFileSync(oldPath, 'utf8'))
       console.log(`📋 Using old version data: ${oldFile}`)
     } else {
       oldVersion = getAntoraValue('asciidoc.attributes.latest-connect-version')
       if (oldVersion) {
         const oldPath = path.join(dataDir, `connect-${oldVersion}.json`)
         if (fs.existsSync(oldPath)) {
-          // Strip augmentation fields to ensure clean comparisons
-          oldIndex = stripAugmentationFields(JSON.parse(fs.readFileSync(oldPath, 'utf8')))
+          // Load with platform metadata intact for accurate diff
+          oldIndex = JSON.parse(fs.readFileSync(oldPath, 'utf8'))
         }
       }
     }
   }
 
-  // Load and strip augmentation fields for clean comparisons
-  let newIndex = stripAugmentationFields(JSON.parse(fs.readFileSync(dataFile, 'utf8')))
+  // Load with platform metadata intact for accurate diff
+  let newIndex = JSON.parse(fs.readFileSync(dataFile, 'utf8'))
 
-  // Save a clean copy of OSS data for binary analysis (before augmentation)
-  // This ensures the binary analyzer compares actual binaries, not augmented data
+  // Save a clean copy of OSS data for binary analysis
+  // Binary analyzer needs pure OSS data without augmented CGO/cloud connectors
   const cleanOssDataPath = path.join(dataDir, `._connect-${newVersion}-clean.json`)
 
-  // Use the already-stripped newIndex for clean data
+  // Create clean version by removing augmented connectors
   const cleanData = JSON.parse(JSON.stringify(newIndex))
+  const connectorTypes = ['inputs', 'outputs', 'processors', 'caches', 'rate_limits',
+    'buffers', 'metrics', 'scanners', 'tracers']
+
+  for (const type of connectorTypes) {
+    if (Array.isArray(cleanData[type])) {
+      // Keep only connectors from OSS rpk (have config/fields)
+      // Remove augmentation-only connectors (added by previous binary analysis)
+      cleanData[type] = cleanData[type].filter(c => c.config || c.fields)
+
+      // Remove platform metadata from remaining connectors
+      cleanData[type].forEach(c => {
+        delete c.cloudSupported
+        delete c.requiresCgo
+        delete c.cloudOnly
+      })
+    }
+  }
 
   fs.writeFileSync(cleanOssDataPath, JSON.stringify(cleanData, null, 2), 'utf8')
 

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -1251,7 +1251,9 @@ async function handleRpcnConnectorDocs (options) {
     // FALLBACK: If binary analysis failed, strip CGO/cloud augmentation from old data
     // to prevent false "removed" reports when comparing augmented old vs non-augmented new
     let oldIndexForDiff = oldIndex
-    if (!binaryAnalysis || !binaryAnalysis.ossVersion) {
+    // Check if CGO analysis specifically failed (cgoIndex will be undefined if CGO binary couldn't be analyzed)
+    const cgoAnalysisFailed = !binaryAnalysis || !binaryAnalysis.ossVersion || !binaryAnalysis.cgoIndex
+    if (cgoAnalysisFailed) {
       console.log('⚠️  Binary analysis unavailable - stripping CGO/cloud metadata from old data for clean comparison')
 
       // Strip CGO/cloud-only connectors and metadata from old data

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -93,6 +93,19 @@ function capToTwoSentences (description) {
 }
 
 /**
+ * Remove platform metadata fields from connectors
+ * @param {Array} connectors - Array of connector objects
+ */
+function stripPlatformMetadata (connectors) {
+  if (!Array.isArray(connectors)) return
+  connectors.forEach(c => {
+    delete c.cloudSupported
+    delete c.requiresCgo
+    delete c.cloudOnly
+  })
+}
+
+/**
  * Update whats-new.adoc with new release information
  * @param {Object} params - Parameters
  * @param {string} params.dataDir - Data directory path
@@ -958,11 +971,7 @@ async function handleRpcnConnectorDocs (options) {
       cleanData[type] = cleanData[type].filter(c => c.config || c.fields)
 
       // Remove platform metadata from remaining connectors
-      cleanData[type].forEach(c => {
-        delete c.cloudSupported
-        delete c.requiresCgo
-        delete c.cloudOnly
-      })
+      stripPlatformMetadata(cleanData[type])
     }
   }
 
@@ -1012,8 +1021,6 @@ async function handleRpcnConnectorDocs (options) {
       console.error(`Error: Failed to publish merged version: ${err.message}`)
     }
   }
-
-  printDeltaReport(oldIndex, newIndex)
 
   // Binary analysis
   let oldBinaryAnalysis = null
@@ -1279,11 +1286,7 @@ async function handleRpcnConnectorDocs (options) {
           }
 
           // Remove platform metadata from remaining connectors
-          oldIndexForDiff[type].forEach(c => {
-            delete c.cloudSupported
-            delete c.requiresCgo
-            delete c.cloudOnly
-          })
+          stripPlatformMetadata(oldIndexForDiff[type])
         }
       }
 
@@ -1291,6 +1294,8 @@ async function handleRpcnConnectorDocs (options) {
         console.log(`   ✓ Total stripped: ${totalStripped} CGO/cloud connectors`)
       }
     }
+
+    printDeltaReport(oldIndexForDiff, newIndex)
 
     const { generateConnectorDiffJson } = require('./report-delta.js')
     diffJson = generateConnectorDiffJson(

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -1247,9 +1247,51 @@ async function handleRpcnConnectorDocs (options) {
   } else if (versionsMatch) {
     console.log(`⏭️  Skipping diff generation: versions match (${oldVersion} === ${newVersion})`)
   } else {
+    // FALLBACK: If binary analysis failed, strip CGO/cloud augmentation from old data
+    // to prevent false "removed" reports when comparing augmented old vs non-augmented new
+    let oldIndexForDiff = oldIndex
+    if (!binaryAnalysis || !binaryAnalysis.ossVersion) {
+      console.log('⚠️  Binary analysis unavailable - stripping CGO/cloud metadata from old data for clean comparison')
+
+      // Strip CGO/cloud-only connectors and metadata from old data
+      oldIndexForDiff = JSON.parse(JSON.stringify(oldIndex))
+      const connectorTypes = ['inputs', 'outputs', 'processors', 'caches', 'rate_limits',
+        'buffers', 'metrics', 'scanners', 'tracers']
+
+      let totalStripped = 0
+      for (const type of connectorTypes) {
+        if (Array.isArray(oldIndexForDiff[type])) {
+          const originalCount = oldIndexForDiff[type].length
+
+          // Remove connectors marked as CGO-only or cloud-only
+          // These shouldn't appear as "removed" when binary analysis is unavailable
+          oldIndexForDiff[type] = oldIndexForDiff[type].filter(c => {
+            return !(c.requiresCgo || c.cloudOnly)
+          })
+
+          const removed = originalCount - oldIndexForDiff[type].length
+          if (removed > 0) {
+            console.log(`   • Stripped ${removed} CGO/cloud connectors from ${type}`)
+            totalStripped += removed
+          }
+
+          // Remove platform metadata from remaining connectors
+          oldIndexForDiff[type].forEach(c => {
+            delete c.cloudSupported
+            delete c.requiresCgo
+            delete c.cloudOnly
+          })
+        }
+      }
+
+      if (totalStripped > 0) {
+        console.log(`   ✓ Total stripped: ${totalStripped} CGO/cloud connectors`)
+      }
+    }
+
     const { generateConnectorDiffJson } = require('./report-delta.js')
     diffJson = generateConnectorDiffJson(
-      oldIndex,
+      oldIndexForDiff,
       newIndex,
       {
         oldVersion: oldVersion,


### PR DESCRIPTION
## Problem

When comparing Redpanda Connect versions (e.g., 4.85.0 → 4.86.0), the PR summary incorrectly reported CGO-only connectors as "removed":
- `tigerbeetle_cdc` (inputs)
- `zmq4` (inputs)
- `zmq4` (outputs)
- `ffi` (processors)

These connectors were not actually removed—they exist in both versions but require CGO builds (linux/amd64 with C library dependencies).

## Root Causes

### 1. Asymmetric Augmentation
- **Old data** (4.85.0): Already augmented with `requiresCgo: true` from previous runs
- **New data** (4.86.0): Not augmented when CGO analysis failed
- **Result:** CGO connectors appeared in old index but not in new index → false "removed" reports

### 2. Timing Bug
The code augmented the disk file but didn't reload `newIndex` in memory:
```javascript
// Line 1235: Comment said "We do NOT reload newIndex"
// But diff generation used stale OSS-only newIndex
generateConnectorDiffJson(oldIndex, newIndex, ...)  // newIndex still OSS-only!
```

### 3. Incomplete Fallback Detection
The fallback condition only checked `ossVersion`:
```javascript
if (!binaryAnalysis || !binaryAnalysis.ossVersion)
```

When CGO analysis failed but cloud analysis succeeded, `ossVersion` existed, so the fallback didn't trigger.

## Solution

### Unified Diff with Platform Metadata

Replaced the flawed "strip before diff" approach with a unified diff that preserves and compares platform metadata:

**report-delta.js:**
- ✅ Removed `stripAugmentationFields` function
- ✅ Enhanced `buildComponentMap` to preserve `requiresCgo`, `cloudSupported`, `cloudOnly`
- ✅ Added platform transition detection (e.g., CGO→OSS, cloud support added/removed)

**rpcn-connector-docs-handler.js:**
- ✅ Reload `newIndex` after augmentation (commit 03509aa4)
- ✅ Detect CGO analysis failure by checking `cgoIndex` specifically (commit 9e9797e2)
- ✅ Fallback: Strip CGO/cloud connectors from old data when binary analysis unavailable

## How It Works

### Scenario A: Docker Available (Full CGO Analysis)
```
1. Fetch OSS connectors via rpk connect
2. Analyze cloud binary → identify cloud-supported connectors
3. Analyze CGO binary → identify CGO-only connectors
4. Augment connector data with platform metadata
5. Reload newIndex with augmented data ← CRITICAL FIX
6. Generate unified diff comparing augmented old vs augmented new
Result: CGO connectors in both → no false removals ✓
```

### Scenario B: Docker Unavailable (Fallback Mode)
```
1. Fetch OSS connectors via rpk connect
2. Analyze cloud binary → success
3. Analyze CGO binary → fails (Docker unavailable)
4. Detect CGO failure via !binaryAnalysis.cgoIndex ← FIX
5. Strip CGO/cloud connectors from old data for clean comparison
6. Generate diff: stripped old vs OSS-only new
Result: CGO connectors not in either → no false removals ✓
```

## Test Results

### Before Fix (Docker Unavailable)
❌ **4 false removals**
```
Summary:
- 1 new connector (string_split)
- 4 removed connectors (FALSE POSITIVES):
  • tigerbeetle_cdc (inputs)
  • zmq4 (inputs)
  • zmq4 (outputs)
  • ffi (processors)
```

### After Fix: Scenario A (Docker Working)
✅ **0 removed components**
```
Done: Cgo analysis complete: 4 cgo-only connectors found
   cgo-only connectors:
   • inputs/tigerbeetle_cdc (stable)
   • inputs/zmq4 (stable)
   • outputs/zmq4 (stable)
   • processors/ffi (stable)

Augmented 301 connectors with cloud/cgo fields
✓ Reloaded newIndex with augmented data for diff comparison

Summary:
- 1 new connector (string_split)
- 0 removed connectors ✓
```

### After Fix: Scenario B (Docker Unavailable)
✅ **0 removed components**
```
Warning: Cgo analysis failed: Binary exited with code 1
⚠️  Binary analysis unavailable - stripping CGO/cloud metadata
   • Stripped 2 CGO/cloud connectors from inputs
   • Stripped 1 CGO/cloud connectors from outputs
   • Stripped 2 CGO/cloud connectors from processors
   ✓ Total stripped: 5 CGO/cloud connectors

Summary:
- 1 new connector (string_split)
- 0 removed connectors ✓
```

## Files Modified

1. **tools/redpanda-connect/report-delta.js**
   - Unified diff approach with platform metadata preservation
   - Platform transition detection

2. **tools/redpanda-connect/rpcn-connector-docs-handler.js**
   - Reload newIndex after augmentation
   - Improved CGO failure detection
   - Fallback stripping logic

## Related PRs

- **rp-connect-docs #407**: Adds `GITHUB_TOKEN` to workflow for binary analysis authentication

## Why CGO Analysis Might Fail

CGO binaries are linux/amd64 and require:
- **Docker** on non-Linux systems (macOS/Windows)
- **libzmq5** library installation in container

The code auto-detects the OS and uses Docker when needed. If Docker is unavailable, the fallback ensures clean diffs without false removals.

## Testing

Tested with version 4.85.0 → 4.86.0:
- ✅ Docker working: Full CGO analysis succeeds
- ✅ Docker unavailable: Fallback prevents false removals
- ✅ New connectors detected correctly (string_split)
- ✅ No false "removed" reports in either scenario
