### PR TITLE
fix: augment intermediate diff data with binary analysis results

### DIFF
--- a/__tests__/macros/rp-connect-components.test.js
+++ b/__tests__/macros/rp-connect-components.test.js
@@ -6,33 +6,34 @@ describe('rp-connect-components macro', () => {
   describe('content catalog URL resolution', () => {
     // Test the URL resolution logic used for removed connectors
     test('resolves relative URL from connector page to whats-new page', () => {
-      // Simulate the path.relative calculation used in the macro
-      const currentPageUrl = '/redpanda-connect/components/inputs/salesforce/'
-      const whatsNewPageUrl = '/redpanda-connect/get-started/whats-new/'
+      // Simulate the path.relative calculation used in the macro (without path.dirname)
+      const currentPageUrl = '/connect/components/inputs/salesforce/'
+      const whatsNewPageUrl = '/connect/get-started/whats-new/'
 
-      const relativeUrl = path.relative(path.dirname(currentPageUrl), whatsNewPageUrl)
+      // For directory-style URLs, use the URL directly as the base
+      const relativeUrl = path.relative(currentPageUrl, whatsNewPageUrl)
 
-      // From /redpanda-connect/components/inputs/salesforce to /redpanda-connect/get-started/whats-new
-      // Should go up 3 levels (salesforce -> inputs -> components -> redpanda-connect) then down to get-started/whats-new
-      expect(relativeUrl).toBe('../../get-started/whats-new')
+      // From /connect/components/inputs/salesforce/ to /connect/get-started/whats-new
+      // Should go up 3 levels then down to get-started/whats-new
+      expect(relativeUrl).toBe('../../../get-started/whats-new')
     })
 
     test('resolves relative URL for cloud context', () => {
-      const currentPageUrl = '/redpanda-cloud/develop/connect/components/inputs/salesforce/'
-      const whatsNewPageUrl = '/redpanda-cloud/develop/connect/get-started/whats-new/'
+      const currentPageUrl = '/cloud-data-platform/develop/connect/components/inputs/salesforce/'
+      const whatsNewPageUrl = '/cloud-data-platform/get-started/whats-new-cloud/'
 
-      const relativeUrl = path.relative(path.dirname(currentPageUrl), whatsNewPageUrl)
+      const relativeUrl = path.relative(currentPageUrl, whatsNewPageUrl)
 
-      expect(relativeUrl).toBe('../../get-started/whats-new')
+      expect(relativeUrl).toBe('../../../../../get-started/whats-new-cloud')
     })
 
     test('handles nested processor pages', () => {
-      const currentPageUrl = '/redpanda-connect/components/processors/salesforce/'
-      const whatsNewPageUrl = '/redpanda-connect/get-started/whats-new/'
+      const currentPageUrl = '/connect/components/processors/salesforce/'
+      const whatsNewPageUrl = '/connect/get-started/whats-new/'
 
-      const relativeUrl = path.relative(path.dirname(currentPageUrl), whatsNewPageUrl)
+      const relativeUrl = path.relative(currentPageUrl, whatsNewPageUrl)
 
-      expect(relativeUrl).toBe('../../get-started/whats-new')
+      expect(relativeUrl).toBe('../../../get-started/whats-new')
     })
   })
 
@@ -69,19 +70,19 @@ describe('rp-connect-components macro', () => {
     test('generates correct page spec for self-managed context', () => {
       const isCloud = false
       const pageSpec = isCloud
-        ? 'redpanda-cloud:develop/connect/get-started:whats-new.adoc'
-        : 'redpanda-connect:get-started:whats-new.adoc'
+        ? 'cloud-data-platform:get-started:whats-new-cloud.adoc'
+        : 'connect:get-started:whats-new.adoc'
 
-      expect(pageSpec).toBe('redpanda-connect:get-started:whats-new.adoc')
+      expect(pageSpec).toBe('connect:get-started:whats-new.adoc')
     })
 
     test('generates correct page spec for cloud context', () => {
       const isCloud = true
       const pageSpec = isCloud
-        ? 'redpanda-cloud:develop/connect/get-started:whats-new.adoc'
-        : 'redpanda-connect:get-started:whats-new.adoc'
+        ? 'cloud-data-platform:get-started:whats-new-cloud.adoc'
+        : 'connect:get-started:whats-new.adoc'
 
-      expect(pageSpec).toBe('redpanda-cloud:develop/connect/get-started:whats-new.adoc')
+      expect(pageSpec).toBe('cloud-data-platform:get-started:whats-new-cloud.adoc')
     })
 
     test('falls back to hardcoded URL when contentCatalog unavailable', () => {
@@ -92,8 +93,8 @@ describe('rp-connect-components macro', () => {
       const isCloud = false
 
       let whatsNewUrl = isCloud
-        ? '/redpanda-cloud/develop/connect/get-started/whats-new/'
-        : '/redpanda-connect/get-started/whats-new/'
+        ? '/cloud-data-platform/get-started/whats-new-cloud/'
+        : '/connect/get-started/whats-new/'
 
       // Simulate the fallback logic
       if (context.contentCatalog && context.file) {
@@ -101,12 +102,12 @@ describe('rp-connect-components macro', () => {
         whatsNewUrl = '/resolved/url/'
       }
 
-      expect(whatsNewUrl).toBe('/redpanda-connect/get-started/whats-new/')
+      expect(whatsNewUrl).toBe('/connect/get-started/whats-new/')
     })
 
     test('uses resolved URL when contentCatalog available', () => {
       const mockPage = {
-        pub: { url: '/redpanda-connect/get-started/whats-new/' }
+        pub: { url: '/connect/get-started/whats-new/' }
       }
 
       const context = {
@@ -114,32 +115,32 @@ describe('rp-connect-components macro', () => {
           resolvePage: jest.fn(() => mockPage)
         },
         file: {
-          src: { component: 'redpanda-connect', module: 'components' },
-          pub: { url: '/redpanda-connect/components/processors/salesforce/' }
+          src: { component: 'connect', module: 'components' },
+          pub: { url: '/connect/components/processors/salesforce/' }
         }
       }
 
       const isCloud = false
       let whatsNewUrl = isCloud
-        ? '/redpanda-cloud/develop/connect/get-started/whats-new/'
-        : '/redpanda-connect/get-started/whats-new/'
+        ? '/cloud-data-platform/get-started/whats-new-cloud/'
+        : '/connect/get-started/whats-new/'
 
-      // Simulate the resolution logic
+      // Simulate the resolution logic (using direct URL, not dirname)
       if (context.contentCatalog && context.file) {
         const pageSpec = isCloud
-          ? 'redpanda-cloud:develop/connect/get-started:whats-new.adoc'
-          : 'redpanda-connect:get-started:whats-new.adoc'
+          ? 'cloud-data-platform:get-started:whats-new-cloud.adoc'
+          : 'connect:get-started:whats-new.adoc'
         const page = context.contentCatalog.resolvePage(pageSpec, context.file.src)
         if (page) {
-          whatsNewUrl = path.relative(path.dirname(context.file.pub.url), page.pub.url)
+          whatsNewUrl = path.relative(context.file.pub.url, page.pub.url)
         }
       }
 
       expect(context.contentCatalog.resolvePage).toHaveBeenCalledWith(
-        'redpanda-connect:get-started:whats-new.adoc',
-        { component: 'redpanda-connect', module: 'components' }
+        'connect:get-started:whats-new.adoc',
+        { component: 'connect', module: 'components' }
       )
-      expect(whatsNewUrl).toBe('../../get-started/whats-new')
+      expect(whatsNewUrl).toBe('../../../get-started/whats-new')
     })
   })
 })

--- a/__tests__/tools/pr-summary-formatter.test.js
+++ b/__tests__/tools/pr-summary-formatter.test.js
@@ -317,10 +317,10 @@ describe('PR Summary - Platform Detection', () => {
 
       // Should have both syntax examples
       expect(summary).toContain('For connectors in pages:');
-      expect(summary).toContain('include::redpanda-connect:components:page$type/connector-name.adoc[tag=single-source]');
+      expect(summary).toContain('include::connect:components:page$type/connector-name.adoc[tag=single-source]');
 
       expect(summary).toContain('For cloud-only connectors (in partials):');
-      expect(summary).toContain('include::redpanda-connect:components:partial$components/cloud-only/type/connector-name.adoc[tag=single-source]');
+      expect(summary).toContain('include::connect:components:partial$components/cloud-only/type/connector-name.adoc[tag=single-source]');
     });
   });
 

--- a/macros/rp-connect-components.js
+++ b/macros/rp-connect-components.js
@@ -1030,17 +1030,18 @@ module.exports.register = function (registry, context) {
         // Build link to release notes using content catalog for proper URL resolution
         const isCloud = attributes['env-cloud'] !== undefined;
         let whatsNewUrl = isCloud
-          ? '/redpanda-cloud/develop/connect/get-started/whats-new/'
-          : '/redpanda-connect/get-started/whats-new/';
+          ? '/cloud-data-platform/get-started/whats-new-cloud/'
+          : '/connect/get-started/whats-new/';
 
         // Try to resolve the page from the content catalog for accurate URLs
         if (context.contentCatalog && context.file) {
           const pageSpec = isCloud
-            ? 'redpanda-cloud:develop/connect/get-started:whats-new.adoc'
-            : 'redpanda-connect:get-started:whats-new.adoc';
+            ? 'cloud-data-platform:get-started:whats-new-cloud.adoc'
+            : 'connect:get-started:whats-new.adoc';
           const page = context.contentCatalog.resolvePage(pageSpec, context.file.src);
           if (page) {
-            whatsNewUrl = path.relative(path.dirname(context.file.pub.url), page.pub.url);
+            // For directory-style URLs like /a/b/c/, use the URL directly as the base
+            whatsNewUrl = path.relative(context.file.pub.url, page.pub.url);
           }
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/test-fields-only-playbook.yml
+++ b/test-fields-only-playbook.yml
@@ -1,6 +1,6 @@
 site:
   title: Test Fields-Only Extension
-  start_page: redpanda-connect::index.adoc
+  start_page: connect::index.adoc
   url: http://localhost:8080
 
 output:

--- a/tools/redpanda-connect/AUTOMATION.md
+++ b/tools/redpanda-connect/AUTOMATION.md
@@ -306,14 +306,14 @@ Brief summary of what this connector does.
 ====
 Common config::
 +
-include::redpanda-connect:components:partial$examples/inputs/connector_name.adoc[tag=common]
+include::connect:components:partial$examples/inputs/connector_name.adoc[tag=common]
 
 Advanced config::
 +
-include::redpanda-connect:components:partial$examples/inputs/connector_name.adoc[tag=advanced]
+include::connect:components:partial$examples/inputs/connector_name.adoc[tag=advanced]
 ====
 
-include::redpanda-connect:components:partial$fields/inputs/connector_name.adoc[]
+include::connect:components:partial$fields/inputs/connector_name.adoc[]
 
 // end::single-source[]
 ```
@@ -517,12 +517,12 @@ _No changes in this release_
 
 **For connectors in pages:**
 \```asciidoc
-include::redpanda-connect:components:page$type/name.adoc[tag=single-source]
+include::connect:components:page$type/name.adoc[tag=single-source]
 \```
 
 **For cloud-only connectors (in partials):**
 \```asciidoc
-include::redpanda-connect:components:partial$components/cloud-only/type/name.adoc[tag=single-source]
+include::connect:components:partial$components/cloud-only/type/name.adoc[tag=single-source]
 \```
 
 ### 🔧 Cgo Requirements

--- a/tools/redpanda-connect/pr-summary-formatter.js
+++ b/tools/redpanda-connect/pr-summary-formatter.js
@@ -101,12 +101,12 @@ function renderBloblangChanges(data, includeVersion = false) {
   lines.push('');
   lines.push('For methods, find the appropriate category section in `methods.adoc` and add:');
   lines.push('```asciidoc');
-  lines.push('include::redpanda-connect:partial$bloblang-methods/method_name.adoc[leveloffset=+2]');
+  lines.push('include::connect:partial$bloblang-methods/method_name.adoc[leveloffset=+2]');
   lines.push('```');
   lines.push('');
   lines.push('For functions, add to the Functions section in `functions.adoc`:');
   lines.push('```asciidoc');
-  lines.push('include::redpanda-connect:partial$bloblang-functions/function_name.adoc[leveloffset=+2]');
+  lines.push('include::connect:partial$bloblang-functions/function_name.adoc[leveloffset=+2]');
   lines.push('```');
   lines.push('');
   lines.push('**Note:** Partials are auto-generated. Includes must be added manually in alphabetical order within their section.');
@@ -700,7 +700,7 @@ function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = 
           lines.push('```asciidoc');
           lines.push('= Connector Name');
           lines.push('');
-          lines.push('include::redpanda-connect:components:page$type/connector-name.adoc[tag=single-source]');
+          lines.push('include::connect:components:page$type/connector-name.adoc[tag=single-source]');
           lines.push('```');
           lines.push('');
         }
@@ -710,7 +710,7 @@ function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = 
           lines.push('```asciidoc');
           lines.push('= Connector Name');
           lines.push('');
-          lines.push('include::redpanda-connect:components:partial$components/cloud-only/type/connector-name.adoc[tag=single-source]');
+          lines.push('include::connect:components:partial$components/cloud-only/type/connector-name.adoc[tag=single-source]');
           lines.push('```');
           lines.push('');
         }

--- a/tools/redpanda-connect/templates/bloblang-functions-overview.hbs
+++ b/tools/redpanda-connect/templates/bloblang-functions-overview.hbs
@@ -23,7 +23,7 @@ root.values_two = range(0, this.max, 2)
 ```
 {{#each functions}}
 
-include::redpanda-connect:components:partial$bloblang-functions/{{this}}.adoc[leveloffset=+1]
+include::connect:components:partial$bloblang-functions/{{this}}.adoc[leveloffset=+1]
 {{/each}}
 
 // end::single-source[]

--- a/tools/redpanda-connect/templates/bloblang-methods-overview.hbs
+++ b/tools/redpanda-connect/templates/bloblang-methods-overview.hbs
@@ -32,7 +32,7 @@ root.foo_two = this.(bar | baz).trim().replace_all("dog", "cat")
 == {{{toSentenceCase this.name}}}
 {{#each this.methods}}
 
-include::redpanda-connect:components:partial$bloblang-methods/{{this}}.adoc[leveloffset=+2]
+include::connect:components:partial$bloblang-methods/{{this}}.adoc[leveloffset=+2]
 {{/each}}
 {{/each}}
 

--- a/tools/redpanda-connect/templates/connector.hbs
+++ b/tools/redpanda-connect/templates/connector.hbs
@@ -47,11 +47,11 @@ You can either xref:install:prebuilt-binary.adoc[download a prebuilt cgo-enabled
 
 {{/if}}
 {{#if (or this.config.children children)}}
-include::redpanda-connect:components:partial$fields/{{typeDir}}/{{name}}.adoc[]
+include::connect:components:partial$fields/{{typeDir}}/{{name}}.adoc[]
 {{/if}}
 
 {{#if this.examples}}
-include::redpanda-connect:components:partial$examples/{{typeDir}}/{{name}}.adoc[]
+include::connect:components:partial$examples/{{typeDir}}/{{name}}.adoc[]
 {{/if}}
 
 


### PR DESCRIPTION
## Summary

This PR updates the Redpanda Connect documentation tooling to align with the docs-site restructure and fixes a URL resolution bug.

### Changes

1. **Component renames** - Updated Antora component references across macros, templates, and tooling:
   - `redpanda-connect` → `connect`
   - `redpanda-cloud` → `cloud-data-platform`
   - Cloud whats-new path: `whats-new.adoc` → `whats-new-cloud.adoc`

2. **URL resolution fix** - Fixed relative URL calculation in `macros/rp-connect-components.js` for removed connector notices. The previous code used `path.dirname()` on directory-style URLs (e.g., `/connect/components/inputs/salesforce/`), which stripped one level too many. Removed the `path.dirname()` call so relative paths resolve correctly.

3. **Version bump** - 5.0.0 → 5.0.1

### Files changed

- `macros/rp-connect-components.js` - URL resolution fix and component renames
- `__tests__/macros/rp-connect-components.test.js` - Updated test paths and expectations
- `tools/redpanda-connect/pr-summary-formatter.js` - Component renames in include directives
- `__tests__/tools/pr-summary-formatter.test.js` - Updated test expectations
- `tools/redpanda-connect/templates/*.hbs` - Component renames in Handlebars templates
- `tools/redpanda-connect/AUTOMATION.md` - Updated documentation references
- `test-fields-only-playbook.yml` - Updated start page reference
- `package.json` - Version bump

### Testing

- All 384 tests pass
- URL resolution verified manually with Node.js path calculations
- Netlify deploy preview available for visual verification

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>