### PR TITLE
Improve agent-friendly docs compliance

### DIFF
--- a/extension-utils/llms-utils.js
+++ b/extension-utils/llms-utils.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * Shared utilities for llms.txt generation and markdown processing.
+ * Used by both convert-to-markdown.js and convert-llms-to-txt.js.
+ */
+
+/**
+ * The base directive text that appears in markdown files pointing to llms.txt.
+ * This is the canonical source of truth used for both rendering and stripping.
+ */
+const LLMS_DIRECTIVE_BASE = 'For the complete documentation index, see [llms.txt](/llms.txt)';
+
+/**
+ * Format the llms directive blockquote for a page.
+ * @param {string} componentName - Optional component name for component-specific link
+ * @returns {string} Formatted markdown blockquote directive
+ */
+function formatLlmsDirective(componentName) {
+  if (componentName) {
+    return `> ${LLMS_DIRECTIVE_BASE}. Component-specific: [${componentName}-full.txt](/${componentName}-full.txt)`;
+  }
+  return `> ${LLMS_DIRECTIVE_BASE}`;
+}
+
+/**
+ * Regex pattern to match and strip the llms directive from markdown content.
+ * Matches the blockquote format with optional component-specific suffix.
+ */
+const LLMS_DIRECTIVE_REGEX = /^> For the complete documentation index, see \[llms\.txt\].*$/gm;
+
+/**
+ * Regex pattern to match and strip HTML source comments from markdown content.
+ */
+const SOURCE_COMMENT_REGEX = /^<!--[\s\S]*?-->\s*/gm;
+
+/**
+ * Strip metadata added by convert-to-markdown extension from page content.
+ * This removes:
+ * 1. HTML comments (source URLs)
+ * 2. llms.txt directive blockquotes (redundant in aggregated exports)
+ *
+ * @param {string|Buffer} content - The markdown content to strip
+ * @returns {string} Cleaned markdown content
+ */
+function stripMarkdownMetadata(content) {
+  let text = typeof content === 'string' ? content : content.toString('utf8');
+
+  // Strip HTML comments (source URLs)
+  text = text.replace(SOURCE_COMMENT_REGEX, '');
+
+  // Strip llms.txt directive blockquotes
+  text = text.replace(LLMS_DIRECTIVE_REGEX, '');
+
+  return text.trim();
+}
+
+module.exports = {
+  LLMS_DIRECTIVE_BASE,
+  LLMS_DIRECTIVE_REGEX,
+  SOURCE_COMMENT_REGEX,
+  formatLlmsDirective,
+  stripMarkdownMetadata,
+};

--- a/extensions/convert-llms-to-txt.js
+++ b/extensions/convert-llms-to-txt.js
@@ -33,6 +33,8 @@ module.exports.register = function () {
       siteUrl = playbook.site?.url || 'https://docs.redpanda.com';
       logger.info(`Using site URL: ${siteUrl}`);
     }
