### PR TITLE
Add page-support-months attribute to EOL computation

### DIFF
--- a/extensions/compute-end-of-life.js
+++ b/extensions/compute-end-of-life.js
@@ -46,6 +46,7 @@ module.exports.register = function ({ config }) {
             'page-eol-date': eolInfo.eolDate,
             'page-eol-doc': eol_doc,
             'page-upgrade-doc': upgrade_doc,
+            'page-support-months': resolvedEOLMonths,
           });
         } else {
           logger.warn(`No release date found for component: ${componentName}. Make sure to set {page-release-date} in the antora.yml of the component version ${version}.`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.17.2",
+  "version": "4.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.17.2",
+      "version": "4.17.3",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.17.2",
+  "version": "4.17.3",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
## Summary
Adds `:page-support-months:` attribute to pages processed by the end-of-life (EOL) extension.

## Changes
- **compute-end-of-life.js**: Now includes `page-support-months` in the attributes set on each page, containing the configured support period in months
- **Version**: Bumped to 4.17.3

## Purpose
This attribute enables UI templates to display support duration information alongside EOL dates. For example, showing "18 months support" in version selectors or support badges.

## Usage
Once published, pages processed by the EOL extension will have:
- `:page-support-months:` - The configured support period (e.g., `18`)

## Related
- docs-ui: https://github.com/redpanda-data/docs-ui/pull/376