### PR TITLE
Bump version from PR 179

### DIFF
--- a/__tests__/tools/bundle-openapi.test.js
+++ b/__tests__/tools/bundle-openapi.test.js
@@ -548,7 +548,7 @@ components:
         expect(passwordSetAt.readOnly).toBe(true);
         expect(passwordSetAt['$ref']).toBeUndefined();
 
-        // Lone $ref should NOT be wrapped
+        // Regular schema definitions (no $ref) should remain unchanged
         const timestamp = result.components.schemas['google.protobuf.Timestamp'];
         expect(timestamp['$ref']).toBeUndefined();
         expect(timestamp.allOf).toBeUndefined();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.15.10",
+  "version": "4.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.15.10",
+      "version": "4.16.0",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.15.10",
+  "version": "4.16.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/bundle-openapi.js
+++ b/tools/bundle-openapi.js
@@ -279,7 +279,8 @@ function wrapRefSiblings(node) {
     const hasSiblings = keys.length > 1;
 
     if (hasSiblings) {
-      // Don't double-wrap if allOf already exists
+      // Skip if allOf already exists — assumes a pre-existing structure
+      // from the source spec that should not be modified.
       if (!node.allOf) {
         const ref = node['$ref'];
         delete node['$ref'];
@@ -578,7 +579,7 @@ function postProcessBundle(filePath, options, quiet = false) {
     bundle.info['x-generator'] = 'redpanda-docs-openapi-bundler';
 
     // Wrap $ref siblings into allOf so renderers display field descriptions
-    wrapRefSiblings(bundle);
+    bundle = wrapRefSiblings(bundle);
 
     // Sort keys for deterministic output
     const sortedBundle = sortObjectKeys(bundle);

--- a/tools/bundle-openapi.js
+++ b/tools/bundle-openapi.js
@@ -251,8 +251,9 @@ function createEntrypoint(tempDir, apiSurface) {
 /**
  * Wrap $ref siblings into allOf to preserve field-level descriptions.
  *
- * OpenAPI 3.1 renderers (e.g. Bump.sh) ignore sibling properties next to $ref
- * and instead display the generic description from the referenced schema.
+ * In OpenAPI 3.0, sibling properties next to $ref are ignored per spec.
+ * Some renderers (e.g. Bump.sh) follow this behavior, displaying the generic
+ * description from the referenced schema instead of field-level overrides.
  * This function transforms { $ref, description, ... } into
  * { allOf: [{ $ref }], description, ... } so renderers pick up field-level
  * descriptions correctly.


### PR DESCRIPTION
This pull request updates the OpenAPI bundling logic to improve compatibility with OpenAPI 3.0 renderers and ensure field-level descriptions are preserved when using `$ref` with sibling properties. It also bumps the package version to `4.16.0`. The most important changes are:

**OpenAPI $ref handling improvements:**

* Updated the documentation and logic in `wrapRefSiblings` to clarify that, per OpenAPI 3.0 spec, sibling properties next to `$ref` are ignored, and to ensure that only nodes without an existing `allOf` are wrapped, preserving the original structure when appropriate. [[1]](diffhunk://#diff-8b2eddb824f8c96b48b5cd207f0f013afbbe15ac531d543bec72bb4f36867558L254-R256) [[2]](diffhunk://#diff-8b2eddb824f8c96b48b5cd207f0f013afbbe15ac531d543bec72bb4f36867558L281-R283)
* Modified the bundling process so that the result of `wrapRefSiblings` is assigned back to the bundle, ensuring the transformation is applied.
* Improved test clarity by updating comments to reflect that regular schema definitions without `$ref` should remain unchanged.

**Version bump:**

* Increased the package version from `4.15.10` to `4.16.0` to reflect these changes.