+    // Normalize: strip trailing slashes to avoid double slashes in URL concatenation
+    siteUrl = siteUrl.replace(/\/+$/, '');
   });
 
   this.on('contentClassified', ({ contentCatalog }) => {
@@ -284,7 +286,8 @@ module.exports.register = function () {
       // Check if base content already exceeds limit
       if (llmsTxtContent.length >= MAX_LLMS_TXT_CHARS) {
         logger.warn(`Base llms.txt content (${llmsTxtContent.length} chars) exceeds ${MAX_LLMS_TXT_CHARS} char limit, truncating`);
-        llmsTxtContent = llmsTxtContent.slice(0, MAX_LLMS_TXT_CHARS - 100) + '\n\n[Content truncated due to size limits]';
+        // Truncate at last newline before limit to avoid cutting mid-line or mid-URL
+        llmsTxtContent = truncateAtNewline(llmsTxtContent, MAX_LLMS_TXT_CHARS - 100) + '\n\n[Content truncated due to size limits]';
       }
 
       // Generate navigation section with component sitemaps and key sections
@@ -298,8 +301,8 @@ module.exports.register = function () {
         llmsTxtContent = llmsTxtContent + '\n\n' + navSection;
         logger.info(`Injected full navigation section (${navSection.length} chars)`);
       } else if (availableSpace > 500) {
-        // Partial navigation section - truncate but include what we can
-        const truncatedNav = navSection.slice(0, availableSpace - 50) + '\n\n[Navigation truncated due to size limits]';
+        // Partial navigation section - truncate at last newline to avoid cutting mid-line or mid-URL
+        const truncatedNav = truncateAtNewline(navSection, availableSpace - 50) + '\n\n[Navigation truncated due to size limits]';
         llmsTxtContent = llmsTxtContent + '\n\n' + truncatedNav;
         logger.warn(`Truncated navigation section from ${navSection.length} to ${truncatedNav.length} chars`);
       } else {
@@ -565,8 +568,33 @@ function addLastmodToComponentSitemaps(contentCatalog, siteCatalog, sitemapIndex
 }
 
 /**
+ * Truncate content at the last newline before the specified limit.
+ * This avoids cutting mid-line or mid-URL which would produce malformed output.
+ *
+ * @param {string} content - Content to truncate
+ * @param {number} maxLength - Maximum length
+ * @returns {string} Truncated content ending at a newline boundary
+ */
+function truncateAtNewline(content, maxLength) {
+  if (content.length <= maxLength) {
+    return content;
+  }
+  const truncated = content.slice(0, maxLength);
+  const lastNewline = truncated.lastIndexOf('\n');
+  if (lastNewline > 0) {
+    return truncated.slice(0, lastNewline);
+  }
+  // Fallback: no newline found, return as-is
+  return truncated;
+}
+
+/**
  * Generate a comprehensive navigation section for llms.txt
  * This improves llms-txt-freshness score by providing pathways to all documentation
+ *
+ * NOTE: The section URLs below are hardcoded. If pages are renamed, moved, or removed,
+ * these links will 404. When restructuring documentation, update these URLs accordingly.
+ * Future improvement: Generate these from the content catalog at build time.
  *
  * @param {string} siteUrl - Base site URL
  * @returns {string} Markdown navigation section

--- a/extensions/convert-llms-to-txt.js
+++ b/extensions/convert-llms-to-txt.js
@@ -71,10 +71,13 @@ module.exports.register = function () {
         let content = llmsPage.markdownContents.toString('utf8');
         logger.info(`Extracted ${content.length} bytes of markdown content`);
 
-        // Strip HTML comments added by convert-to-markdown extension
+        // Strip metadata added by convert-to-markdown extension
         // These reference the unpublished /home/llms/ URL which doesn't make sense for llms.txt
+        // 1. Strip HTML comments (source URLs)
         content = content.replace(/^<!--[\s\S]*?-->\s*/gm, '').trim();
-        logger.debug(`Stripped HTML comments, now ${content.length} bytes`);
+        // 2. Strip llms.txt directive blockquotes (these point to this file, which is redundant)
+        content = content.replace(/^> For the complete documentation index, see \[llms\.txt\].*$/gm, '').trim();
+        logger.debug(`Stripped metadata, now ${content.length} bytes`);
 
         // Fix URLs: convert em dashes back to double hyphens and remove invisible characters
         // The markdown converter applies smart typography that turns -- into — (em dash)
@@ -274,8 +277,26 @@ module.exports.register = function () {
     if (llmsPage && llmsPage.llmsTxtContent) {
       logger.info('Adding llms.txt to site root');
 
+      // Inject comprehensive navigation section for better coverage
+      // Target: Stay under 50K chars (agent-friendly docs spec limit)
+      const MAX_LLMS_TXT_CHARS = 45000; // Leave buffer below 50K
+      let llmsTxtContent = llmsPage.llmsTxtContent;
+
+      // Generate navigation section with component sitemaps and key sections
+      const navSection = generateNavigationSection(components, siteUrl);
+
+      // Only inject if we're under the limit
+      if (llmsTxtContent.length + navSection.length < MAX_LLMS_TXT_CHARS) {
+        llmsTxtContent = llmsTxtContent + '\n\n' + navSection;
+        logger.info(`Injected navigation section (${navSection.length} chars)`);
+      } else {
+        logger.warn(`Skipping navigation injection - would exceed ${MAX_LLMS_TXT_CHARS} char limit`);
+      }
+
+      logger.info(`Final llms.txt size: ${llmsTxtContent.length} chars`);
+
       siteCatalog.addFile({
-        contents: Buffer.from(llmsPage.llmsTxtContent, 'utf8'),
+        contents: Buffer.from(llmsTxtContent, 'utf8'),
         out: { path: 'llms.txt' },
       });
       logger.info('Successfully added llms.txt');
@@ -528,4 +549,58 @@ function addLastmodToComponentSitemaps(contentCatalog, siteCatalog, sitemapIndex
   });
 
   return sitemapIndexXml;
+}
+
+/**
+ * Generate a comprehensive navigation section for llms.txt
+ * This improves llms-txt-freshness score by providing pathways to all documentation
+ *
+ * @param {Array} components - Antora components with their metadata
+ * @param {string} siteUrl - Base site URL
+ * @returns {string} Markdown navigation section
+ */
+function generateNavigationSection(components, siteUrl) {
+  let nav = `## Complete documentation index\n\n`;
+  nav += `For comprehensive page listings, use the sitemaps:\n\n`;
+  nav += `- [sitemap.md](${siteUrl}/sitemap.md) - Main sitemap index with all documentation\n`;
+  nav += `- [sitemap-all.md](${siteUrl}/sitemap-all.md) - Combined listing of all ${components.reduce((sum, c) => sum + (c.latest?.pages?.length || 0), 0).toLocaleString()}+ pages\n\n`;
+
+  nav += `### Component sitemaps\n\n`;
+
+  // Add component-specific sitemaps
+  const componentSitemaps = [
+    { name: 'ROOT', title: 'Redpanda Self-Managed', path: 'sitemap-ROOT.md' },
+    { name: 'redpanda-cloud', title: 'Redpanda Cloud', path: 'sitemap-redpanda-cloud.md' },
+    { name: 'redpanda-connect', title: 'Redpanda Connect', path: 'sitemap-redpanda-connect.md' },
+    { name: 'redpanda-labs', title: 'Redpanda Labs', path: 'sitemap-redpanda-labs.md' },
+  ];
+
+  for (const sitemap of componentSitemaps) {
+    const component = components.find(c => c.name === sitemap.name);
+    const pageCount = component?.latest?.pages?.length || 'many';
+    nav += `- [${sitemap.title}](${siteUrl}/${sitemap.path}) - ${pageCount} pages\n`;
+  }
+
+  nav += `\n### Key documentation sections\n\n`;
+  nav += `**Self-Managed:**\n`;
+  nav += `- [Deploy](${siteUrl}/current/deploy.md) - Installation and deployment guides\n`;
+  nav += `- [Manage](${siteUrl}/current/manage.md) - Cluster operations and administration\n`;
+  nav += `- [Develop](${siteUrl}/current/develop.md) - Application development guides\n`;
+  nav += `- [Reference](${siteUrl}/current/reference.md) - Configuration, CLI, and API references\n`;
+  nav += `- [Upgrade](${siteUrl}/current/upgrade.md) - Version upgrade procedures\n`;
+  nav += `- [Troubleshoot](${siteUrl}/current/troubleshoot.md) - Debugging and issue resolution\n`;
+
+  nav += `\n**Cloud:**\n`;
+  nav += `- [Get Started](${siteUrl}/redpanda-cloud/get-started.md) - Cloud quickstart and cluster types\n`;
+  nav += `- [Manage](${siteUrl}/redpanda-cloud/manage.md) - Cloud cluster management\n`;
+  nav += `- [Networking](${siteUrl}/redpanda-cloud/networking.md) - Network configuration\n`;
+  nav += `- [Security](${siteUrl}/redpanda-cloud/security.md) - Authentication and authorization\n`;
+  nav += `- [AI Agents](${siteUrl}/redpanda-cloud/ai-agents.md) - Agentic Data Plane documentation\n`;
+
+  nav += `\n**Connect:**\n`;
+  nav += `- [Components](${siteUrl}/redpanda-connect/components.md) - All connectors, processors, and more\n`;
+  nav += `- [Guides](${siteUrl}/redpanda-connect/guides.md) - Integration tutorials\n`;
+  nav += `- [Configuration](${siteUrl}/redpanda-connect/configuration.md) - YAML configuration reference\n`;
+
+  return nav;
 }

--- a/extensions/convert-llms-to-txt.js
+++ b/extensions/convert-llms-to-txt.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { toMarkdownUrl } = require('../extension-utils/url-utils');
+const { stripMarkdownMetadata } = require('../extension-utils/llms-utils');
 
 /**
  * Extracts markdown from llms.adoc page and generates AI-friendly documentation exports.
@@ -71,12 +72,9 @@ module.exports.register = function () {
         let content = llmsPage.markdownContents.toString('utf8');
         logger.info(`Extracted ${content.length} bytes of markdown content`);
 
-        // Strip metadata added by convert-to-markdown extension
+        // Strip metadata added by convert-to-markdown extension using shared helper
         // These reference the unpublished /home/llms/ URL which doesn't make sense for llms.txt
-        // 1. Strip HTML comments (source URLs)
-        content = content.replace(/^<!--[\s\S]*?-->\s*/gm, '').trim();
-        // 2. Strip llms.txt directive blockquotes (these point to this file, which is redundant)
-        content = content.replace(/^> For the complete documentation index, see \[llms\.txt\].*$/gm, '').trim();
+        content = stripMarkdownMetadata(content);
         logger.debug(`Stripped metadata, now ${content.length} bytes`);
 
         // Fix URLs: convert em dashes back to double hyphens and remove invisible characters
@@ -190,7 +188,8 @@ module.exports.register = function () {
       fullContent += `# Page ${index + 1}: ${pageTitle}\n\n`;
       fullContent += `**URL**: ${pageUrl}\n\n`;
       fullContent += `---\n\n`;
-      fullContent += page.markdownContents.toString('utf8');
+      // Strip metadata (directive, source comments) from page content
+      fullContent += stripMarkdownMetadata(page.markdownContents);
       fullContent += `\n\n---\n\n`;
     });
 
@@ -261,7 +260,8 @@ module.exports.register = function () {
         componentContent += `# Page ${index + 1}: ${pageTitle}\n\n`;
         componentContent += `**URL**: ${pageUrl}\n\n`;
         componentContent += `---\n\n`;
-        componentContent += page.markdownContents.toString('utf8');
+        // Strip metadata (directive, source comments) from page content
+        componentContent += stripMarkdownMetadata(page.markdownContents);
         componentContent += `\n\n---\n\n`;
       });
 
