### PR TITLE
fix: skip field-only pages in unlisted pages check

### DIFF
--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -38,7 +38,8 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
 
   // Select indexable pages
   const pages = contentCatalog.getPages((page) => {
-    if (!page.out || page.asciidoc?.attributes?.noindex != null) return
+    // Skip pages without output, noindex pages, and field-only pages (internal includes)
+    if (!page.out || page.asciidoc?.attributes?.noindex != null || page.isFieldOnlyPage) return
     return {}
   })
 

--- a/extensions/unlisted-pages.js
+++ b/extensions/unlisted-pages.js
@@ -20,6 +20,9 @@ module.exports.register = function ({ config }) {
               return collector; // Skip adding this page to the collector
             }
 
+            // Skip field-only pages (generated for includes, not standalone navigation)
+            if (page.isFieldOnlyPage) return collector;
+
             if (!(page.pub.url in navEntriesByUrl) && page.pub.url !== defaultUrl) {
               logger.warn({ file: page.src, source: page.src.origin }, 'detected unlisted page');
               return collector.concat(page);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.17.1",
+  "version": "4.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.17.1",
+      "version": "4.17.2",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.17.1",
+  "version": "4.17.2",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
## Summary
- Skip pages marked with `isFieldOnlyPage = true` in the unlisted-pages extension
- Eliminates noisy warnings for `/tmp/generated-fields-only/` paths during Antora builds
- These pages are intentionally not in navigation (they're internal includes, not standalone content)

## Test plan
- [x] All 370 tests pass
- [x] Build rp-connect-docs and verify no warnings for field-only pages