@@ -277,20 +277,33 @@ module.exports.register = function () {
     if (llmsPage && llmsPage.llmsTxtContent) {
       logger.info('Adding llms.txt to site root');
 
-      // Inject comprehensive navigation section for better coverage
       // Target: Stay under 50K chars (agent-friendly docs spec limit)
       const MAX_LLMS_TXT_CHARS = 45000; // Leave buffer below 50K
       let llmsTxtContent = llmsPage.llmsTxtContent;
 
-      // Generate navigation section with component sitemaps and key sections
-      const navSection = generateNavigationSection(components, siteUrl);
+      // Check if base content already exceeds limit
+      if (llmsTxtContent.length >= MAX_LLMS_TXT_CHARS) {
+        logger.warn(`Base llms.txt content (${llmsTxtContent.length} chars) exceeds ${MAX_LLMS_TXT_CHARS} char limit, truncating`);
+        llmsTxtContent = llmsTxtContent.slice(0, MAX_LLMS_TXT_CHARS - 100) + '\n\n[Content truncated due to size limits]';
+      }
 
-      // Only inject if we're under the limit
-      if (llmsTxtContent.length + navSection.length < MAX_LLMS_TXT_CHARS) {
+      // Generate navigation section with component sitemaps and key sections
+      const navSection = generateNavigationSection(siteUrl);
+
+      // Calculate available space for navigation section
+      const availableSpace = MAX_LLMS_TXT_CHARS - llmsTxtContent.length - 2; // -2 for \n\n separator
+
+      if (availableSpace >= navSection.length) {
+        // Full navigation section fits
         llmsTxtContent = llmsTxtContent + '\n\n' + navSection;
-        logger.info(`Injected navigation section (${navSection.length} chars)`);
+        logger.info(`Injected full navigation section (${navSection.length} chars)`);
+      } else if (availableSpace > 500) {
+        // Partial navigation section - truncate but include what we can
+        const truncatedNav = navSection.slice(0, availableSpace - 50) + '\n\n[Navigation truncated due to size limits]';
+        llmsTxtContent = llmsTxtContent + '\n\n' + truncatedNav;
+        logger.warn(`Truncated navigation section from ${navSection.length} to ${truncatedNav.length} chars`);
       } else {
-        logger.warn(`Skipping navigation injection - would exceed ${MAX_LLMS_TXT_CHARS} char limit`);
+        logger.warn(`Skipping navigation injection - only ${availableSpace} chars available`);
       }
 
       logger.info(`Final llms.txt size: ${llmsTxtContent.length} chars`);
@@ -555,31 +568,20 @@ function addLastmodToComponentSitemaps(contentCatalog, siteCatalog, sitemapIndex
  * Generate a comprehensive navigation section for llms.txt
  * This improves llms-txt-freshness score by providing pathways to all documentation
  *
- * @param {Array} components - Antora components with their metadata
  * @param {string} siteUrl - Base site URL
  * @returns {string} Markdown navigation section
  */
-function generateNavigationSection(components, siteUrl) {
+function generateNavigationSection(siteUrl) {
   let nav = `## Complete documentation index\n\n`;
   nav += `For comprehensive page listings, use the sitemaps:\n\n`;
   nav += `- [sitemap.md](${siteUrl}/sitemap.md) - Main sitemap index with all documentation\n`;
-  nav += `- [sitemap-all.md](${siteUrl}/sitemap-all.md) - Combined listing of all ${components.reduce((sum, c) => sum + (c.latest?.pages?.length || 0), 0).toLocaleString()}+ pages\n\n`;
+  nav += `- [sitemap-all.md](${siteUrl}/sitemap-all.md) - Combined listing of all documentation pages\n\n`;
 
   nav += `### Component sitemaps\n\n`;
-
-  // Add component-specific sitemaps
-  const componentSitemaps = [
-    { name: 'ROOT', title: 'Redpanda Self-Managed', path: 'sitemap-ROOT.md' },
-    { name: 'redpanda-cloud', title: 'Redpanda Cloud', path: 'sitemap-redpanda-cloud.md' },
-    { name: 'redpanda-connect', title: 'Redpanda Connect', path: 'sitemap-redpanda-connect.md' },
-    { name: 'redpanda-labs', title: 'Redpanda Labs', path: 'sitemap-redpanda-labs.md' },
-  ];
-
-  for (const sitemap of componentSitemaps) {
-    const component = components.find(c => c.name === sitemap.name);
-    const pageCount = component?.latest?.pages?.length || 'many';
-    nav += `- [${sitemap.title}](${siteUrl}/${sitemap.path}) - ${pageCount} pages\n`;
-  }
+  nav += `- [Redpanda Self-Managed](${siteUrl}/sitemap-ROOT.md)\n`;
+  nav += `- [Redpanda Cloud](${siteUrl}/sitemap-redpanda-cloud.md)\n`;
+  nav += `- [Redpanda Connect](${siteUrl}/sitemap-redpanda-connect.md)\n`;
+  nav += `- [Redpanda Labs](${siteUrl}/sitemap-redpanda-labs.md)\n`;
 
   nav += `\n### Key documentation sections\n\n`;
   nav += `**Self-Managed:**\n`;

--- a/extensions/convert-to-markdown.js
+++ b/extensions/convert-to-markdown.js
@@ -500,17 +500,20 @@ module.exports.register = function () {
             restOfMarkdown = markdown.substring(h1Match[0].length).trimStart()
           }
 
-          // Add frontmatter AFTER H1 heading, then source reference and AI-friendly note
+          // Structure: H1 → llms.txt directive (blockquote) → frontmatter → source → content
+          // The directive must appear near the top for agent-friendly docs spec compliance
           if (canonicalUrl) {
             const componentName = page.src?.component || '';
-            const urlHint = componentName
-              ? `<!-- Note for AI: This is a Markdown export. For aggregated content, see /llms.txt (curated overview), /${componentName}-full.txt (this component only), or /llms-full.txt (complete documentation). -->`
-              : `<!-- Note for AI: This is a Markdown export. For aggregated content, see /llms.txt (curated overview) or /llms-full.txt (complete documentation). -->`;
+            // Use markdown blockquote format for the directive (visible, can be hidden with CSS)
+            const llmsDirective = componentName
+              ? `> For the complete documentation index, see [llms.txt](/llms.txt). Component-specific: [${componentName}-full.txt](/${componentName}-full.txt)`
+              : `> For the complete documentation index, see [llms.txt](/llms.txt)`;
 
-            markdown = `${h1Heading}\n${frontmatter}<!-- Source: ${canonicalUrl} -->\n${urlHint}\n\n${restOfMarkdown}`
+            markdown = `${h1Heading}\n${llmsDirective}\n\n${frontmatter}<!-- Source: ${canonicalUrl} -->\n\n${restOfMarkdown}`
           } else if (frontmatter) {
-            // If no canonical URL but we have frontmatter, still add it after H1
-            markdown = `${h1Heading}\n${frontmatter}${restOfMarkdown}`
+            // If no canonical URL but we have frontmatter, still add directive after H1
+            const llmsDirective = `> For the complete documentation index, see [llms.txt](/llms.txt)`;
+            markdown = `${h1Heading}\n${llmsDirective}\n\n${frontmatter}${restOfMarkdown}`
           }
 
           // Clean up unnecessary whitespace

--- a/extensions/convert-to-markdown.js
+++ b/extensions/convert-to-markdown.js
@@ -2,6 +2,7 @@ const path = require('path')
 const os = require('os')
 const yaml = require('js-yaml')
 const { toMarkdownUrl } = require('../extension-utils/url-utils')
+const { formatLlmsDirective } = require('../extension-utils/llms-utils')
 const TurndownService = require('turndown')
 const turndownPluginGfm = require('turndown-plugin-gfm')
 const { gfm } = turndownPluginGfm
@@ -505,14 +506,12 @@ module.exports.register = function () {
           if (canonicalUrl) {
             const componentName = page.src?.component || '';
             // Use markdown blockquote format for the directive (visible, can be hidden with CSS)
-            const llmsDirective = componentName
-              ? `> For the complete documentation index, see [llms.txt](/llms.txt). Component-specific: [${componentName}-full.txt](/${componentName}-full.txt)`
-              : `> For the complete documentation index, see [llms.txt](/llms.txt)`;
+            const llmsDirective = formatLlmsDirective(componentName);
 
             markdown = `${h1Heading}\n${llmsDirective}\n\n${frontmatter}<!-- Source: ${canonicalUrl} -->\n\n${restOfMarkdown}`
           } else if (frontmatter) {
             // If no canonical URL but we have frontmatter, still add directive after H1
-            const llmsDirective = `> For the complete documentation index, see [llms.txt](/llms.txt)`;
+            const llmsDirective = formatLlmsDirective();
             markdown = `${h1Heading}\n${llmsDirective}\n\n${frontmatter}${restOfMarkdown}`
           }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.15.8",
+  "version": "4.15.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.15.8",
+      "version": "4.15.10",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.15.8",
+  "version": "4.15.10",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/property-extractor/property_extractor.py
+++ b/tools/property-extractor/property_extractor.py
@@ -2143,7 +2143,8 @@ def resolve_type_and_default(properties, definitions):
                 if resolved_type == "enum" or "enum" in resolved:
                     # Enums are represented as strings with an enum constraint in JSON Schema
                     prop["type"] = "string"
-                    if "enum" in resolved:
+                    # Only set enum if not already set by an override (accepted_values)
+                    if "enum" in resolved and "enum" not in prop:
                         prop["enum"] = resolved["enum"]
                 elif resolved_type in ("object", "string", "integer", "boolean", "array", "number"):
                     prop["type"] = resolved_type

--- a/tools/property-extractor/transformers.py
+++ b/tools/property-extractor/transformers.py
@@ -2483,8 +2483,10 @@ class RuntimeValidationEnumExtractor:
         )
 
         if enum_results:
-            # Extract just the values for the enum field
-            property["enum"] = [result["value"] for result in enum_results]
+            # Skip if enum was already set by an override (accepted_values)
+            if "enum" not in property:
+                # Extract just the values for the enum field
+                property["enum"] = [result["value"] for result in enum_results]
 
             # Add metadata about which enum values are enterprise-only
             enum_metadata = {}


### PR DESCRIPTION
## Summary

Improves compliance with the [Agent-Friendly Docs spec](https://agentdocsspec.com/spec/) to make our documentation more accessible to AI agents.

### Changes

**llms-txt Directive (`convert-to-markdown.js`):**
- Move directive to appear immediately after H1 heading (before frontmatter)
- Change from HTML comment to visible markdown blockquote format
- Follows spec recommendation: can be hidden with CSS while remaining accessible to agents

**Comprehensive Navigation (`convert-llms-to-txt.js`):**
- Inject navigation section programmatically into llms.txt
- Link to sitemap.md and component sitemaps for improved coverage
- Include key documentation section links
- Respect 45K character limit (buffer below 50K spec limit)

### Expected Improvements

| Check | Before | Expected After |
|-------|--------|----------------|
| llms-txt-directive | Warning (buried deep) | Pass (near top) |
| llms-txt-freshness | 10% | 80%+ (via sitemap links) |

### Related PR

- redpanda-data/docs-site#163

## Test plan

- [x] Build docs locally and verify llms.txt contains navigation section
- [x] Verify markdown files have blockquote directive near top
- [x] Run afdocs check on deploy preview