### PR TITLE
Add unified navigation extension and update component references

### DIFF
--- a/__tests__/extensions/generate-fields-only-pages.test.js
+++ b/__tests__/extensions/generate-fields-only-pages.test.js
@@ -33,12 +33,12 @@ describe('generate-fields-only-pages extension', () => {
     extension.register.call(mockContext, {})
 
     expect(mockContentCatalog.findBy).toHaveBeenCalledWith({
-      component: 'redpanda-connect',
+      component: 'connect',
       version: 'master',
       module: 'components',
       family: 'attachment'
     })
-    expect(logger.warn).toHaveBeenCalledWith('No JSON attachment found in the components module of the redpanda-connect content catalog. Skipping field-only page generation.')
+    expect(logger.warn).toHaveBeenCalledWith('No JSON attachment found in the components module of the connect content catalog. Skipping field-only page generation.')
   })
 
   test('disables extension when enabled: false', () => {

--- a/__tests__/extensions/unified-navigation.test.js
+++ b/__tests__/extensions/unified-navigation.test.js
@@ -1,0 +1,343 @@
+const unifiedNavigationExtension = require('../../extensions/unified-navigation')
+
+describe('unified-navigation extension', () => {
+  let mockContext
+  let mockContentCatalog
+  let mockComponents
+  let mockPages
+  let extensionInstance
+
+  beforeEach(() => {
+    // Reset mocks
+    mockPages = []
+    mockComponents = []
+
+    mockContentCatalog = {
+      getComponents: jest.fn(() => mockComponents),
+      getPages: jest.fn(() => mockPages),
+      getComponent: jest.fn((name) => mockComponents.find(c => c.name === name)),
+    }
+
+    // Create extension instance with getLogger and on methods
+    extensionInstance = {
+      getLogger: jest.fn(() => ({
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      })),
+    }
+
+    const handlers = {}
+    extensionInstance.on = jest.fn((event, handler) => {
+      handlers[event] = handler
+    })
+
+    unifiedNavigationExtension.register.call(extensionInstance)
+
+    // Store handlers for testing
+    extensionInstance._handlers = handlers
+  })
+
+  describe('components without page-navigation', () => {
+    it('should not add custom navigation attributes', () => {
+      // Setup: component without page-navigation config
+      const page = {
+        src: { component: 'docs', version: 'master' },
+        asciidoc: { attributes: {} },
+        out: {},
+        pub: { url: '/docs/' },
+      }
+
+      mockPages.push(page)
+
+      const component = {
+        name: 'docs',
+        versions: [{
+          version: 'master',
+          navigation: [{ content: 'Overview', url: '/docs/' }],
+          asciidoc: {
+            attributes: {} // No page-navigation
+          },
+        }],
+      }
+
+      mockComponents.push(component)
+
+      // Execute navigationBuilt event
+      extensionInstance._handlers.navigationBuilt({ contentCatalog: mockContentCatalog })
+
+      // Assert: page should not have custom navigation
+      expect(page.asciidoc.attributes['page-custom-navigation']).toBeUndefined()
+      expect(page.asciidoc.attributes['page-has-custom-nav']).toBeUndefined()
+    })
+  })
+
+  describe('parent component with children', () => {
+    it('should show parent nav items outside buckets when component owns config', () => {
+      // Setup: data-platform with children
+      const dataPlatformPage = {
+        src: { component: 'data-platform', version: 'master' },
+        asciidoc: { attributes: {} },
+        out: {},
+        pub: { url: '/data-platform/' },
+      }
+
+      const mcpPage = {
+        src: { component: 'data-platform', version: 'master' },
+        asciidoc: { attributes: {} },
+        out: {},
+        pub: { url: '/data-platform/mcp/' },
+      }
+
+      mockPages.push(dataPlatformPage, mcpPage)
+
+      const dataPlatform = {
+        name: 'data-platform',
+        latestVersion: null, // Will be set below
+        versions: [{
+          version: 'master',
+          displayVersion: 'master',
+          url: '/data-platform/',
+          navigation: [
+            { content: 'Overview', url: '/data-platform/', urlType: 'internal' },
+            { content: 'Install MCP', url: '/data-platform/mcp/', urlType: 'internal' },
+          ],
+          asciidoc: {
+            attributes: {
+              'component-metadata': { title: 'Data Platform', color: '#5239CC', icon: 'stack-2' },
+              'page-navigation': `
+                - data-platform:
+                    - cloud-data-platform
+                    - self-managed:
+                        - streaming
+                        - connect
+              `,
+            },
+          },
+        }],
+      }
+      dataPlatform.latestVersion = dataPlatform.versions[0]
+
+      const cloudDataPlatform = {
+        name: 'cloud-data-platform',
+        latestVersion: null,
+        versions: [{
+          version: 'master',
+          displayVersion: 'master',
+          url: '/cloud/',
+          navigation: [{ content: 'Cloud Home', url: '/cloud/', urlType: 'internal' }],
+          asciidoc: { attributes: { 'component-metadata': { title: 'Cloud', color: '#blue', icon: 'cloud' } } },
+        }],
+      }
+      cloudDataPlatform.latestVersion = cloudDataPlatform.versions[0]
+
+      const selfManaged = {
+        name: 'self-managed',
+        latestVersion: null,
+        versions: [{
+          version: 'master',
+          displayVersion: 'master',
+          url: '/self-managed/',
+          navigation: [{ content: 'Self-Managed Home', url: '/self-managed/', urlType: 'internal' }],
+          asciidoc: { attributes: { 'component-metadata': { title: 'Self-Managed', color: '#red', icon: 'server' } } },
+        }],
+      }
+      selfManaged.latestVersion = selfManaged.versions[0]
+
+      mockComponents.push(dataPlatform, cloudDataPlatform, selfManaged)
+
+      // Execute
+      extensionInstance._handlers.navigationBuilt({ contentCatalog: mockContentCatalog })
+
+      // Assert: data-platform should have custom navigation
+      expect(dataPlatformPage.asciidoc.attributes['page-has-custom-nav']).toBe('true')
+
+      const customNav = JSON.parse(dataPlatformPage.asciidoc.attributes['page-custom-navigation'])
+
+      // First item should be parent's nav items with showNavItemsOnly
+      expect(customNav[0]).toHaveProperty('showNavItemsOnly', true)
+      expect(customNav[0].items).toHaveLength(2) // Overview + Install MCP
+      expect(customNav[0].items[0].content).toBe('Overview')
+
+      // Followed by child buckets
+      expect(customNav[1]).toHaveProperty('componentName', 'cloud-data-platform')
+      expect(customNav[2]).toHaveProperty('componentName', 'self-managed')
+    })
+  })
+
+  describe('child component navigation', () => {
+    it('should not duplicate nav items for components that inherit config', () => {
+      // Setup: self-managed page with its own config
+      const selfManagedPage = {
+        src: { component: 'self-managed', version: 'master' },
+        asciidoc: { attributes: {} },
+        out: {},
+        pub: { url: '/self-managed/' },
+      }
+
+      mockPages.push(selfManagedPage)
+
+      const selfManaged = {
+        name: 'self-managed',
+        latestVersion: { version: 'master' },
+        versions: [{
+          version: 'master',
+          navigation: [{ content: 'Self-Managed Home', url: '/self-managed/', urlType: 'internal' }],
+          asciidoc: {
+            attributes: {
+              'component-metadata': { title: 'Self-Managed', color: '#red', icon: 'server' },
+              'page-navigation': `
+                - self-managed:
+                    - streaming
+                    - connect
+              `,
+            },
+          },
+        }],
+      }
+
+      const streaming = {
+        name: 'streaming',
+        latestVersion: null,
+        versions: [{
+          version: 'master',
+          displayVersion: 'master',
+          url: '/streaming/',
+          navigation: [{ content: 'Streaming Docs', url: '/streaming/', urlType: 'internal' }],
+          asciidoc: { attributes: { 'component-metadata': { title: 'Streaming', color: '#green' } } },
+        }],
+      }
+      streaming.latestVersion = streaming.versions[0]
+
+      const connect = {
+        name: 'connect',
+        latestVersion: null,
+        versions: [{
+          version: 'master',
+          displayVersion: 'master',
+          url: '/connect/',
+          navigation: [{ content: 'Connect Docs', url: '/connect/', urlType: 'internal' }],
+          asciidoc: { attributes: { 'component-metadata': { title: 'Connect', color: '#purple' } } },
+        }],
+      }
+      connect.latestVersion = connect.versions[0]
+
+      mockComponents.push(selfManaged, streaming, connect)
+
+      // Execute
+      extensionInstance._handlers.navigationBuilt({ contentCatalog: mockContentCatalog })
+
+      // Assert
+      const customNav = JSON.parse(selfManagedPage.asciidoc.attributes['page-custom-navigation'])
+
+      // First item should be parent's nav items (self-managed owns its config)
+      expect(customNav[0]).toHaveProperty('showNavItemsOnly', true)
+      expect(customNav[0].items).toHaveLength(1)
+      expect(customNav[0].items[0].content).toBe('Self-Managed Home')
+
+      // Followed by only child buckets (streaming, connect), not self-managed bucket
+      expect(customNav).toHaveLength(3) // parent nav + 2 child buckets
+      expect(customNav[1].componentName).toBe('streaming')
+      expect(customNav[2].componentName).toBe('connect')
+
+      // Ensure no self-managed bucket that would duplicate the nav items
+      expect(customNav.some(item => item.componentName === 'self-managed')).toBe(false)
+    })
+  })
+
+  describe('unpublished page filtering', () => {
+    it('should filter unpublished pages from navigation', () => {
+      const page = {
+        src: { component: 'docs', version: 'master' },
+        asciidoc: { attributes: {} },
+        out: {},
+        pub: { url: '/docs/' },
+      }
+
+      // Page without out property (unpublished)
+      const unpublishedPage = {
+        src: { component: 'docs', version: 'master' },
+        asciidoc: { attributes: {} },
+        // No out property
+        pub: { url: '/docs/unpublished/' },
+      }
+
+      mockPages.push(page, unpublishedPage)
+
+      const component = {
+        name: 'docs',
+        latestVersion: null,
+        versions: [{
+          version: 'master',
+          displayVersion: 'master',
+          url: '/docs/',
+          navigation: [
+            { content: 'Published', url: '/docs/', urlType: 'internal' },
+            { content: 'Unpublished', url: '/docs/unpublished/', urlType: 'internal' },
+          ],
+          asciidoc: {
+            attributes: {
+              'component-metadata': { title: 'Docs', color: '#blue' },
+              'page-navigation': '- docs',
+            },
+          },
+        }],
+      }
+      component.latestVersion = component.versions[0]
+
+      mockComponents.push(component)
+
+      // Execute
+      extensionInstance._handlers.navigationBuilt({ contentCatalog: mockContentCatalog })
+
+      // Assert
+      const customNav = JSON.parse(page.asciidoc.attributes['page-custom-navigation'])
+      const bucket = customNav.find(item => item.componentName === 'docs')
+
+      // Should only have published page
+      expect(bucket.items).toHaveLength(1)
+      expect(bucket.items[0].content).toBe('Published')
+    })
+  })
+
+  describe('standalone components', () => {
+    it('should use standard Antora nav for standalone components without children', () => {
+      const page = {
+        src: { component: 'agentic-data-plane', version: 'master' },
+        asciidoc: { attributes: {} },
+        out: {},
+        pub: { url: '/agentic-data-plane/' },
+      }
+
+      mockPages.push(page)
+
+      const agenticDataPlane = {
+        name: 'agentic-data-plane',
+        latestVersion: null,
+        versions: [{
+          version: 'master',
+          displayVersion: 'master',
+          url: '/agentic-data-plane/',
+          navigation: [{ content: 'Agentic Home', url: '/agentic-data-plane/', urlType: 'internal' }],
+          asciidoc: {
+            attributes: {
+              'component-metadata': { title: 'Agentic Data Plane', color: '#orange' },
+              'page-navigation': '- agentic-data-plane', // Standalone, no children
+            },
+          },
+        }],
+      }
+      agenticDataPlane.latestVersion = agenticDataPlane.versions[0]
+
+      mockComponents.push(agenticDataPlane)
+
+      // Execute
+      extensionInstance._handlers.navigationBuilt({ contentCatalog: mockContentCatalog })
+
+      // Assert: standalone components should not get custom navigation
+      expect(page.asciidoc.attributes['page-custom-navigation']).toBeUndefined()
+      expect(page.asciidoc.attributes['page-has-custom-nav']).toBeUndefined()
+    })
+  })
+})

--- a/__tests__/extensions/unified-navigation.test.js
+++ b/__tests__/extensions/unified-navigation.test.js
@@ -248,14 +248,23 @@ describe('unified-navigation extension', () => {
 
   describe('unpublished page filtering', () => {
     it('should filter unpublished pages from navigation', () => {
-      const page = {
+      // Parent page
+      const parentPage = {
+        src: { component: 'parent', version: 'master' },
+        asciidoc: { attributes: {} },
+        out: {},
+        pub: { url: '/parent/' },
+      }
+
+      // Published child page
+      const childPage = {
         src: { component: 'docs', version: 'master' },
         asciidoc: { attributes: {} },
         out: {},
         pub: { url: '/docs/' },
       }
 
-      // Page without out property (unpublished)
+      // Unpublished child page (no out property)
       const unpublishedPage = {
         src: { component: 'docs', version: 'master' },
         asciidoc: { attributes: {} },
@@ -263,9 +272,27 @@ describe('unified-navigation extension', () => {
         pub: { url: '/docs/unpublished/' },
       }
 
-      mockPages.push(page, unpublishedPage)
+      mockPages.push(parentPage, childPage, unpublishedPage)
 
-      const component = {
+      const parent = {
+        name: 'parent',
+        latestVersion: null,
+        versions: [{
+          version: 'master',
+          displayVersion: 'master',
+          url: '/parent/',
+          navigation: [{ content: 'Parent Home', url: '/parent/', urlType: 'internal' }],
+          asciidoc: {
+            attributes: {
+              'component-metadata': { title: 'Parent', color: '#purple' },
+              'page-navigation': '- parent:\n    - docs',
+            },
+          },
+        }],
+      }
+      parent.latestVersion = parent.versions[0]
+
+      const docs = {
         name: 'docs',
         latestVersion: null,
         versions: [{
@@ -279,20 +306,19 @@ describe('unified-navigation extension', () => {
           asciidoc: {
             attributes: {
               'component-metadata': { title: 'Docs', color: '#blue' },
-              'page-navigation': '- docs',
             },
           },
         }],
       }
-      component.latestVersion = component.versions[0]
+      docs.latestVersion = docs.versions[0]
 
-      mockComponents.push(component)
+      mockComponents.push(parent, docs)
 
       // Execute
       extensionInstance._handlers.navigationBuilt({ contentCatalog: mockContentCatalog })
 
-      // Assert
-      const customNav = JSON.parse(page.asciidoc.attributes['page-custom-navigation'])
+      // Assert: Check parent page has custom navigation
+      const customNav = JSON.parse(parentPage.asciidoc.attributes['page-custom-navigation'])
       const bucket = customNav.find(item => item.componentName === 'docs')
 
       // Should only have published page

--- a/__tests__/macros/rp-connect-components.test.js
+++ b/__tests__/macros/rp-connect-components.test.js
@@ -1,0 +1,145 @@
+'use strict'
+
+const { posix: path } = require('path')
+
+describe('rp-connect-components macro', () => {
+  describe('content catalog URL resolution', () => {
+    // Test the URL resolution logic used for removed connectors
+    test('resolves relative URL from connector page to whats-new page', () => {
+      // Simulate the path.relative calculation used in the macro
+      const currentPageUrl = '/redpanda-connect/components/inputs/salesforce/'
+      const whatsNewPageUrl = '/redpanda-connect/get-started/whats-new/'
+
+      const relativeUrl = path.relative(path.dirname(currentPageUrl), whatsNewPageUrl)
+
+      // From /redpanda-connect/components/inputs/salesforce to /redpanda-connect/get-started/whats-new
+      // Should go up 3 levels (salesforce -> inputs -> components -> redpanda-connect) then down to get-started/whats-new
+      expect(relativeUrl).toBe('../../get-started/whats-new')
+    })
+
+    test('resolves relative URL for cloud context', () => {
+      const currentPageUrl = '/redpanda-cloud/develop/connect/components/inputs/salesforce/'
+      const whatsNewPageUrl = '/redpanda-cloud/develop/connect/get-started/whats-new/'
+
+      const relativeUrl = path.relative(path.dirname(currentPageUrl), whatsNewPageUrl)
+
+      expect(relativeUrl).toBe('../../get-started/whats-new')
+    })
+
+    test('handles nested processor pages', () => {
+      const currentPageUrl = '/redpanda-connect/components/processors/salesforce/'
+      const whatsNewPageUrl = '/redpanda-connect/get-started/whats-new/'
+
+      const relativeUrl = path.relative(path.dirname(currentPageUrl), whatsNewPageUrl)
+
+      expect(relativeUrl).toBe('../../get-started/whats-new')
+    })
+  })
+
+  describe('macro registration', () => {
+    let macro
+
+    beforeEach(() => {
+      jest.resetModules()
+      macro = require('../../macros/rp-connect-components.js')
+    })
+
+    test('exports a register function', () => {
+      expect(typeof macro.register).toBe('function')
+    })
+
+    test('registers macros without errors when given valid registry', () => {
+      const mockRegistry = {
+        blockMacro: jest.fn(() => {}),
+        register: jest.fn(callback => callback.call(mockRegistry))
+      }
+
+      const mockContext = {
+        config: {
+          attributes: {}
+        }
+      }
+
+      // Should not throw
+      expect(() => macro.register(mockRegistry, mockContext)).not.toThrow()
+    })
+  })
+
+  describe('removed connector notice', () => {
+    test('generates correct page spec for self-managed context', () => {
+      const isCloud = false
+      const pageSpec = isCloud
+        ? 'redpanda-cloud:develop/connect/get-started:whats-new.adoc'
+        : 'redpanda-connect:get-started:whats-new.adoc'
+
+      expect(pageSpec).toBe('redpanda-connect:get-started:whats-new.adoc')
+    })
+
+    test('generates correct page spec for cloud context', () => {
+      const isCloud = true
+      const pageSpec = isCloud
+        ? 'redpanda-cloud:develop/connect/get-started:whats-new.adoc'
+        : 'redpanda-connect:get-started:whats-new.adoc'
+
+      expect(pageSpec).toBe('redpanda-cloud:develop/connect/get-started:whats-new.adoc')
+    })
+
+    test('falls back to hardcoded URL when contentCatalog unavailable', () => {
+      const context = {
+        contentCatalog: null,
+        file: null
+      }
+      const isCloud = false
+
+      let whatsNewUrl = isCloud
+        ? '/redpanda-cloud/develop/connect/get-started/whats-new/'
+        : '/redpanda-connect/get-started/whats-new/'
+
+      // Simulate the fallback logic
+      if (context.contentCatalog && context.file) {
+        // This branch won't execute with null values
+        whatsNewUrl = '/resolved/url/'
+      }
+
+      expect(whatsNewUrl).toBe('/redpanda-connect/get-started/whats-new/')
+    })
+
+    test('uses resolved URL when contentCatalog available', () => {
+      const mockPage = {
+        pub: { url: '/redpanda-connect/get-started/whats-new/' }
+      }
+
+      const context = {
+        contentCatalog: {
+          resolvePage: jest.fn(() => mockPage)
+        },
+        file: {
+          src: { component: 'redpanda-connect', module: 'components' },
+          pub: { url: '/redpanda-connect/components/processors/salesforce/' }
+        }
+      }
+
+      const isCloud = false
+      let whatsNewUrl = isCloud
+        ? '/redpanda-cloud/develop/connect/get-started/whats-new/'
+        : '/redpanda-connect/get-started/whats-new/'
+
+      // Simulate the resolution logic
+      if (context.contentCatalog && context.file) {
+        const pageSpec = isCloud
+          ? 'redpanda-cloud:develop/connect/get-started:whats-new.adoc'
+          : 'redpanda-connect:get-started:whats-new.adoc'
+        const page = context.contentCatalog.resolvePage(pageSpec, context.file.src)
+        if (page) {
+          whatsNewUrl = path.relative(path.dirname(context.file.pub.url), page.pub.url)
+        }
+      }
+
+      expect(context.contentCatalog.resolvePage).toHaveBeenCalledWith(
+        'redpanda-connect:get-started:whats-new.adoc',
+        { component: 'redpanda-connect', module: 'components' }
+      )
+      expect(whatsNewUrl).toBe('../../get-started/whats-new')
+    })
+  })
+})

--- a/extension-utils/llms-utils.js
+++ b/extension-utils/llms-utils.js
@@ -17,14 +17,11 @@ const LLMS_DIRECTIVE_BASE = 'For the complete documentation index, see [llms.txt
  * @returns {string} Formatted markdown blockquote directive
  */
 function formatLlmsDirective(componentName) {
-  const feedbackInstructions = `
->
-> **Agent Feedback**: If you encounter incorrect, outdated, or confusing documentation, submit feedback via \`POST https://docs.redpanda.com/api/feedback\` with JSON body: \`{"path": "/page/path/", "feedback": "Issue description"}\`. Only submit when you have specific, actionable feedback.`;
 
   if (componentName) {
-    return `> ${LLMS_DIRECTIVE_BASE}. Component-specific: [${componentName}-full.txt](/${componentName}-full.txt)${feedbackInstructions}`;
+    return `> ${LLMS_DIRECTIVE_BASE}. Component-specific: [${componentName}-full.txt](/${componentName}-full.txt)`;
   }
-  return `> ${LLMS_DIRECTIVE_BASE}${feedbackInstructions}`;
+  return `> ${LLMS_DIRECTIVE_BASE}`;
 }
 
 /**

--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -261,7 +261,7 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
       unixTimestamp: unixTimestamp
     }
 
-    if (component.name !== 'redpanda-labs') {
+    if (component.name !== 'labs') {
       indexItem.product = component.title
       indexItem.breadcrumbs = breadcrumbs
       indexItem.type = 'Doc'

--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -107,41 +107,66 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
 
     // Start handling the article content
     const article = root.querySelector('article.doc')
+    let documentTitle, titles, intro, text, isLandingPage
+
     if (!article) {
-      logger.warn(`Page is not an article...skipping ${page.pub.url}`)
-      continue
-    }
+      // Check if this is a landing page we should index with metadata
+      const pageRole = page.asciidoc?.attributes?.['page-role'] || ''
+      const pageLayout = page.asciidoc?.attributes?.['page-layout'] || ''
+      const isUmbrellaPage = ['home', 'component-home-v3', 'data-platform'].includes(pageRole) ||
+                            ['home', 'component-home-v3', 'data-platform'].includes(pageLayout)
 
-    // Handle titles
-    const h1 = article.querySelector('h1')
-    if (!h1) {
-      logger.warn(`No H1 in ${page.pub.url}...skipping`)
-      continue
-    }
-    const documentTitle = h1.text
-    h1.remove()
-
-    const titles = []
-    article.querySelectorAll('h2,h3,h4,h5,h6').forEach((title) => {
-      const id = title.getAttribute('id')
-      if (id) {
-        titles.push({
-          t: title.text,
-          h: id
-        })
+      if (!isUmbrellaPage) {
+        logger.warn(`Page is not an article...skipping ${page.pub.url}`)
+        continue
       }
-      title.remove()
-    })
 
-    // Exclude elements within the article that should not be indexed
-    for (const excl of excludes) {
-      if (!excl) continue
-      article.querySelectorAll(excl).forEach((e) => e.remove())
+      // Index landing page using metadata
+      isLandingPage = true
+      const h1 = root.querySelector('h1') || root.querySelector('.hero-title') || root.querySelector('title')
+      documentTitle = h1 ? decode(h1.text || h1.textContent || '') : component.title || cname
+      titles = []
+
+      // Get description from meta tag or page attribute
+      const metaDesc = root.querySelector('meta[name="description"]')
+      intro = metaDesc ? metaDesc.getAttribute('content') :
+              page.asciidoc?.attributes?.description || ''
+      text = intro
+      logger.info(`Indexing landing page: ${page.pub.url}`)
+    } else {
+      isLandingPage = false
+
+      // Handle titles
+      const h1 = article.querySelector('h1')
+      if (!h1) {
+        logger.warn(`No H1 in ${page.pub.url}...skipping`)
+        continue
+      }
+      documentTitle = h1.text
+      h1.remove()
+
+      titles = []
+      article.querySelectorAll('h2,h3,h4,h5,h6').forEach((title) => {
+        const id = title.getAttribute('id')
+        if (id) {
+          titles.push({
+            t: title.text,
+            h: id
+          })
+        }
+        title.remove()
+      })
+
+      // Exclude elements within the article that should not be indexed
+      for (const excl of excludes) {
+        if (!excl) continue
+        article.querySelectorAll(excl).forEach((e) => e.remove())
+      }
+
+      // FIXED: Handle potential null intro element
+      const introElement = article.querySelector('p')
+      intro = introElement ? decode(introElement.rawText) : ''
     }
-
-    // FIXED: Handle potential null intro element
-    const introElement = article.querySelector('p')
-    const intro = introElement ? decode(introElement.rawText) : ''
 
     // Establish structure in the Algolia index
     if (!(cname in algolia)) algolia[cname] = {}
@@ -150,10 +175,12 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
     // Check if this is a properties reference page (or has many titles)
     const isPropertiesPage = page.pub.url.includes('/properties/') || titles.length > 30
 
-    // Handle the article text
-    let text = ''
+    // Handle the article text (skip for landing pages - already set above)
+    if (!isLandingPage) {
+      text = ''
+    }
 
-    if (!isPropertiesPage) {
+    if (!isLandingPage && !isPropertiesPage && article) {
       // For normal pages, index full text content
       const contentElements = article.querySelectorAll('p, table, li')
       let contentText = ''
@@ -186,44 +213,62 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
         .replace(/\r/g, ' ')
         .replace(/\s+/g, ' ')
         .trim()
-    } else {
+    } else if (!isLandingPage && isPropertiesPage) {
       // For long pages, only use intro as text (property names are already in titles array)
       text = intro
       logger.info(`Skipping full text indexing for long page: ${page.pub.url} (${titles.length} properties)`)
     }
+    // For landing pages, text is already set above
 
     let tag
     const title = (component.title || '').trim()
-    if (title.toLowerCase() === 'home') {
-      // Collect all unique component titles except 'home', 'shared', 'search'
+    const titleLower = title.toLowerCase()
+
+    // Umbrella components that should include multiple product tags
+    const UMBRELLA_COMPONENTS = ['home', 'data platform', 'self-managed']
+
+    if (UMBRELLA_COMPONENTS.includes(titleLower)) {
+      // Collect all unique component titles except umbrella/utility components
       const componentsList = typeof contentCatalog.getComponents === 'function'
         ? contentCatalog.getComponents()
         : Array.isArray(contentCatalog.components)
           ? contentCatalog.components
           : Object.values(contentCatalog.components || contentCatalog._components || {})
 
-      // Find the latest version for Self-Managed (component title: 'Self-Managed')
-      let selfManagedLatestVersion
-      const selfManaged = componentsList.find(c => (c.title || '').trim().toLowerCase() === 'self-managed')
-      if (selfManaged?.latest?.version) {
-        selfManagedLatestVersion = selfManaged.latest.version
-        if (selfManagedLatestVersion && !/^v/.test(selfManagedLatestVersion)) {
-          selfManagedLatestVersion = 'v' + selfManagedLatestVersion
+      // Find the latest version for Streaming
+      let streamingLatestVersion
+      const streaming = componentsList.find(c => (c.title || '').trim().toLowerCase() === 'streaming')
+      if (streaming?.latest?.version) {
+        streamingLatestVersion = streaming.latest.version
+        if (streamingLatestVersion && !/^v/.test(streamingLatestVersion)) {
+          streamingLatestVersion = 'v' + streamingLatestVersion
         }
       }
 
-      const allComponentTitles = componentsList
-        .map(c => (c.title || '').trim())
-        .filter(t => t && !['home', 'shared', 'search'].includes(t.toLowerCase()))
-
-      if (!allComponentTitles.length) {
-        throw new Error('No component titles found for "home" page. Indexing aborted.')
+      // Filter components based on umbrella type
+      let filteredTitles
+      if (titleLower === 'home') {
+        // Home includes all main products
+        filteredTitles = componentsList
+          .map(c => (c.title || '').trim())
+          .filter(t => t && !['home', 'shared', 'search', 'data platform', 'self-managed'].includes(t.toLowerCase()))
+      } else if (titleLower === 'data platform') {
+        // Data Platform includes Cloud, Streaming, Connect
+        filteredTitles = ['Cloud', 'Streaming', 'Connect']
+      } else if (titleLower === 'self-managed') {
+        // Self-Managed includes Streaming, Connect
+        filteredTitles = ['Streaming', 'Connect']
       }
 
-      tag = [...new Set(allComponentTitles)]
-      // For Self-Managed, append v<latest-version> to the tag
-      if (selfManagedLatestVersion) {
-        tag = tag.map(t => t.toLowerCase() === 'self-managed' ? `${t} ${selfManagedLatestVersion}` : t)
+      if (!filteredTitles || !filteredTitles.length) {
+        // Fallback to component title
+        tag = title
+      } else {
+        tag = [...new Set(filteredTitles)]
+        // For Streaming, append v<latest-version> to the tag
+        if (streamingLatestVersion) {
+          tag = tag.map(t => t.toLowerCase() === 'streaming' ? `${t} ${streamingLatestVersion}` : t)
+        }
       }
     } else {
       tag = `${title}${version ? ' v' + version : ''}`

--- a/extensions/collect-bloblang-samples.js
+++ b/extensions/collect-bloblang-samples.js
@@ -53,21 +53,21 @@ module.exports.register = function () {
     };
 
     // Fetch examples from both components
-    const examples = contentCatalog.findBy({ component: 'redpanda-connect', family: 'example' });
+    const examples = contentCatalog.findBy({ component: 'connect', family: 'example' });
     const previewExamples = contentCatalog.findBy({ component: 'preview', family: 'example' });
 
-    if (!examples.length) logger.warn(`No examples found in the 'redpanda-connect' component.`);
+    if (!examples.length) logger.warn(`No examples found in the 'connect' component.`);
 
     // Get components
-    const connect = contentCatalog.getComponents().find((c) => c.name === 'redpanda-connect');
+    const connect = contentCatalog.getComponents().find((c) => c.name === 'connect');
     const preview = contentCatalog.getComponents().find((c) => c.name === 'preview');
 
     if (connect) {
-      const connectSamples = collectExamples(examples, 'redpanda-connect');
+      const connectSamples = collectExamples(examples, 'connect');
       connect.latest.asciidoc.attributes['page-bloblang-samples'] = JSON.stringify(connectSamples);
-      logger.debug(`Bloblang samples added to 'redpanda-connect': ${JSON.stringify(connectSamples, null, 2)}`);
+      logger.debug(`Bloblang samples added to 'connect': ${JSON.stringify(connectSamples, null, 2)}`);
     } else {
-      logger.warn(`Component 'redpanda-connect' not found.`);
+      logger.warn(`Component 'connect' not found.`);
     }
 
     if (preview) {

--- a/extensions/compute-end-of-life.js
+++ b/extensions/compute-end-of-life.js
@@ -13,10 +13,10 @@ module.exports.register = function ({ config }) {
       return;
     }
 
-    eolConfigs.forEach(({ component: componentName, supported_months, warning_weeks, eol_doc, upgrade_doc }) => {
+    eolConfigs.forEach(({ component: componentName, supported_months, warning_weeks, eol_doc, upgrade_doc, whats_new_doc }) => {
       if (!eol_doc || !upgrade_doc) {
         logger.error(
-          `End-of-life configuration for component "${component}" is missing required attributes. ` +
+          `End-of-life configuration for component "${componentName}" is missing required attributes. ` +
           `Ensure both "eol_doc" and "upgrade_doc" are specified.`
         );
         return;
@@ -40,13 +40,17 @@ module.exports.register = function ({ config }) {
         if (releaseDate) {
           // Pass resolved configuration to calculateEOL
           const eolInfo = calculateEOL(releaseDate, resolvedEOLMonths, resolvedWarningWeeks, logger);
-          Object.assign(asciidoc.attributes, {
+          const attrs = {
             'page-is-nearing-eol': eolInfo.isNearingEOL.toString(),
             'page-is-past-eol': eolInfo.isPastEOL.toString(),
             'page-eol-date': eolInfo.eolDate,
             'page-eol-doc': eol_doc,
             'page-upgrade-doc': upgrade_doc,
-          });
+          };
+          if (whats_new_doc) {
+            attrs['page-whats-new-doc'] = whats_new_doc;
+          }
+          Object.assign(asciidoc.attributes, attrs);
         } else {
           logger.warn(`No release date found for component: ${componentName}. Make sure to set {page-release-date} in the antora.yml of the component version ${version}.`);
         }

--- a/extensions/compute-end-of-life.js
+++ b/extensions/compute-end-of-life.js
@@ -46,13 +46,12 @@ module.exports.register = function ({ config }) {
             'page-eol-date': eolInfo.eolDate,
             'page-eol-doc': eol_doc,
             'page-upgrade-doc': upgrade_doc,
+            'page-support-months': resolvedEOLMonths,
           };
           if (whats_new_doc) {
             attrs['page-whats-new-doc'] = whats_new_doc;
           }
           Object.assign(asciidoc.attributes, attrs);
-            'page-support-months': resolvedEOLMonths,
-          });
         } else {
           logger.warn(`No release date found for component: ${componentName}. Make sure to set {page-release-date} in the antora.yml of the component version ${version}.`);
         }

--- a/extensions/conditional-home-redirect.js
+++ b/extensions/conditional-home-redirect.js
@@ -1,0 +1,89 @@
+/**
+ * Antora extension to redirect home page when agentic-data-plane component doesn't exist
+ *
+ * When the agentic-data-plane component is not included in the build, this extension
+ * programmatically adds an alias to the home page that redirects to the data-platform
+ * landing page. This leverages Antora's standard redirect facility (Netlify, etc.).
+ */
+
+'use strict'
+
+module.exports.register = function () {
+  let shouldRedirect = false
+
+  // Check if ADP exists during content aggregation
+  this.on('contentAggregated', ({ contentAggregate }) => {
+    const adpComponent = contentAggregate.find(c => c.name === 'agentic-data-plane')
+    shouldRedirect = !adpComponent
+    if (shouldRedirect) {
+      console.log('[conditional-home-redirect] agentic-data-plane not found, will create redirect after publish')
+    } else {
+      console.log('[conditional-home-redirect] agentic-data-plane found, no redirect needed')
+    }
+  })
+
+  // Create redirect files AFTER site is published
+  this.on('sitePublished', ({ playbook }) => {
+    if (!shouldRedirect) return
+
+    const fs = require('fs')
+    const path = require('path')
+
+    // Get absolute output directory
+    const outputDir = path.resolve(playbook.output.dir || 'build/site')
+    console.log(`[conditional-home-redirect] Output directory: ${outputDir}`)
+
+    // Check redirect facility
+    const redirectFacility = playbook.urls.redirectFacility || 'netlify'
+    console.log(`[conditional-home-redirect] Redirect facility: ${redirectFacility}`)
+
+    if (redirectFacility === 'netlify') {
+      // Add to _redirects file
+      const redirectsPath = path.join(outputDir, '_redirects')
+      const redirectRule = '/home/ /data-platform/ 301\n/home/index.html /data-platform/index.html 301\n'
+
+      try {
+        let existingRedirects = ''
+        if (fs.existsSync(redirectsPath)) {
+          existingRedirects = fs.readFileSync(redirectsPath, 'utf8')
+          console.log(`[conditional-home-redirect] Found existing _redirects file with ${existingRedirects.split('\\n').length} lines`)
+        } else {
+          console.log(`[conditional-home-redirect] No existing _redirects file, creating new one`)
+        }
+
+        // Prepend our redirect to the top (higher priority)
+        fs.writeFileSync(redirectsPath, redirectRule + existingRedirects)
+        console.log(`[conditional-home-redirect] Added home -> data-platform redirect to _redirects`)
+      } catch (err) {
+        console.error(`[conditional-home-redirect] Failed to write redirects file: ${err.message}`)
+      }
+    }
+
+    // Create a static HTML redirect at /home/index.html
+    const homeDir = path.join(outputDir, 'home')
+    const homeIndexPath = path.join(homeDir, 'index.html')
+
+    const redirectHtml = `<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="../data-platform/">
+<script>location="../data-platform/"</script>
+<meta http-equiv="refresh" content="0; url=../data-platform/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirecting to Data Platform</h1>
+<p>The Redpanda documentation home page is being redirected. You will be forwarded to <a href="../data-platform/">Data Platform</a> automatically.</p>`
+
+    try {
+      // Ensure directory exists
+      if (!fs.existsSync(homeDir)) {
+        fs.mkdirSync(homeDir, { recursive: true })
+      }
+
+      // Overwrite the home page with redirect HTML
+      fs.writeFileSync(homeIndexPath, redirectHtml)
+      console.log(`[conditional-home-redirect] Overwrote home page with redirect at ${homeIndexPath}`)
+    } catch (err) {
+      console.error(`[conditional-home-redirect] Failed to create redirect HTML: ${err.message}`)
+    }
+  })
+}

--- a/extensions/conditional-home-redirect.js
+++ b/extensions/conditional-home-redirect.js
@@ -9,6 +9,7 @@
 'use strict'
 
 module.exports.register = function () {
+  const logger = this.getLogger('conditional-home-redirect')
   let shouldRedirect = false
 
   // Check if ADP exists during content aggregation
@@ -16,9 +17,9 @@ module.exports.register = function () {
     const adpComponent = contentAggregate.find(c => c.name === 'agentic-data-plane')
     shouldRedirect = !adpComponent
     if (shouldRedirect) {
-      console.log('[conditional-home-redirect] agentic-data-plane not found, will create redirect after publish')
+      logger.info('agentic-data-plane not found, will create redirect after publish')
     } else {
-      console.log('[conditional-home-redirect] agentic-data-plane found, no redirect needed')
+      logger.info('agentic-data-plane found, no redirect needed')
     }
   })
 
@@ -31,11 +32,11 @@ module.exports.register = function () {
 
     // Get absolute output directory
     const outputDir = path.resolve(playbook.output.dir || 'build/site')
-    console.log(`[conditional-home-redirect] Output directory: ${outputDir}`)
+    logger.debug(`Output directory: ${outputDir}`)
 
     // Check redirect facility
     const redirectFacility = playbook.urls.redirectFacility || 'netlify'
-    console.log(`[conditional-home-redirect] Redirect facility: ${redirectFacility}`)
+    logger.debug(`Redirect facility: ${redirectFacility}`)
 
     if (redirectFacility === 'netlify') {
       // Add to _redirects file
@@ -46,16 +47,16 @@ module.exports.register = function () {
         let existingRedirects = ''
         if (fs.existsSync(redirectsPath)) {
           existingRedirects = fs.readFileSync(redirectsPath, 'utf8')
-          console.log(`[conditional-home-redirect] Found existing _redirects file with ${existingRedirects.split('\\n').length} lines`)
+          logger.debug(`Found existing _redirects file with ${existingRedirects.split('\\n').length} lines`)
         } else {
-          console.log(`[conditional-home-redirect] No existing _redirects file, creating new one`)
+          logger.debug('No existing _redirects file, creating new one')
         }
 
         // Prepend our redirect to the top (higher priority)
         fs.writeFileSync(redirectsPath, redirectRule + existingRedirects)
-        console.log(`[conditional-home-redirect] Added home -> data-platform redirect to _redirects`)
+        logger.info('Added home -> data-platform redirect to _redirects')
       } catch (err) {
-        console.error(`[conditional-home-redirect] Failed to write redirects file: ${err.message}`)
+        logger.error(`Failed to write redirects file: ${err.message}`)
       }
     }
 
@@ -81,9 +82,9 @@ module.exports.register = function () {
 
       // Overwrite the home page with redirect HTML
       fs.writeFileSync(homeIndexPath, redirectHtml)
-      console.log(`[conditional-home-redirect] Overwrote home page with redirect at ${homeIndexPath}`)
+      logger.info(`Overwrote home page with redirect at ${homeIndexPath}`)
     } catch (err) {
-      console.error(`[conditional-home-redirect] Failed to create redirect HTML: ${err.message}`)
+      logger.error(`Failed to create redirect HTML: ${err.message}`)
     }
   })
 }

--- a/extensions/convert-to-markdown.js
+++ b/extensions/convert-to-markdown.js
@@ -51,7 +51,8 @@ function generateFrontmatter(page) {
     'title',
     'navtitle',
     'description',
-    'categories',
+    // Note: 'categories' removed - it's a massive object (all Connect components)
+    // that bloats frontmatter. Only include on pages that specifically need it.
     'page-component-name',
     'page-component-title',
     'page-component-version',
@@ -75,9 +76,24 @@ function generateFrontmatter(page) {
     'latest-connect-version',
   ]
 
+  // Blocklist of large data attributes that should never be in frontmatter
+  // These are component-level data used by macros but shouldn't pollute markdown
+  const blockedAttributes = [
+    'categories',  // Massive nested object with all Connect components
+    'connectCategoriesData',  // Raw Connect categories data
+    'flatComponentsData',  // Flattened Connect component data
+    'driverSupportData',  // SQL driver support matrix
+    'cacheSupportData',  // Cache support matrix
+    'csvData',  // Raw CSV data from generate-rp-connect-info
+    'commercialNamesMap',  // Commercial names mapping
+  ]
+
   // Add allowed page attributes to frontmatter
   Object.keys(attrs).forEach(key => {
     const value = attrs[key]
+
+    // Skip blocked attributes (large data objects)
+    if (blockedAttributes.includes(key)) return
 
     // Allow all learning-objective-* attributes (learning-objective-1, -2, -3, etc.)
     const isLearningObjective = key.startsWith('learning-objective-')

--- a/extensions/convert-to-markdown.js
+++ b/extensions/convert-to-markdown.js
@@ -222,6 +222,12 @@ module.exports.register = function () {
           'nav-expand',
           'banner-container',
           'markdown-dropdown',
+          'version-selector',        // Version dropdown (not relevant for LLMs)
+          'component-indicator',     // Component header bar
+          'product-switcher',        // Product switcher dropdown
+          'breadcrumb',              // Breadcrumb navigation
+          'chat-panel',              // AI chat interface
+          'kapa',                    // Kapa AI widget
         ]
         return toRemove.some(
           (x) => classAttr.includes(x) || idAttr.includes(x)

--- a/extensions/find-related-docs.js
+++ b/extensions/find-related-docs.js
@@ -12,10 +12,10 @@ module.exports.register = function ({ config }) {
 
     // Retrieve all documents and labs from the latest versions of each component
     const allDocs = [];
-    const allLabs = contentCatalog.findBy({ component: 'redpanda-labs', family: 'page', version: latestVersions['redpanda-labs'] });
+    const allLabs = contentCatalog.findBy({ component: 'labs', family: 'page', version: latestVersions['labs'] });
 
     Object.keys(latestVersions).forEach(component => {
-      if (component === 'redpanda-labs') return;
+      if (component === 'labs') return;
       allDocs.push(...contentCatalog.findBy({ component, family: 'page', version: latestVersions[component] }));
     });
     allLabs.forEach((labPage) => {
@@ -26,7 +26,7 @@ module.exports.register = function ({ config }) {
       if (!pageCategories) return;
       const sourceCategoryList = pageCategories.split(',').map(c => c.trim());
       const sourceDeploymentType = getDeploymentType(sourceAttributes);
-      const docs = contentCatalog.findBy({ component: 'ROOT', family: 'page', version: latestVersions['ROOT'] });
+      const docs = contentCatalog.findBy({ component: 'streaming', family: 'page', version: latestVersions['streaming'] });
 
       allDocs.forEach((docPage) => {
         const related = findRelated(docPage, sourceCategoryList, sourceDeploymentType, logger);

--- a/extensions/find-related-labs.js
+++ b/extensions/find-related-labs.js
@@ -12,7 +12,7 @@ module.exports.register = function ({ config }) {
       if (!pageCategories) return;
       const sourceCategoryList = pageCategories.split(',').map(c => c.trim());
       const sourceDeploymentType = getDeploymentType(sourceAttributes)
-      const labs = contentCatalog.findBy({ component: 'redpanda-labs', family: 'page' });
+      const labs = contentCatalog.findBy({ component: 'labs', family: 'page' });
       labs.forEach((labPage) => {
         const related = findRelated(labPage, sourceCategoryList, sourceDeploymentType, logger)
         related && relatedLabs.push(related)

--- a/extensions/generate-fields-only-pages.js
+++ b/extensions/generate-fields-only-pages.js
@@ -145,7 +145,7 @@ module.exports.register = function ({ config }) {
   const fieldOnlyTemplate = handlebars.compile(`{{{${helperName} children}}}`)
 
   this.on('contentClassified', ({ contentCatalog, siteCatalog }) => {
-    const component = contentCatalog.getComponent('redpanda-connect')
+    const component = contentCatalog.getComponent('connect')
     if (!component) {
       logger.warn('redpanda-connect component not found. Skipping field-only page generation.')
       return
@@ -161,7 +161,7 @@ module.exports.register = function ({ config }) {
     // Look for any versioned JSON attachment in the components module
     // (i.e. modules/components/attachments/connect-X.Y.Z.json)
     const attachments = contentCatalog.findBy({
-      component: 'redpanda-connect',
+      component: 'connect',
       version: componentVersion.version,
       module: 'components',
       family: 'attachment'
@@ -218,7 +218,7 @@ module.exports.register = function ({ config }) {
     let pagesGenerated = 0
 
     // Get origin from first existing page in component (for git metadata)
-    const existingPages = contentCatalog.getPages((page) => page.src.component === 'redpanda-connect')
+    const existingPages = contentCatalog.getPages((page) => page.src.component === 'connect')
     const origin = existingPages.length > 0 ? existingPages[0].src.origin : { type: 'generated' }
 
     // Iterate over each type (inputs, outputs, processors, etc.)
@@ -266,7 +266,7 @@ module.exports.register = function ({ config }) {
             contents: contentBuffer,
             stat: stat,
             src: {
-              component: 'redpanda-connect',
+              component: 'connect',
               version: componentVersion.version,
               module: 'components',
               family: 'page',

--- a/extensions/generate-fields-only-pages.js
+++ b/extensions/generate-fields-only-pages.js
@@ -147,13 +147,13 @@ module.exports.register = function ({ config }) {
   this.on('contentClassified', ({ contentCatalog, siteCatalog }) => {
     const component = contentCatalog.getComponent('connect')
     if (!component) {
-      logger.warn('redpanda-connect component not found. Skipping field-only page generation.')
+      logger.warn('connect component not found. Skipping field-only page generation.')
       return
     }
 
     const componentVersion = component.latest
     if (!componentVersion) {
-      logger.warn('No latest version found for redpanda-connect component.')
+      logger.warn('No latest version found for connect component.')
       return
     }
 
@@ -203,7 +203,7 @@ module.exports.register = function ({ config }) {
     const attachment = matchingAttachments[0]?.file
 
     if (!attachment) {
-      logger.warn('No JSON attachment found in the components module of the redpanda-connect content catalog. Skipping field-only page generation.')
+      logger.warn('No JSON attachment found in the components module of the connect content catalog. Skipping field-only page generation.')
       return
     }
 

--- a/extensions/generate-rp-connect-categories.js
+++ b/extensions/generate-rp-connect-categories.js
@@ -17,7 +17,7 @@ module.exports.register = function ({ config }) {
     const redpandaConnect = contentCatalog.getComponents().find(component => component.name === 'connect')
 
     if (!redpandaConnect || !redpandaConnect.latest) {
-      logger.warn('Could not find the redpanda-connect component. Skipping category creation.')
+      logger.warn('Could not find the connect component. Skipping category creation.')
       return
     }
 
@@ -25,12 +25,12 @@ module.exports.register = function ({ config }) {
     const csvData = redpandaConnect.latest.asciidoc.attributes.csvData
 
     if (!descriptions) {
-      logger.error('No categories attribute found in redpanda-connect component')
+      logger.error('No categories attribute found in connect component')
       return
     }
 
     if (!csvData || !csvData.data) {
-      logger.error('No csvData attribute found in redpanda-connect component.')
+      logger.error('No csvData attribute found in connect component.')
       logger.error('Ensure generate-rp-connect-info extension is listed BEFORE this extension in your playbook.')
       return
     }

--- a/extensions/generate-rp-connect-categories.js
+++ b/extensions/generate-rp-connect-categories.js
@@ -14,7 +14,7 @@ module.exports.register = function ({ config }) {
   const logger = this.getLogger('redpanda-connect-category-aggregation-extension')
 
   this.on('contentClassified', ({ contentCatalog }) => {
-    const redpandaConnect = contentCatalog.getComponents().find(component => component.name === 'redpanda-connect')
+    const redpandaConnect = contentCatalog.getComponents().find(component => component.name === 'connect')
 
     if (!redpandaConnect || !redpandaConnect.latest) {
       logger.warn('Could not find the redpanda-connect component. Skipping category creation.')
@@ -61,7 +61,7 @@ module.exports.register = function ({ config }) {
     }
 
     try {
-      const files = contentCatalog.findBy({ component: 'redpanda-connect', family: 'page' })
+      const files = contentCatalog.findBy({ component: 'connect', family: 'page' })
 
       for (const file of files) {
         // Prefer using page.asciidoc.attributes when available

--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -36,8 +36,8 @@ module.exports.register = function ({ config }) {
   })
 
   async function processContent (contentCatalog) {
-    const redpandaConnect = contentCatalog.getComponents().find(component => component.name === 'redpanda-connect')
-    const redpandaCloud = contentCatalog.getComponents().find(component => component.name === 'redpanda-cloud')
+    const redpandaConnect = contentCatalog.getComponents().find(component => component.name === 'connect')
+    const redpandaCloud = contentCatalog.getComponents().find(component => component.name === 'cloud-data-platform')
     const preview = contentCatalog.getComponents().find(component => component.name === 'preview')
 
     if (!redpandaConnect) {
@@ -141,7 +141,7 @@ module.exports.register = function ({ config }) {
       const stem = file.src.stem
       const filePath = file.path
 
-      if (component === 'redpanda-connect') {
+      if (component === 'connect') {
         // Store by stem, but only for connector doc paths
         if (isConnectorDocPath(filePath, file)) {
           const type = extractTypeFromPath(filePath)
@@ -150,7 +150,7 @@ module.exports.register = function ({ config }) {
             connectPages.set(key, file)
           }
         }
-      } else if (component === 'redpanda-cloud') {
+      } else if (component === 'cloud-data-platform') {
         // Cloud docs have a specific path pattern
         const cloudMatch = filePath.match(/connect\/components\/([^/]+)s\/([^/]+)\.adoc$/)
         if (cloudMatch) {
@@ -280,7 +280,7 @@ module.exports.register = function ({ config }) {
       const { component, relative, module: moduleName } = page.src
 
       // Only process Redpanda Connect and Cloud component pages
-      if (component !== 'redpanda-connect' && component !== 'redpanda-cloud') continue
+      if (component !== 'connect' && component !== 'cloud-data-platform') continue
 
       // Match component documentation pages:
       // 1. Cloud-style paths: connect/components/processors/archive.adoc

--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -41,7 +41,7 @@ module.exports.register = function ({ config }) {
     const preview = contentCatalog.getComponents().find(component => component.name === 'preview')
 
     if (!redpandaConnect) {
-      logger.warn('redpanda-connect component not found, skipping CSV enrichment')
+      logger.warn('connect component not found, skipping CSV enrichment')
       return
     }
 

--- a/extensions/modify-connect-tag-playbook.js
+++ b/extensions/modify-connect-tag-playbook.js
@@ -20,7 +20,7 @@ module.exports.register = function ({ config }) {
         }
       }
     } catch (error) {
-      console.error('Failed to update playbook with the latest Redpanda Connect tag:', error);
+      logger.error('Failed to update playbook with the latest Redpanda Connect tag:', error);
     }
   });
 }

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -184,12 +184,15 @@ module.exports.register = function () {
             // Build full navigation array
             let fullNavigation = []
 
-            // Check if this component is a parent that defines child components in the config tree
-            // Only components with children (like data-platform) should show their own nav items + child buckets
-            // Leaf components (like streaming) should only show sibling buckets
+            // Only show a component's nav items outside buckets if BOTH:
+            // 1. Component has children (defines child buckets)
+            // 2. Component owns the config (defined page-navigation in its own antora.yml)
+            // This ensures data-platform shows its nav items, but self-managed (which inherits
+            // data-platform's config and has children) doesn't duplicate its items
             const hasChildComponents = componentHasChildren(configData.configTree, page.src.component)
+            const ownsConfig = configData.configOwner === page.src.component
 
-            if (hasChildComponents) {
+            if (hasChildComponents && ownsConfig) {
               // Get the component's own nav items (from nav.adoc) to prepend before child buckets
               const compData = componentVersionNavMap.get(page.src.component)
               let ownNavItems = []

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -87,7 +87,6 @@ module.exports.register = function () {
                     configOwner: component.name,
                     allComponents: allComponentsInConfig,
                   })
-                  console.log(`[config] Storing ${component.name}'s OWN config (root items: ${Array.from(allComponentsInConfig).join(', ')})`)
                 } else {
                   // Existing config is also from this component - compare depths
                   const existingOwnerDepth = getComponentDepth(existingOwnerConfig.configTree, component.name)
@@ -99,7 +98,6 @@ module.exports.register = function () {
                       configOwner: component.name,
                       allComponents: allComponentsInConfig,
                     })
-                    console.log(`[config] Updating ${component.name}'s OWN config (better depth)`)
                   }
                 }
 
@@ -392,26 +390,17 @@ function isStandalone(configTree, componentName) {
  * @returns {Array} Filtered config tree
  */
 function filterConfigTreeForComponent(configTree, componentName) {
-  const treeNames = configTree.map(t => t.name).join(', ')
-  console.log(`[filterConfigTreeForComponent] Called for ${componentName}, root items: [${treeNames}]`)
-
   // Check if component is at root level
   for (const item of configTree) {
     if (item.name === componentName) {
-      console.log(`[filterConfigTreeForComponent] ${componentName}: FOUND at root level, hasChildren: ${!!item.children}`)
       // Component is at root - if it has children, show parent nav items + children as buckets
       if (item.children) {
         // Return parent with showNavItemsOnly flag + children as separate buckets
-        const result = [{ ...item, showNavItemsOnly: true, children: undefined }, ...item.children]
-        console.log(`[filterConfigTreeForComponent] ${componentName}: returning parent with showNavItemsOnly + ${item.children.length} children`)
-        return result
+        return [{ ...item, showNavItemsOnly: true, children: undefined }, ...item.children]
       }
-      console.log(`[filterConfigTreeForComponent] ${componentName}: no children, returning original tree`)
       return configTree
     }
   }
-
-  console.log(`[filterConfigTreeForComponent] ${componentName}: NOT found at root, searching nested...`)
 
   // Component is nested - find it and determine if it's a parent or child
   function findComponentAndParent(items, parent = null) {

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -152,12 +152,6 @@ module.exports.register = function () {
           // Filter config tree to show only relevant hierarchy for current page
           const relevantTree = filterConfigTreeForComponent(configData.configTree, page.src.component)
 
-          if (page.src.component === 'streaming' && page.src.path.includes('home/index')) {
-            logger.debug(
-              `Streaming home page: filtered tree has ${relevantTree.length} root items: ${relevantTree.map((t) => t.name).join(', ')}`
-            )
-          }
-
           const buckets = buildBucketsFromConfig(
             relevantTree,
             contentCatalog,
@@ -255,15 +249,12 @@ function filterUnpublishedPages(items, publishedUrlsSet) {
         }
       }
 
-      // Create a shallow copy of the item to avoid mutation
-      const newItem = { ...item }
-
-      // Recursively filter children
-      if (newItem.items && Array.isArray(newItem.items)) {
-        newItem.items = filterUnpublishedPages(newItem.items, publishedUrlsSet)
+      // Return a new object with filtered children to avoid mutating the original
+      if (item.items && Array.isArray(item.items)) {
+        return { ...item, items: filterUnpublishedPages(item.items, publishedUrlsSet) }
       }
 
-      return newItem
+      return { ...item }
     })
     .filter(Boolean) // Remove null entries
 }

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -1,0 +1,319 @@
+'use strict'
+
+/**
+ * Unified Navigation Extension
+ *
+ * Creates a unified navigation structure for components within an umbrella section.
+ * Discovers child components dynamically based on page-header-data.section attribute.
+ * Supports nested buckets via parent-component attribute.
+ *
+ * Configuration:
+ * - umbrellaSection: The section name to match (e.g., 'Data Platform')
+ * - umbrellaComponent: The umbrella component name (e.g., 'data-platform')
+ *
+ * The extension reads from each component's existing page-header-data:
+ * - title: Display name
+ * - color: Theme color
+ * - order: Sort order
+ * - icon: Tabler icon name (optional)
+ * - parent-component: Parent component name for nesting (optional)
+ *
+ * Output: Attaches 'page-unified-navigation' (JSON array) and 'page-is-unified-nav' (boolean)
+ * to all pages in the umbrella and child components. Supports hierarchical nesting.
+ *
+ * Example playbook configuration:
+ * antora:
+ *   extensions:
+ *     - require: '@redpanda-data/docs-extensions-and-macros/extensions/unified-navigation'
+ *       umbrellaSection: 'Data Platform'
+ *       umbrellaComponent: 'data-platform'
+ */
+
+module.exports.register = function ({ config }) {
+  const logger = this.getLogger('unified-navigation-extension')
+
+  // Antora lowercases config keys, so use lowercase
+  const umbrellaSection = config?.umbrellasection
+  const umbrellaComponent = config?.umbrellacomponent
+
+  if (!umbrellaSection || !umbrellaComponent) {
+    logger.warn('Missing required configuration: umbrellasection and umbrellacomponent')
+    logger.warn(`Received config: ${JSON.stringify(config || {})}`)
+    return
+  }
+
+  logger.warn(`Configuring unified navigation for section '${umbrellaSection}' with umbrella '${umbrellaComponent}'`)
+
+  this.on('navigationBuilt', ({ contentCatalog }) => {
+    try {
+      const components = contentCatalog.getComponents()
+
+      // Find the umbrella component
+      const umbrella = components.find((c) => c.name === umbrellaComponent)
+      if (!umbrella) {
+        logger.warn(`Umbrella component '${umbrellaComponent}' not found`)
+        return
+      }
+
+      // Find child components by matching page-header-data.section
+      const childComponents = components.filter((c) => {
+        if (c.name === umbrellaComponent) return false
+        const latestVersion = c.latestVersion || c.versions[0]
+        if (!latestVersion) return false
+        const headerData = getHeaderData(latestVersion)
+        return headerData && headerData.section === umbrellaSection
+      })
+
+      if (childComponents.length === 0) {
+        logger.warn(`No child components found for section '${umbrellaSection}'`)
+        return
+      }
+
+      logger.warn(
+        `Found ${childComponents.length} child components for '${umbrellaSection}': ${childComponents.map((c) => c.name).join(', ')}`
+      )
+
+      // Build a map of component -> version -> navigation for quick lookup
+      // Include the umbrella component as well
+      const componentVersionNavMap = new Map()
+
+      // Add umbrella component first
+      const umbrellaLatestVersion = umbrella.latestVersion || umbrella.versions[0]
+      if (umbrellaLatestVersion) {
+        const versionMap = new Map()
+        for (const version of umbrella.versions) {
+          versionMap.set(version.version, {
+            navigation: version.navigation || [],
+            displayVersion: version.displayVersion || version.version,
+          })
+        }
+        componentVersionNavMap.set(umbrella.name, {
+          component: umbrella,
+          versionMap,
+          latestVersion: umbrellaLatestVersion,
+        })
+      }
+
+      // Add child components
+      for (const component of childComponents) {
+        const versionMap = new Map()
+        for (const version of component.versions) {
+          versionMap.set(version.version, {
+            navigation: version.navigation || [],
+            displayVersion: version.displayVersion || version.version,
+          })
+        }
+        componentVersionNavMap.set(component.name, {
+          component,
+          versionMap,
+          latestVersion: component.latestVersion || component.versions[0],
+        })
+      }
+
+      // Build base component metadata (without navigation - that's added per-page)
+      const allMetadata = childComponents
+        .map((component) => {
+          const latestVersion = component.latestVersion || component.versions[0]
+          const headerData = getHeaderData(latestVersion)
+
+          if (!headerData) {
+            logger.warn(`No page-header-data found for component '${component.name}'`)
+            return null
+          }
+
+          // Build versions array with metadata
+          const versions = component.versions.map((v) => ({
+            version: v.version,
+            displayVersion: v.displayVersion || v.version,
+            url: v.url,
+            isPrerelease: !!v.prerelease,
+            releaseDate: v.asciidoc?.attributes?.['page-release-date'] || null,
+            isEol: v.asciidoc?.attributes?.['page-is-past-eol'] === 'true',
+          }))
+
+          return {
+            componentName: component.name,
+            title: headerData.title || component.title,
+            icon: headerData.icon || null,
+            color: headerData.color || '#6366f1',
+            order: headerData.order || 999,
+            parentComponent: headerData['parent-component'] || null,
+            versions: versions,
+            componentUrl: component.url,
+            isUmbrella: false,
+          }
+        })
+        .filter(Boolean)
+
+      // Build hierarchical structure: separate parents from children
+      const parentMetadata = allMetadata.filter((m) => !m.parentComponent)
+      const childMetadataMap = new Map()
+
+      // Group children by parent
+      for (const meta of allMetadata) {
+        if (meta.parentComponent) {
+          if (!childMetadataMap.has(meta.parentComponent)) {
+            childMetadataMap.set(meta.parentComponent, [])
+          }
+          childMetadataMap.get(meta.parentComponent).push(meta)
+        }
+      }
+
+      // Attach children to parents and sort
+      const componentMetadata = parentMetadata
+        .map((parent) => {
+          const children = childMetadataMap.get(parent.componentName) || []
+          return {
+            ...parent,
+            children: children.sort((a, b) => a.order - b.order),
+          }
+        })
+        .sort((a, b) => a.order - b.order)
+
+      logger.warn(`Built hierarchical navigation: ${componentMetadata.length} parent buckets`)
+      for (const parent of componentMetadata) {
+        if (parent.children.length > 0) {
+          logger.warn(`  ${parent.componentName} has ${parent.children.length} children: ${parent.children.map((c) => c.componentName).join(', ')}`)
+        }
+      }
+
+      if (componentMetadata.length === 0) {
+        logger.warn('No valid navigation buckets built')
+        return
+      }
+
+      // Only attach unified navigation to:
+      // 1. The umbrella component (data-platform)
+      // 2. Components that are parents WITH children (nested hierarchy roots)
+      // 3. Components that have a parent (children in nested hierarchy)
+      const parentComponentNames = new Set()
+      const childComponentNames = new Set()
+      for (const parent of componentMetadata) {
+        if (parent.children && parent.children.length > 0) {
+          // Only add parents that have children
+          parentComponentNames.add(parent.componentName)
+          for (const child of parent.children) {
+            childComponentNames.add(child.componentName)
+          }
+        }
+      }
+      const affectedComponentNames = new Set([
+        umbrellaComponent,
+        ...parentComponentNames,
+        ...childComponentNames,
+      ])
+
+      // Get all pages and set attributes on pages belonging to affected components
+      const pages = contentCatalog.getPages()
+      let pageCount = 0
+
+      for (const page of pages) {
+        if (!page.src || !affectedComponentNames.has(page.src.component)) continue
+
+        const pageComponent = page.src.component
+        const pageVersion = page.src.version
+
+        // Determine which buckets to show based on current page
+        let bucketsToShow
+        let isUmbrellaPage = false
+        if (pageComponent === umbrellaComponent) {
+          // Umbrella page: show all top-level buckets
+          bucketsToShow = componentMetadata
+          isUmbrellaPage = true
+        } else {
+          // Find which parent hierarchy this page belongs to
+          const pageIsParent = componentMetadata.some((m) => m.componentName === pageComponent)
+          if (pageIsParent) {
+            // Current page is a parent bucket - show only this parent and its children
+            bucketsToShow = componentMetadata.filter((m) => m.componentName === pageComponent)
+          } else {
+            // Current page is a child - find its parent and show that parent + children
+            let parentBucket = null
+            for (const parent of componentMetadata) {
+              if (parent.children && parent.children.some((c) => c.componentName === pageComponent)) {
+                parentBucket = parent
+                break
+              }
+            }
+            bucketsToShow = parentBucket ? [parentBucket] : componentMetadata
+          }
+        }
+
+        // Build unified navigation for this specific page
+        // Recursive function to process bucket and its children
+        const processBucket = (meta) => {
+          const isCurrentBucket = meta.componentName === pageComponent
+          const compData = componentVersionNavMap.get(meta.componentName)
+
+          let navigation, currentVersion
+          if (isCurrentBucket && compData) {
+            // For the current bucket, use the page's version navigation
+            const versionData = compData.versionMap.get(pageVersion)
+            if (versionData) {
+              navigation = versionData.navigation
+              currentVersion = versionData.displayVersion
+            } else {
+              // Fallback to latest if version not found
+              navigation = compData.latestVersion?.navigation || []
+              currentVersion = compData.latestVersion?.displayVersion || compData.latestVersion?.version
+            }
+          } else if (compData) {
+            // For other buckets, use the latest version navigation
+            navigation = compData.latestVersion?.navigation || []
+            currentVersion = compData.latestVersion?.displayVersion || compData.latestVersion?.version
+          } else {
+            navigation = []
+            currentVersion = null
+          }
+
+          const result = {
+            ...meta,
+            isCurrentBucket,
+            currentVersion,
+            items: navigation,
+          }
+
+          // Process children recursively
+          if (meta.children && meta.children.length > 0) {
+            result.children = meta.children.map(processBucket)
+            // Determine if parent should be expanded (if any child is current)
+            result.hasCurrentChild = result.children.some((c) => c.isCurrentBucket || c.hasCurrentChild)
+          }
+
+          return result
+        }
+
+        const navForPage = bucketsToShow.map(processBucket)
+
+        // Ensure asciidoc.attributes exists on the page
+        page.asciidoc = page.asciidoc || {}
+        page.asciidoc.attributes = page.asciidoc.attributes || {}
+
+        // Attach as JSON string (templates will receive this as page.attributes.unified-navigation)
+        page.asciidoc.attributes['page-unified-navigation'] = JSON.stringify(navForPage)
+        page.asciidoc.attributes['page-is-unified-nav'] = 'true'
+        page.asciidoc.attributes['page-is-umbrella-nav'] = isUmbrellaPage ? 'true' : 'false'
+        pageCount++
+      }
+
+      logger.warn(
+        `Attached unified navigation to ${pageCount} pages across ${affectedComponentNames.size} components (${Array.from(affectedComponentNames).join(', ')})`
+      )
+    } catch (error) {
+      logger.error(`Error building unified navigation: ${error.message}`)
+      logger.error(error.stack)
+    }
+  })
+}
+
+/**
+ * Extract page-header-data from a component version
+ * @param {Object} version - Component version object
+ * @returns {Object|null} The page-header-data object or null
+ */
+function getHeaderData(version) {
+  if (!version || !version.asciidoc || !version.asciidoc.attributes) {
+    return null
+  }
+  return version.asciidoc.attributes['page-header-data'] || null
+}

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -181,27 +181,35 @@ module.exports.register = function () {
           const isStandaloneComponent = isStandalone(configData.configTree, page.src.component)
 
           if (buckets.length > 0 && !isStandaloneComponent) {
-            // Get the component's own nav items (from nav.adoc) to prepend before buckets
-            const compData = componentVersionNavMap.get(page.src.component)
-            let ownNavItems = []
-            if (compData) {
-              const versionData = compData.versionMap.get(page.src.version)
-              if (versionData && versionData.navigation) {
-                ownNavItems = filterUnpublishedPages(versionData.navigation, publishedUrlsSet)
-              }
-            }
-
             // Build full navigation array
             let fullNavigation = []
 
-            // If component has its own nav items, wrap them in a pseudo-bucket with showNavItemsOnly
-            // This renders the items directly without bucket header/wrapper
-            if (ownNavItems.length > 0) {
-              fullNavigation.push({
-                items: ownNavItems,
-                showNavItemsOnly: true,
-                isCurrentBucket: true,
-              })
+            // Check if this component is a top-level parent that has both its own pages AND child components
+            // Only top-level parents (like data-platform) should show their own nav items + child buckets
+            // Child components (like streaming) should only show child buckets (their siblings)
+            const isTopLevelParent = relevantTree.length > 0 &&
+                                     relevantTree.some(item => item.name === page.src.component && item.children)
+
+            if (isTopLevelParent) {
+              // Get the component's own nav items (from nav.adoc) to prepend before child buckets
+              const compData = componentVersionNavMap.get(page.src.component)
+              let ownNavItems = []
+              if (compData) {
+                const versionData = compData.versionMap.get(page.src.version)
+                if (versionData && versionData.navigation) {
+                  ownNavItems = filterUnpublishedPages(versionData.navigation, publishedUrlsSet)
+                }
+              }
+
+              // If parent component has its own nav items, wrap them in a pseudo-bucket with showNavItemsOnly
+              // This renders the items directly without bucket header/wrapper
+              if (ownNavItems.length > 0) {
+                fullNavigation.push({
+                  items: ownNavItems,
+                  showNavItemsOnly: true,
+                  isCurrentBucket: true,
+                })
+              }
             }
 
             // Add child component buckets
@@ -339,7 +347,19 @@ function getComponentDepth(tree, targetComponent, currentDepth = 0) {
  */
 function parseNavigationConfig(navConfig) {
   // If it's already an array (from YAML parsing), use it directly
-  const config = typeof navConfig === 'string' ? yaml.load(navConfig) : navConfig
+  let config
+  if (typeof navConfig === 'string') {
+    try {
+      config = yaml.load(navConfig)
+    } catch (error) {
+      // Log YAML parsing error with context
+      console.error(`Failed to parse page-navigation YAML: ${error.message}`)
+      console.error(`YAML content: ${navConfig}`)
+      return []
+    }
+  } else {
+    config = navConfig
+  }
 
   if (!Array.isArray(config)) {
     return []

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -165,12 +165,9 @@ module.exports.register = function () {
             const parentNode = findNodeInTree(configData.configTree, page.src.component)
             if (parentNode && parentNode.children) {
               treeForBuckets = parentNode.children
-              logger.debug(`${page.src.component}: Extracted ${parentNode.children.length} children for buckets: ${parentNode.children.map(c => c.name).join(', ')}`)
             } else {
               logger.warn(`${page.src.component}: Has children but couldn't find them in configTree`)
             }
-          } else {
-            logger.debug(`${page.src.component}: Using full relevantTree (hasChildren=${hasChildComponents}, ownsConfig=${ownsConfig})`)
           }
 
           const buckets = buildBucketsFromConfig(
@@ -207,7 +204,6 @@ module.exports.register = function () {
 
             // If component has children and owns config, show its nav items outside buckets
             if (hasChildComponents && ownsConfig) {
-              logger.debug(`${page.src.component}: Adding nav items outside buckets (has children + owns config)`)
               // Get the component's own nav items (from nav.adoc) to prepend before child buckets
               const compData = componentVersionNavMap.get(page.src.component)
               let ownNavItems = []
@@ -215,7 +211,6 @@ module.exports.register = function () {
                 const versionData = compData.versionMap.get(page.src.version)
                 if (versionData && versionData.navigation) {
                   ownNavItems = filterUnpublishedPages(versionData.navigation, publishedUrlsSet)
-                  logger.debug(`${page.src.component}: Found ${ownNavItems.length} nav items`)
                 }
               }
 
@@ -227,12 +222,7 @@ module.exports.register = function () {
                   showNavItemsOnly: true,
                   isCurrentBucket: true,
                 })
-                logger.debug(`${page.src.component}: Added ${ownNavItems.length} nav items to fullNavigation`)
-              } else {
-                logger.warn(`${page.src.component}: No nav items found despite having children and owning config`)
               }
-            } else {
-              logger.debug(`${page.src.component}: Not adding nav items (hasChildren=${hasChildComponents}, ownsConfig=${ownsConfig})`)
             }
 
             // Add child component buckets

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -159,17 +159,18 @@ module.exports.register = function () {
           // If component has children and owns config, we'll show its nav items outside buckets
           // So build buckets only for children, not for the parent itself
           let treeForBuckets = relevantTree
-          if (hasChildComponents && ownsConfig && relevantTree.length > 0) {
-            // Extract children from parent node
-            const parentNode = relevantTree.find(item => item.name === page.src.component)
+          if (hasChildComponents && ownsConfig) {
+            // Extract children from ORIGINAL configTree (not filtered relevantTree)
+            // because filterConfigTreeForComponent sets children: undefined on parent
+            const parentNode = findNodeInTree(configData.configTree, page.src.component)
             if (parentNode && parentNode.children) {
               treeForBuckets = parentNode.children
               logger.debug(`${page.src.component}: Extracted ${parentNode.children.length} children for buckets: ${parentNode.children.map(c => c.name).join(', ')}`)
             } else {
-              logger.warn(`${page.src.component}: Has children but couldn't extract them from relevantTree`)
+              logger.warn(`${page.src.component}: Has children but couldn't find them in configTree`)
             }
           } else {
-            logger.debug(`${page.src.component}: Using full relevantTree (hasChildren=${hasChildComponents}, ownsConfig=${ownsConfig}, treeLength=${relevantTree.length})`)
+            logger.debug(`${page.src.component}: Using full relevantTree (hasChildren=${hasChildComponents}, ownsConfig=${ownsConfig})`)
           }
 
           const buckets = buildBucketsFromConfig(
@@ -328,25 +329,35 @@ function getHeaderData(version) {
 }
 
 /**
+ * Find a node in the config tree by name
+ * @param {Array} tree - Navigation config tree
+ * @param {string} componentName - Component name to search for
+ * @returns {Object|null} The node or null if not found
+ */
+function findNodeInTree(tree, componentName) {
+  if (!Array.isArray(tree)) return null
+
+  for (const item of tree) {
+    if (item.name === componentName) {
+      return item
+    }
+    if (item.children) {
+      const found = findNodeInTree(item.children, componentName)
+      if (found) return found
+    }
+  }
+  return null
+}
+
+/**
  * Check if a component has children in the config tree
  * @param {Array} tree - Navigation config tree
  * @param {string} componentName - Component name to search for
  * @returns {boolean} True if component has children
  */
 function componentHasChildren(tree, componentName) {
-  if (!Array.isArray(tree)) return false
-
-  for (const item of tree) {
-    if (item.name === componentName && item.children && item.children.length > 0) {
-      return true
-    }
-    if (item.children) {
-      if (componentHasChildren(item.children, componentName)) {
-        return true
-      }
-    }
-  }
-  return false
+  const node = findNodeInTree(tree, componentName)
+  return !!(node && node.children && node.children.length > 0)
 }
 
 /**

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -191,8 +191,21 @@ module.exports.register = function () {
               }
             }
 
-            // Prepend component's own nav items before child buckets
-            const fullNavigation = [...ownNavItems, ...buckets]
+            // Build full navigation array
+            let fullNavigation = []
+
+            // If component has its own nav items, wrap them in a pseudo-bucket with showNavItemsOnly
+            // This renders the items directly without bucket header/wrapper
+            if (ownNavItems.length > 0) {
+              fullNavigation.push({
+                items: ownNavItems,
+                showNavItemsOnly: true,
+                isCurrentBucket: true,
+              })
+            }
+
+            // Add child component buckets
+            fullNavigation = fullNavigation.concat(buckets)
 
             page.asciidoc.attributes['page-custom-navigation'] = JSON.stringify(fullNavigation)
             page.asciidoc.attributes['page-has-custom-nav'] = 'true'

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -1,304 +1,207 @@
 'use strict'
 
 /**
- * Unified Navigation Extension
+ * Unified Navigation Extension (Config-Driven)
  *
- * Creates a unified navigation structure for components within an umbrella section.
- * Discovers child components dynamically based on page-header-data.section attribute.
- * Supports nested buckets via parent-component attribute.
+ * Creates a unified navigation structure based on component configuration.
+ * Components define their navigation hierarchy via the 'page-navigation' attribute in antora.yml.
+ * Supports nested buckets with version detection and breadcrumb hierarchy computation.
  *
- * Configuration:
- * - umbrellaSection: The section name to match (e.g., 'Data Platform')
- * - umbrellaComponent: The umbrella component name (e.g., 'data-platform')
+ * Configuration: No playbook configuration needed - reads from component antora.yml files.
  *
- * The extension reads from each component's existing page-header-data:
- * - title: Display name
- * - color: Theme color
- * - order: Sort order
- * - icon: Tabler icon name (optional)
- * - parent-component: Parent component name for nesting (optional)
+ * Component antora.yml configuration:
+ * asciidoc:
+ *   attributes:
+ *     component-metadata:
+ *       title: "Component Name"
+ *       color: "#hexcolor"
+ *       icon: "tabler-icon-name"
+ *       order: 10
+ *     page-navigation:
+ *       - component-name
+ *       - parent-component:
+ *           - child-component-1
+ *           - child-component-2
  *
- * Output: Attaches 'page-unified-navigation' (JSON array) and 'page-is-unified-nav' (boolean)
- * to all pages in the umbrella and child components. Supports hierarchical nesting.
+ * Output: Attaches to pages with page-navigation config:
+ * - 'page-custom-navigation' (JSON array of buckets)
+ * - 'page-has-custom-nav' (boolean)
+ * - 'page-is-umbrella-nav' (boolean)
+ * - 'page-breadcrumb-hierarchy' (JSON array of breadcrumb items)
  *
- * Example playbook configuration:
- * antora:
- *   extensions:
- *     - require: '@redpanda-data/docs-extensions-and-macros/extensions/unified-navigation'
- *       umbrellaSection: 'Data Platform'
- *       umbrellaComponent: 'data-platform'
+ * Components without page-navigation use standard Antora navigation.
  */
 
-module.exports.register = function ({ config }) {
+module.exports.register = function () {
   const logger = this.getLogger('unified-navigation-extension')
-
-  // Antora lowercases config keys, so use lowercase
-  const umbrellaSection = config?.umbrellasection
-  const umbrellaComponent = config?.umbrellacomponent
-
-  if (!umbrellaSection || !umbrellaComponent) {
-    logger.warn('Missing required configuration: umbrellasection and umbrellacomponent')
-    logger.warn(`Received config: ${JSON.stringify(config || {})}`)
-    return
-  }
-
-  logger.warn(`Configuring unified navigation for section '${umbrellaSection}' with umbrella '${umbrellaComponent}'`)
 
   this.on('navigationBuilt', ({ contentCatalog }) => {
     try {
+      // Build a set of published page URLs (pages that have page.out defined)
+      const allPages = contentCatalog.getPages()
+      const publishedUrlsSet = new Set(
+        allPages
+          .filter((page) => page.out && page.pub && page.pub.url)
+          .map((page) => page.pub.url)
+      )
+
       const components = contentCatalog.getComponents()
 
-      // Find the umbrella component
-      const umbrella = components.find((c) => c.name === umbrellaComponent)
-      if (!umbrella) {
-        logger.warn(`Umbrella component '${umbrellaComponent}' not found`)
-        return
-      }
+      // Build component version navigation map (used by both config-driven and section-based nav)
+      const componentVersionNavMap = buildComponentVersionNavMap(components)
 
-      // Find child components by matching page-header-data.section
-      const childComponents = components.filter((c) => {
-        if (c.name === umbrellaComponent) return false
-        const latestVersion = c.latestVersion || c.versions[0]
-        if (!latestVersion) return false
-        const headerData = getHeaderData(latestVersion)
-        return headerData && headerData.section === umbrellaSection
-      })
-
-      if (childComponents.length === 0) {
-        logger.warn(`No child components found for section '${umbrellaSection}'`)
-        return
-      }
-
-      logger.warn(
-        `Found ${childComponents.length} child components for '${umbrellaSection}': ${childComponents.map((c) => c.name).join(', ')}`
-      )
-
-      // Build a map of component -> version -> navigation for quick lookup
-      // Include the umbrella component as well
-      const componentVersionNavMap = new Map()
-
-      // Add umbrella component first
-      const umbrellaLatestVersion = umbrella.latestVersion || umbrella.versions[0]
-      if (umbrellaLatestVersion) {
-        const versionMap = new Map()
-        for (const version of umbrella.versions) {
-          versionMap.set(version.version, {
-            navigation: version.navigation || [],
-            displayVersion: version.displayVersion || version.version,
-          })
-        }
-        componentVersionNavMap.set(umbrella.name, {
-          component: umbrella,
-          versionMap,
-          latestVersion: umbrellaLatestVersion,
-        })
-      }
-
-      // Add child components
-      for (const component of childComponents) {
-        const versionMap = new Map()
-        for (const version of component.versions) {
-          versionMap.set(version.version, {
-            navigation: version.navigation || [],
-            displayVersion: version.displayVersion || version.version,
-          })
-        }
-        componentVersionNavMap.set(component.name, {
-          component,
-          versionMap,
-          latestVersion: component.latestVersion || component.versions[0],
-        })
-      }
-
-      // Build base component metadata (without navigation - that's added per-page)
-      const allMetadata = childComponents
-        .map((component) => {
-          const latestVersion = component.latestVersion || component.versions[0]
-          const headerData = getHeaderData(latestVersion)
-
-          if (!headerData) {
-            logger.warn(`No page-header-data found for component '${component.name}'`)
-            return null
-          }
-
-          // Build versions array with metadata
-          const versions = component.versions.map((v) => ({
-            version: v.version,
-            displayVersion: v.displayVersion || v.version,
-            url: v.url,
-            isPrerelease: !!v.prerelease,
-            releaseDate: v.asciidoc?.attributes?.['page-release-date'] || null,
-            isEol: v.asciidoc?.attributes?.['page-is-past-eol'] === 'true',
-          }))
-
-          return {
-            componentName: component.name,
-            title: headerData.title || component.title,
-            icon: headerData.icon || null,
-            color: headerData.color || '#6366f1',
-            order: headerData.order || 999,
-            parentComponent: headerData['parent-component'] || null,
-            versions: versions,
-            componentUrl: component.url,
-            isUmbrella: false,
-          }
-        })
-        .filter(Boolean)
-
-      // Build hierarchical structure: separate parents from children
-      const parentMetadata = allMetadata.filter((m) => !m.parentComponent)
-      const childMetadataMap = new Map()
-
-      // Group children by parent
-      for (const meta of allMetadata) {
-        if (meta.parentComponent) {
-          if (!childMetadataMap.has(meta.parentComponent)) {
-            childMetadataMap.set(meta.parentComponent, [])
-          }
-          childMetadataMap.get(meta.parentComponent).push(meta)
-        }
-      }
-
-      // Attach children to parents and sort
-      const componentMetadata = parentMetadata
-        .map((parent) => {
-          const children = childMetadataMap.get(parent.componentName) || []
-          return {
-            ...parent,
-            children: children.sort((a, b) => a.order - b.order),
-          }
-        })
-        .sort((a, b) => a.order - b.order)
-
-      logger.warn(`Built hierarchical navigation: ${componentMetadata.length} parent buckets`)
-      for (const parent of componentMetadata) {
-        if (parent.children.length > 0) {
-          logger.warn(`  ${parent.componentName} has ${parent.children.length} children: ${parent.children.map((c) => c.componentName).join(', ')}`)
-        }
-      }
-
-      if (componentMetadata.length === 0) {
-        logger.warn('No valid navigation buckets built')
-        return
-      }
-
-      // Only attach unified navigation to:
-      // 1. The umbrella component (data-platform)
-      // 2. Components that are parents WITH children (nested hierarchy roots)
-      // 3. Components that have a parent (children in nested hierarchy)
-      const parentComponentNames = new Set()
-      const childComponentNames = new Set()
-      for (const parent of componentMetadata) {
-        if (parent.children && parent.children.length > 0) {
-          // Only add parents that have children
-          parentComponentNames.add(parent.componentName)
-          for (const child of parent.children) {
-            childComponentNames.add(child.componentName)
-          }
-        }
-      }
-      const affectedComponentNames = new Set([
-        umbrellaComponent,
-        ...parentComponentNames,
-        ...childComponentNames,
-      ])
-
-      // Get all pages and set attributes on pages belonging to affected components
+      // PHASE 1: Config-Driven Navigation
+      // Step 1: Collect all components with page-navigation config
       const pages = contentCatalog.getPages()
-      let pageCount = 0
+      const configDrivenPages = new Set()
+      const componentConfigs = new Map() // component -> {configTree, configOwner}
 
-      for (const page of pages) {
-        if (!page.src || !affectedComponentNames.has(page.src.component)) continue
+      // First pass: find components with page-navigation config
+      for (const component of components) {
+        for (const version of component.versions) {
+          const navConfig = version.asciidoc?.attributes?.['page-navigation']
+          if (navConfig) {
+            try {
+              const configTree = parseNavigationConfig(navConfig)
+              if (configTree.length > 0) {
+                // Store config and extract all component names mentioned
+                const allComponentsInConfig = new Set()
+                const extractComponents = (tree) => {
+                  for (const item of tree) {
+                    allComponentsInConfig.add(item.name)
+                    if (item.children) {
+                      extractComponents(item.children)
+                    }
+                  }
+                }
+                extractComponents(configTree)
 
-        const pageComponent = page.src.component
-        const pageVersion = page.src.version
+                // Store config for the owner
+                // A component's OWN config always takes priority (regardless of depth)
+                const existingOwnerConfig = componentConfigs.get(component.name)
 
-        // Determine which buckets to show based on current page
-        let bucketsToShow
-        let isUmbrellaPage = false
-        if (pageComponent === umbrellaComponent) {
-          // Umbrella page: show all top-level buckets
-          bucketsToShow = componentMetadata
-          isUmbrellaPage = true
-        } else {
-          // Find which parent hierarchy this page belongs to
-          const pageIsParent = componentMetadata.some((m) => m.componentName === pageComponent)
-          if (pageIsParent) {
-            // Current page is a parent bucket - show only this parent and its children
-            bucketsToShow = componentMetadata.filter((m) => m.componentName === pageComponent)
-          } else {
-            // Current page is a child - find its parent and show that parent + children
-            let parentBucket = null
-            for (const parent of componentMetadata) {
-              if (parent.children && parent.children.some((c) => c.componentName === pageComponent)) {
-                parentBucket = parent
-                break
+                if (!existingOwnerConfig || existingOwnerConfig.configOwner !== component.name) {
+                  // No existing config, or existing config is from another component - use this one
+                  componentConfigs.set(component.name, {
+                    configTree,
+                    configOwner: component.name,
+                    allComponents: allComponentsInConfig,
+                  })
+                  console.log(`[config] Storing ${component.name}'s OWN config (root items: ${Array.from(allComponentsInConfig).join(', ')})`)
+                } else {
+                  // Existing config is also from this component - compare depths
+                  const existingOwnerDepth = getComponentDepth(existingOwnerConfig.configTree, component.name)
+                  const newOwnerDepth = getComponentDepth(configTree, component.name)
+                  if (newOwnerDepth >= existingOwnerDepth) {
+                    // New config has equal or better hierarchy, use it
+                    componentConfigs.set(component.name, {
+                      configTree,
+                      configOwner: component.name,
+                      allComponents: allComponentsInConfig,
+                    })
+                    console.log(`[config] Updating ${component.name}'s OWN config (better depth)`)
+                  }
+                }
+
+                // Also store this config for all child components
+                // Prefer configs with deeper nesting (more parent context for breadcrumbs)
+                for (const childComponent of allComponentsInConfig) {
+                  const existingConfig = componentConfigs.get(childComponent)
+                  const newDepth = getComponentDepth(configTree, childComponent)
+
+                  if (!existingConfig) {
+                    // No existing config, store this one
+                    componentConfigs.set(childComponent, {
+                      configTree,
+                      configOwner: component.name,
+                      allComponents: allComponentsInConfig,
+                    })
+                  } else {
+                    // Compare depths - prefer deeper nesting (more parent context)
+                    const existingDepth = getComponentDepth(existingConfig.configTree, childComponent)
+                    if (newDepth > existingDepth) {
+                      // New config has more parent context, prefer it for breadcrumbs
+                      componentConfigs.set(childComponent, {
+                        configTree,
+                        configOwner: component.name,
+                        allComponents: allComponentsInConfig,
+                      })
+                    }
+                  }
+                }
               }
+            } catch (error) {
+              logger.error(`Error parsing page-navigation for ${component.name}: ${error.message}`)
             }
-            bucketsToShow = parentBucket ? [parentBucket] : componentMetadata
           }
         }
-
-        // Build unified navigation for this specific page
-        // Recursive function to process bucket and its children
-        const processBucket = (meta) => {
-          const isCurrentBucket = meta.componentName === pageComponent
-          const compData = componentVersionNavMap.get(meta.componentName)
-
-          let navigation, currentVersion
-          if (isCurrentBucket && compData) {
-            // For the current bucket, use the page's version navigation
-            const versionData = compData.versionMap.get(pageVersion)
-            if (versionData) {
-              navigation = versionData.navigation
-              currentVersion = versionData.displayVersion
-            } else {
-              // Fallback to latest if version not found
-              navigation = compData.latestVersion?.navigation || []
-              currentVersion = compData.latestVersion?.displayVersion || compData.latestVersion?.version
-            }
-          } else if (compData) {
-            // For other buckets, use the latest version navigation
-            navigation = compData.latestVersion?.navigation || []
-            currentVersion = compData.latestVersion?.displayVersion || compData.latestVersion?.version
-          } else {
-            navigation = []
-            currentVersion = null
-          }
-
-          const result = {
-            ...meta,
-            isCurrentBucket,
-            currentVersion,
-            items: navigation,
-          }
-
-          // Process children recursively
-          if (meta.children && meta.children.length > 0) {
-            result.children = meta.children.map(processBucket)
-            // Determine if parent should be expanded (if any child is current)
-            result.hasCurrentChild = result.children.some((c) => c.isCurrentBucket || c.hasCurrentChild)
-          }
-
-          return result
-        }
-
-        const navForPage = bucketsToShow.map(processBucket)
-
-        // Ensure asciidoc.attributes exists on the page
-        page.asciidoc = page.asciidoc || {}
-        page.asciidoc.attributes = page.asciidoc.attributes || {}
-
-        // Attach as JSON string (templates will receive this as page.attributes.unified-navigation)
-        page.asciidoc.attributes['page-unified-navigation'] = JSON.stringify(navForPage)
-        page.asciidoc.attributes['page-is-unified-nav'] = 'true'
-        page.asciidoc.attributes['page-is-umbrella-nav'] = isUmbrellaPage ? 'true' : 'false'
-        pageCount++
       }
 
-      logger.warn(
-        `Attached unified navigation to ${pageCount} pages across ${affectedComponentNames.size} components (${Array.from(affectedComponentNames).join(', ')})`
-      )
+      // Step 1.5: Find the home component's config for breadcrumb calculations
+      // Home has the full hierarchy, so use it for ALL breadcrumb computations
+      const homeConfig = componentConfigs.get('home')
+
+      // Step 2: Apply navigation to all pages of components mentioned in configs
+      for (const page of pages) {
+        if (!page.src) continue
+
+        const configData = componentConfigs.get(page.src.component)
+        if (!configData) continue // No config for this component
+
+        try {
+          // Filter config tree to show only relevant hierarchy for current page
+          const relevantTree = filterConfigTreeForComponent(configData.configTree, page.src.component)
+
+          if (page.src.component === 'streaming' && page.src.path.includes('home/index')) {
+            logger.warn(
+              `Streaming home page: filtered tree has ${relevantTree.length} root items: ${relevantTree.map((t) => t.name).join(', ')}`
+            )
+          }
+
+          const buckets = buildBucketsFromConfig(
+            relevantTree,
+            contentCatalog,
+            page.src.component,
+            page.src.version,
+            publishedUrlsSet,
+            componentVersionNavMap,
+            page
+          )
+
+          // Always compute breadcrumb hierarchy from HOME config (which has full hierarchy)
+          // This ensures components like self-managed show "Docs > Data Platform > Self-Managed"
+          // instead of just "Docs > Self-Managed"
+          page.asciidoc = page.asciidoc || {}
+          page.asciidoc.attributes = page.asciidoc.attributes || {}
+
+          if (homeConfig) {
+            const hierarchy = findComponentPath(homeConfig.configTree, page.src.component, contentCatalog)
+            if (hierarchy) {
+              page.asciidoc.attributes['page-breadcrumb-hierarchy'] = JSON.stringify(hierarchy)
+            }
+          }
+
+          // Only set custom navigation if buckets exist AND component is not standalone
+          // Standalone components appear at root level with no children (e.g., agentic-data-plane)
+          // They appear in product switcher/home nav but use standard Antora nav on their own pages
+          const isStandaloneComponent = isStandalone(configData.configTree, page.src.component)
+
+          if (buckets.length > 0 && !isStandaloneComponent) {
+            page.asciidoc.attributes['page-custom-navigation'] = JSON.stringify(buckets)
+            page.asciidoc.attributes['page-has-custom-nav'] = 'true'
+            // Set is-umbrella-nav to show parent bucket headers
+            page.asciidoc.attributes['page-is-umbrella-nav'] = 'true'
+          }
+
+          configDrivenPages.add(page.src.component)
+        } catch (error) {
+          logger.error(`Error processing navigation for ${page.src.path}: ${error.message}`)
+        }
+      }
+
+      if (configDrivenPages.size > 0) {
+        logger.warn(`Processed config-driven navigation for ${configDrivenPages.size} components: ${Array.from(configDrivenPages).join(', ')}`)
+      }
     } catch (error) {
       logger.error(`Error building unified navigation: ${error.message}`)
       logger.error(error.stack)
@@ -307,13 +210,384 @@ module.exports.register = function ({ config }) {
 }
 
 /**
- * Extract page-header-data from a component version
+ * Build a map of component navigation data for quick lookup
+ * @param {Array} components - Array of component objects from content catalog
+ * @returns {Map} Map of component name -> { component, versionMap, latestVersion }
+ */
+function buildComponentVersionNavMap(components) {
+  const map = new Map()
+
+  for (const component of components) {
+    const versionMap = new Map()
+    for (const version of component.versions) {
+      versionMap.set(version.version, {
+        navigation: version.navigation || [],
+        displayVersion: version.displayVersion || version.version,
+      })
+    }
+
+    map.set(component.name, {
+      component,
+      versionMap,
+      latestVersion: component.latestVersion || component.versions[0],
+    })
+  }
+
+  return map
+}
+
+/**
+ * Filter navigation items to exclude unpublished pages
+ * @param {Array} items - Navigation items array
+ * @param {Map} publishedUrlsSet - Set of published page URLs
+ * @returns {Array} Filtered navigation items
+ */
+function filterUnpublishedPages(items, publishedUrlsSet) {
+  if (!Array.isArray(items)) return []
+
+  return items
+    .map((item) => {
+      // If item has a URL, check if it's in the published URLs set
+      if (item.url) {
+        // Skip items whose pages aren't published
+        if (!publishedUrlsSet.has(item.url)) {
+          return null
+        }
+      }
+
+      // Recursively filter children
+      if (item.items && Array.isArray(item.items)) {
+        item.items = filterUnpublishedPages(item.items, publishedUrlsSet)
+      }
+
+      return item
+    })
+    .filter(Boolean) // Remove null entries
+}
+
+/**
+ * Extract component-metadata from a component version
  * @param {Object} version - Component version object
- * @returns {Object|null} The page-header-data object or null
+ * @returns {Object|null} The component-metadata object or null
  */
 function getHeaderData(version) {
   if (!version || !version.asciidoc || !version.asciidoc.attributes) {
     return null
   }
-  return version.asciidoc.attributes['page-header-data'] || null
+  return version.asciidoc.attributes['component-metadata'] || null
+}
+
+/**
+ * Find the depth of a component in a config tree
+ * @param {Array} tree - Navigation config tree
+ * @param {string} targetComponent - Component name to find
+ * @param {number} currentDepth - Current depth in recursion
+ * @returns {number} Depth of component (0 = root level), or -1 if not found
+ */
+function getComponentDepth(tree, targetComponent, currentDepth = 0) {
+  for (const item of tree) {
+    if (item.name === targetComponent) {
+      return currentDepth
+    }
+    if (item.children) {
+      const childDepth = getComponentDepth(item.children, targetComponent, currentDepth + 1)
+      if (childDepth !== -1) return childDepth
+    }
+  }
+  return -1 // Not found
+}
+
+/**
+ * Parse page-navigation YAML config into component tree structure
+ * @param {string|array} navConfig - YAML string or parsed array from page-navigation attribute
+ * @returns {Array} Array of bucket definitions with hierarchy
+ *
+ * Example input:
+ * - data-platform:
+ *     - cloud-data-platform
+ *     - self-managed: [streaming, connect]
+ * - redpanda-adp
+ *
+ * Example output:
+ * [{
+ *   name: 'data-platform',
+ *   children: [
+ *     { name: 'cloud-data-platform' },
+ *     { name: 'self-managed', children: [{ name: 'streaming' }, { name: 'connect' }] }
+ *   ]
+ * }, { name: 'redpanda-adp' }]
+ */
+function parseNavigationConfig(navConfig) {
+  // If it's already an array (from YAML parsing), use it directly
+  const config = typeof navConfig === 'string' ? JSON.parse(navConfig) : navConfig
+
+  if (!Array.isArray(config)) {
+    return []
+  }
+
+  function parseItem(item) {
+    if (typeof item === 'string') {
+      // Simple component name
+      return { name: item }
+    } else if (typeof item === 'object' && item !== null) {
+      // Object with component name as key and children as value
+      const keys = Object.keys(item)
+      if (keys.length === 0) return null
+
+      const name = keys[0]
+      const childrenValue = item[name]
+
+      if (!childrenValue) {
+        return { name }
+      }
+
+      // Parse children (can be array of strings, objects, or mix)
+      const children = Array.isArray(childrenValue)
+        ? childrenValue.map(parseItem).filter(Boolean)
+        : [parseItem(childrenValue)].filter(Boolean)
+
+      return { name, children: children.length > 0 ? children : undefined }
+    }
+
+    return null
+  }
+
+  return config.map(parseItem).filter(Boolean)
+}
+
+/**
+ * Build navigation buckets from parsed config tree
+ * @param {Array} configTree - Parsed navigation config tree
+ * @param {Object} contentCatalog - Antora content catalog
+ * @param {string} currentPageComponent - Current page's component name
+ * @param {string} currentPageVersion - Current page's version
+ * @param {Set} publishedUrlsSet - Set of published page URLs
+ * @param {Map} componentVersionNavMap - Map of component navigation data
+ * @returns {Array} Array of bucket objects for templates
+ */
+/**
+ * Check if a component is standalone (root-level with no children)
+ * Standalone components appear in product switcher but use standard Antora nav
+ * @param {Array} configTree - Parsed navigation config tree
+ * @param {string} componentName - Component name to check
+ * @returns {boolean} True if component is standalone
+ */
+function isStandalone(configTree, componentName) {
+  for (const item of configTree) {
+    if (item.name === componentName) {
+      // Component found at root level
+      return !item.children || item.children.length === 0
+    }
+  }
+  return false
+}
+
+/**
+ * Filter config tree to show only relevant hierarchy for a component
+ * - If component is at root level: return entire tree
+ * - If component is a parent (has children): return that parent with its children
+ * - If component is a child (leaf): return parent + siblings (parent marked for nav-only display)
+ * @param {Array} configTree - Full navigation config tree
+ * @param {string} componentName - Current page component
+ * @returns {Array} Filtered config tree
+ */
+function filterConfigTreeForComponent(configTree, componentName) {
+  const treeNames = configTree.map(t => t.name).join(', ')
+  console.log(`[filterConfigTreeForComponent] Called for ${componentName}, root items: [${treeNames}]`)
+
+  // Check if component is at root level
+  for (const item of configTree) {
+    if (item.name === componentName) {
+      console.log(`[filterConfigTreeForComponent] ${componentName}: FOUND at root level, hasChildren: ${!!item.children}`)
+      // Component is at root - if it has children, show parent nav items + children as buckets
+      if (item.children) {
+        // Return parent with showNavItemsOnly flag + children as separate buckets
+        const result = [{ ...item, showNavItemsOnly: true, children: undefined }, ...item.children]
+        console.log(`[filterConfigTreeForComponent] ${componentName}: returning parent with showNavItemsOnly + ${item.children.length} children`)
+        return result
+      }
+      console.log(`[filterConfigTreeForComponent] ${componentName}: no children, returning original tree`)
+      return configTree
+    }
+  }
+
+  console.log(`[filterConfigTreeForComponent] ${componentName}: NOT found at root, searching nested...`)
+
+  // Component is nested - find it and determine if it's a parent or child
+  function findComponentAndParent(items, parent = null) {
+    for (const item of items) {
+      if (item.name === componentName) {
+        // Found the component
+        if (item.children) {
+          // Component is a parent - return it with its children
+          return { isParent: true, parent: null, result: [item] }
+        } else {
+          // Component is a leaf child
+          // Check if there are other leaf siblings (to determine if we should show siblings)
+          const siblings = parent ? parent.children.filter(child => child.name !== componentName) : []
+          const hasLeafSiblings = siblings.some(sibling => !sibling.children)
+
+          if (hasLeafSiblings) {
+            // Has other leaf siblings - show parent nav + all siblings (like Streaming/Connect)
+            // Mark parent as "showNavItemsOnly" so it doesn't render as a bucket header
+            return { isParent: false, parent: parent, result: parent ? [{ ...parent, showNavItemsOnly: true }, ...parent.children] : [item] }
+          } else {
+            // No leaf siblings (standalone like Cloud) - return empty to use standard nav
+            return { isParent: false, parent: null, result: [] }
+          }
+        }
+      }
+
+      if (item.children) {
+        const found = findComponentAndParent(item.children, item)
+        if (found) return found
+      }
+    }
+    return null
+  }
+
+  const found = findComponentAndParent(configTree)
+  return found ? found.result : configTree // Fallback to full tree if not found
+}
+
+function buildBucketsFromConfig(
+  configTree,
+  contentCatalog,
+  currentPageComponent,
+  currentPageVersion,
+  publishedUrlsSet,
+  componentVersionNavMap,
+  page
+) {
+  // Get list of buckets to expand by default from page attribute
+  const expandBucketsAttr = page?.asciidoc?.attributes?.['page-expand-buckets'] || ''
+  const expandBuckets = expandBucketsAttr.split(',').map((s) => s.trim()).filter(Boolean)
+
+  function buildBucket(configItem) {
+    const componentName = configItem.name
+    const component = contentCatalog.getComponent(componentName)
+
+    if (!component) {
+      return null // Component not found
+    }
+
+    const latestVersion = component.latestVersion || component.versions[0]
+    if (!latestVersion) {
+      return null
+    }
+
+    // Get metadata from component-metadata
+    const metadata = getHeaderData(latestVersion)
+    if (!metadata) {
+      return null
+    }
+
+    // Build versions array
+    const versions = component.versions.map((v) => ({
+      version: v.version,
+      displayVersion: v.displayVersion || v.version,
+      url: v.url,
+      isPrerelease: !!v.prerelease,
+      releaseDate: v.asciidoc?.attributes?.['page-release-date'] || null,
+      isEol: v.asciidoc?.attributes?.['page-is-past-eol'] === 'true',
+    }))
+
+    // Determine if this is the current bucket
+    const isCurrentBucket = componentName === currentPageComponent
+
+    // Check if this bucket should be expanded by default (from page attribute)
+    const isExpandedByDefault = expandBuckets.includes(componentName)
+
+    // Get navigation for this component
+    let navigation, displayVersion
+    const compData = componentVersionNavMap.get(componentName)
+
+    if (isCurrentBucket && compData) {
+      // For current bucket, use page's version
+      const versionData = compData.versionMap.get(currentPageVersion)
+      if (versionData) {
+        navigation = versionData.navigation
+        displayVersion = versionData.displayVersion
+      } else {
+        navigation = compData.latestVersion?.navigation || []
+        displayVersion = compData.latestVersion?.displayVersion || compData.latestVersion?.version
+      }
+    } else if (compData) {
+      // For other buckets, use latest version
+      navigation = compData.latestVersion?.navigation || []
+      displayVersion = compData.latestVersion?.displayVersion || compData.latestVersion?.version
+    } else {
+      navigation = []
+      displayVersion = latestVersion.displayVersion || latestVersion.version
+    }
+
+    // Filter unpublished pages
+    const filteredNavigation = filterUnpublishedPages(navigation, publishedUrlsSet)
+
+    const bucket = {
+      componentName,
+      title: metadata.title || component.title || componentName,
+      color: metadata.color || '#6366f1',
+      icon: metadata.icon || null,
+      order: metadata.order || 999,
+      versions,
+      currentVersion: displayVersion,
+      isCurrentBucket,
+      isExpandedByDefault,
+      items: filteredNavigation,
+      componentUrl: component.url,
+      showNavItemsOnly: configItem.showNavItemsOnly || false, // Flag for rendering nav items without bucket header,
+    }
+
+    // Process children recursively
+    if (configItem.children && configItem.children.length > 0) {
+      bucket.children = configItem.children.map(buildBucket).filter(Boolean)
+      // Determine if parent should be expanded
+      bucket.hasCurrentChild = bucket.children.some((c) => c.isCurrentBucket || c.hasCurrentChild)
+    }
+
+    return bucket
+  }
+
+  return configTree.map(buildBucket).filter(Boolean)
+}
+
+/**
+ * Find component's position in navigation hierarchy for breadcrumbs
+ * @param {Array} configTree - Parsed navigation config tree
+ * @param {string} targetComponent - Component to find
+ * @param {Object} contentCatalog - Antora content catalog
+ * @returns {Array|null} Array of breadcrumb items or null
+ */
+function findComponentPath(configTree, targetComponent, contentCatalog) {
+  function search(items, path = []) {
+    for (const item of items) {
+      const componentName = item.name
+      const component = contentCatalog.getComponent(componentName)
+
+      if (!component) continue
+
+      const latestVersion = component.latestVersion || component.versions[0]
+      const metadata = latestVersion ? getHeaderData(latestVersion) : null
+
+      const breadcrumbItem = {
+        component: componentName,
+        title: metadata?.title || component.title || componentName,
+        url: component.url || `/${componentName}/`,
+      }
+
+      if (componentName === targetComponent) {
+        return [...path, breadcrumbItem]
+      }
+
+      if (item.children && item.children.length > 0) {
+        const childPath = search(item.children, [...path, breadcrumbItem])
+        if (childPath) return childPath
+      }
+    }
+
+    return null
+  }
+
+  return search(configTree)
 }

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -152,8 +152,23 @@ module.exports.register = function () {
           // Filter config tree to show only relevant hierarchy for current page
           const relevantTree = filterConfigTreeForComponent(configData.configTree, page.src.component)
 
+          // Check if this component has children and owns the config
+          const hasChildComponents = componentHasChildren(configData.configTree, page.src.component)
+          const ownsConfig = configData.configOwner === page.src.component
+
+          // If component has children and owns config, we'll show its nav items outside buckets
+          // So build buckets only for children, not for the parent itself
+          let treeForBuckets = relevantTree
+          if (hasChildComponents && ownsConfig && relevantTree.length > 0) {
+            // Extract children from parent node
+            const parentNode = relevantTree.find(item => item.name === page.src.component)
+            if (parentNode && parentNode.children) {
+              treeForBuckets = parentNode.children
+            }
+          }
+
           const buckets = buildBucketsFromConfig(
-            relevantTree,
+            treeForBuckets,
             contentCatalog,
             page.src.component,
             page.src.version,
@@ -184,14 +199,7 @@ module.exports.register = function () {
             // Build full navigation array
             let fullNavigation = []
 
-            // Only show a component's nav items outside buckets if BOTH:
-            // 1. Component has children (defines child buckets)
-            // 2. Component owns the config (defined page-navigation in its own antora.yml)
-            // This ensures data-platform shows its nav items, but self-managed (which inherits
-            // data-platform's config and has children) doesn't duplicate its items
-            const hasChildComponents = componentHasChildren(configData.configTree, page.src.component)
-            const ownsConfig = configData.configOwner === page.src.component
-
+            // If component has children and owns config, show its nav items outside buckets
             if (hasChildComponents && ownsConfig) {
               // Get the component's own nav items (from nav.adoc) to prepend before child buckets
               const compData = componentVersionNavMap.get(page.src.component)

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -181,7 +181,20 @@ module.exports.register = function () {
           const isStandaloneComponent = isStandalone(configData.configTree, page.src.component)
 
           if (buckets.length > 0 && !isStandaloneComponent) {
-            page.asciidoc.attributes['page-custom-navigation'] = JSON.stringify(buckets)
+            // Get the component's own nav items (from nav.adoc) to prepend before buckets
+            const compData = componentVersionNavMap.get(page.src.component)
+            let ownNavItems = []
+            if (compData) {
+              const versionData = compData.versionMap.get(page.src.version)
+              if (versionData && versionData.navigation) {
+                ownNavItems = filterUnpublishedPages(versionData.navigation, publishedUrlsSet)
+              }
+            }
+
+            // Prepend component's own nav items before child buckets
+            const fullNavigation = [...ownNavItems, ...buckets]
+
+            page.asciidoc.attributes['page-custom-navigation'] = JSON.stringify(fullNavigation)
             page.asciidoc.attributes['page-has-custom-nav'] = 'true'
             // Set is-umbrella-nav to show parent bucket headers
             page.asciidoc.attributes['page-is-umbrella-nav'] = 'true'

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -184,13 +184,12 @@ module.exports.register = function () {
             // Build full navigation array
             let fullNavigation = []
 
-            // Check if this component is a top-level parent that has both its own pages AND child components
-            // Only top-level parents (like data-platform) should show their own nav items + child buckets
-            // Child components (like streaming) should only show child buckets (their siblings)
-            const isTopLevelParent = relevantTree.length > 0 &&
-                                     relevantTree.some(item => item.name === page.src.component && item.children)
+            // Check if this component is a parent that defines child components in the config tree
+            // Only components with children (like data-platform) should show their own nav items + child buckets
+            // Leaf components (like streaming) should only show sibling buckets
+            const hasChildComponents = componentHasChildren(configData.configTree, page.src.component)
 
-            if (isTopLevelParent) {
+            if (hasChildComponents) {
               // Get the component's own nav items (from nav.adoc) to prepend before child buckets
               const compData = componentVersionNavMap.get(page.src.component)
               let ownNavItems = []
@@ -303,6 +302,28 @@ function getHeaderData(version) {
     return null
   }
   return version.asciidoc.attributes['component-metadata'] || null
+}
+
+/**
+ * Check if a component has children in the config tree
+ * @param {Array} tree - Navigation config tree
+ * @param {string} componentName - Component name to search for
+ * @returns {boolean} True if component has children
+ */
+function componentHasChildren(tree, componentName) {
+  if (!Array.isArray(tree)) return false
+
+  for (const item of tree) {
+    if (item.name === componentName && item.children && item.children.length > 0) {
+      return true
+    }
+    if (item.children) {
+      if (componentHasChildren(item.children, componentName)) {
+        return true
+      }
+    }
+  }
+  return false
 }
 
 /**

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const yaml = require('js-yaml')
+
 /**
  * Unified Navigation Extension (Config-Driven)
  *
@@ -151,7 +153,7 @@ module.exports.register = function () {
           const relevantTree = filterConfigTreeForComponent(configData.configTree, page.src.component)
 
           if (page.src.component === 'streaming' && page.src.path.includes('home/index')) {
-            logger.warn(
+            logger.debug(
               `Streaming home page: filtered tree has ${relevantTree.length} root items: ${relevantTree.map((t) => t.name).join(', ')}`
             )
           }
@@ -198,7 +200,7 @@ module.exports.register = function () {
       }
 
       if (configDrivenPages.size > 0) {
-        logger.warn(`Processed config-driven navigation for ${configDrivenPages.size} components: ${Array.from(configDrivenPages).join(', ')}`)
+        logger.info(`Processed config-driven navigation for ${configDrivenPages.size} components: ${Array.from(configDrivenPages).join(', ')}`)
       }
     } catch (error) {
       logger.error(`Error building unified navigation: ${error.message}`)
@@ -253,12 +255,15 @@ function filterUnpublishedPages(items, publishedUrlsSet) {
         }
       }
 
+      // Create a shallow copy of the item to avoid mutation
+      const newItem = { ...item }
+
       // Recursively filter children
-      if (item.items && Array.isArray(item.items)) {
-        item.items = filterUnpublishedPages(item.items, publishedUrlsSet)
+      if (newItem.items && Array.isArray(newItem.items)) {
+        newItem.items = filterUnpublishedPages(newItem.items, publishedUrlsSet)
       }
 
-      return item
+      return newItem
     })
     .filter(Boolean) // Remove null entries
 }
@@ -317,7 +322,7 @@ function getComponentDepth(tree, targetComponent, currentDepth = 0) {
  */
 function parseNavigationConfig(navConfig) {
   // If it's already an array (from YAML parsing), use it directly
-  const config = typeof navConfig === 'string' ? JSON.parse(navConfig) : navConfig
+  const config = typeof navConfig === 'string' ? yaml.load(navConfig) : navConfig
 
   if (!Array.isArray(config)) {
     return []

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -164,7 +164,12 @@ module.exports.register = function () {
             const parentNode = relevantTree.find(item => item.name === page.src.component)
             if (parentNode && parentNode.children) {
               treeForBuckets = parentNode.children
+              logger.debug(`${page.src.component}: Extracted ${parentNode.children.length} children for buckets: ${parentNode.children.map(c => c.name).join(', ')}`)
+            } else {
+              logger.warn(`${page.src.component}: Has children but couldn't extract them from relevantTree`)
             }
+          } else {
+            logger.debug(`${page.src.component}: Using full relevantTree (hasChildren=${hasChildComponents}, ownsConfig=${ownsConfig}, treeLength=${relevantTree.length})`)
           }
 
           const buckets = buildBucketsFromConfig(
@@ -201,6 +206,7 @@ module.exports.register = function () {
 
             // If component has children and owns config, show its nav items outside buckets
             if (hasChildComponents && ownsConfig) {
+              logger.debug(`${page.src.component}: Adding nav items outside buckets (has children + owns config)`)
               // Get the component's own nav items (from nav.adoc) to prepend before child buckets
               const compData = componentVersionNavMap.get(page.src.component)
               let ownNavItems = []
@@ -208,6 +214,7 @@ module.exports.register = function () {
                 const versionData = compData.versionMap.get(page.src.version)
                 if (versionData && versionData.navigation) {
                   ownNavItems = filterUnpublishedPages(versionData.navigation, publishedUrlsSet)
+                  logger.debug(`${page.src.component}: Found ${ownNavItems.length} nav items`)
                 }
               }
 
@@ -219,7 +226,12 @@ module.exports.register = function () {
                   showNavItemsOnly: true,
                   isCurrentBucket: true,
                 })
+                logger.debug(`${page.src.component}: Added ${ownNavItems.length} nav items to fullNavigation`)
+              } else {
+                logger.warn(`${page.src.component}: No nav items found despite having children and owning config`)
               }
+            } else {
+              logger.debug(`${page.src.component}: Not adding nav items (hasChildren=${hasChildComponents}, ownsConfig=${ownsConfig})`)
             }
 
             // Add child component buckets

--- a/extensions/unlisted-pages.js
+++ b/extensions/unlisted-pages.js
@@ -7,7 +7,7 @@ module.exports.register = function ({ config }) {
   this.on('navigationBuilt', ({ siteCatalog, contentCatalog }) => {
     contentCatalog.getComponents().forEach(({ versions }) => {
       versions.forEach(({ name: component, version, navigation: nav, url: defaultUrl }) => {
-        if (component === 'api' || component === 'redpanda-labs') return;
+        if (component === 'api' || component === 'labs') return;
         if (!nav) return;
 
         const navEntriesByUrl = getNavEntriesByUrl(nav);

--- a/extensions/unlisted-pages.js
+++ b/extensions/unlisted-pages.js
@@ -23,6 +23,10 @@ module.exports.register = function ({ config }) {
             // Skip field-only pages (generated for includes, not standalone navigation)
             if (page.isFieldOnlyPage) return collector;
 
+            // Skip technical pages that are intentionally unlisted (e.g., llms.txt, sitemap)
+            const technicalPages = ['llms', 'sitemap', 'sitemap-llms'];
+            if (technicalPages.includes(page.src.stem)) return collector;
+
             if (!(page.pub.url in navEntriesByUrl) && page.pub.url !== defaultUrl) {
               logger.warn({ file: page.src, source: page.src.origin }, 'detected unlisted page');
               return collector.concat(page);

--- a/extensions/unpublish-pages.js
+++ b/extensions/unpublish-pages.js
@@ -18,11 +18,11 @@ module.exports.register = function () {
 
       // Debug logging for ANY page with publish-only-during-beta attribute
       if (page.asciidoc?.attributes['publish-only-during-beta']) {
-        logger.warn(`Found page with publish-only-during-beta: ${page.src?.relative || page.pub?.url}`);
-        logger.warn(`  - publish-only-during-beta: ${page.asciidoc?.attributes['publish-only-during-beta']}`);
-        logger.warn(`  - page-component-version-is-prerelease: ${page.asciidoc?.attributes['page-component-version-is-prerelease']}`);
-        logger.warn(`  - page-unpublish: ${page.asciidoc?.attributes['page-unpublish']}`);
-        logger.warn(`  - component: ${componentName}, version: ${pageVersion}`);
+        logger.debug(`Found page with publish-only-during-beta: ${page.src?.relative || page.pub?.url}`);
+        logger.debug(`  - publish-only-during-beta: ${page.asciidoc?.attributes['publish-only-during-beta']}`);
+        logger.debug(`  - page-component-version-is-prerelease: ${page.asciidoc?.attributes['page-component-version-is-prerelease']}`);
+        logger.debug(`  - page-unpublish: ${page.asciidoc?.attributes['page-unpublish']}`);
+        logger.debug(`  - component: ${componentName}, version: ${pageVersion}`);
       }
 
       // Check the conditions for unpublishing the page
@@ -35,7 +35,7 @@ module.exports.register = function () {
 
       // Unpublish the shouldUnpublish pages
       if (shouldUnpublish) {
-        logger.warn(`  -> UNPUBLISHING: ${page.src?.relative || page.pub?.url}`);
+        logger.info(`Unpublishing page: ${page.src?.relative || page.pub?.url}`);
         siteCatalog.unpublishedPages.push(page.pub.url)
         delete page.out;
       }

--- a/extensions/unpublish-pages.js
+++ b/extensions/unpublish-pages.js
@@ -1,6 +1,8 @@
 'use strict';
 
 module.exports.register = function () {
+  const logger = this.getLogger('unpublish-pages-extension');
+
   this.on('documentsConverted', ({ siteCatalog, contentCatalog }) => {
     // Get all pages that have an `out` property
     const pages = contentCatalog.getPages((page) => page.out);
@@ -14,6 +16,15 @@ module.exports.register = function () {
       pageVersion = page.asciidoc?.attributes['page-component-version'];
       const component = contentCatalog.getComponent(componentName);
 
+      // Debug logging for ANY page with publish-only-during-beta attribute
+      if (page.asciidoc?.attributes['publish-only-during-beta']) {
+        logger.warn(`Found page with publish-only-during-beta: ${page.src?.relative || page.pub?.url}`);
+        logger.warn(`  - publish-only-during-beta: ${page.asciidoc?.attributes['publish-only-during-beta']}`);
+        logger.warn(`  - page-component-version-is-prerelease: ${page.asciidoc?.attributes['page-component-version-is-prerelease']}`);
+        logger.warn(`  - page-unpublish: ${page.asciidoc?.attributes['page-unpublish']}`);
+        logger.warn(`  - component: ${componentName}, version: ${pageVersion}`);
+      }
+
       // Check the conditions for unpublishing the page
       const shouldUnpublish = (
         page.asciidoc?.attributes['page-unpublish'] ||
@@ -24,6 +35,7 @@ module.exports.register = function () {
 
       // Unpublish the shouldUnpublish pages
       if (shouldUnpublish) {
+        logger.warn(`  -> UNPUBLISHING: ${page.src?.relative || page.pub?.url}`);
         siteCatalog.unpublishedPages.push(page.pub.url)
         delete page.out;
       }

--- a/extensions/version-fetcher/fetch-latest-docker-tag.js
+++ b/extensions/version-fetcher/fetch-latest-docker-tag.js
@@ -6,9 +6,10 @@
  *
  * @param {string} dockerNamespace - The Docker Hub namespace (organization or username)
  * @param {string} dockerRepo - The repository name on Docker Hub
+ * @param {Object} logger - Optional Antora logger instance for logging
  * @returns {Promise<{ latestStableRelease: string|null, latestBetaRelease: string|null }>}
  */
-module.exports = async (dockerNamespace, dockerRepo) => {
+module.exports = async (dockerNamespace, dockerRepo, logger = null) => {
   const { default: fetch } = await import('node-fetch');
 
   try {
@@ -64,7 +65,11 @@ module.exports = async (dockerNamespace, dockerRepo) => {
     };
 
   } catch (error) {
-    console.error('Error fetching Docker tags:', error);
+    if (logger) {
+      logger.error('Error fetching Docker tags:', error);
+    } else {
+      console.error('Error fetching Docker tags:', error);
+    }
     return {
       latestStableRelease: null,
       latestBetaRelease: null

--- a/extensions/version-fetcher/get-latest-connect.js
+++ b/extensions/version-fetcher/get-latest-connect.js
@@ -1,10 +1,14 @@
-module.exports = async (github, owner, repo) => {
+module.exports = async (github, owner, repo, logger = null) => {
 
   try {
     const release = await github.rest.repos.getLatestRelease({ owner, repo });
     return release.data.tag_name
   } catch (error) {
-    console.error(error);
+    if (logger) {
+      logger.error(error);
+    } else {
+      console.error(error);
+    }
     return null;
   }
 };

--- a/extensions/version-fetcher/get-latest-console-version.js
+++ b/extensions/version-fetcher/get-latest-console-version.js
@@ -1,6 +1,6 @@
 const { retryWithBackoff, isRetryableGitHubError } = require('./retry-util');
 
-module.exports = async (github, owner, repo) => {
+module.exports = async (github, owner, repo, logger = null) => {
   const semver = require('semver');
 
   return retryWithBackoff(
@@ -29,7 +29,11 @@ module.exports = async (github, owner, repo) => {
           latestBetaRelease: latestBetaReleaseVersion || null
         };
       } else {
-        console.log("No valid semver releases found.");
+        if (logger) {
+          logger.warn("No valid semver releases found.");
+        } else {
+          console.log("No valid semver releases found.");
+        }
         return { latestStableRelease: null, latestBetaRelease: null };
       }
     },
@@ -38,9 +42,14 @@ module.exports = async (github, owner, repo) => {
       initialDelay: 1000,
       shouldRetry: isRetryableGitHubError,
       operationName: `Fetch Console version from ${owner}/${repo}`
-    }
+    },
+    logger
   ).catch(error => {
-    console.error('Failed to fetch release information after retries:', error);
+    if (logger) {
+      logger.error('Failed to fetch release information after retries:', error);
+    } else {
+      console.error('Failed to fetch release information after retries:', error);
+    }
     return { latestStableRelease: null, latestBetaRelease: null };
   });
 };

--- a/extensions/version-fetcher/get-latest-redpanda-helm-version-from-operator.js
+++ b/extensions/version-fetcher/get-latest-redpanda-helm-version-from-operator.js
@@ -63,9 +63,9 @@ module.exports = async (github, owner, repo, stableDockerTag, betaDockerTag, log
         if (error.status === 404) {
           // Branch doesn't exist yet - this is expected for unreleased versions
           if (logger) {
-            logger.warn(`Branch ${branchName} not found (operator version may not be released yet)`);
+            logger.warn(`Fetched operator ${dockerTag} from Docker Hub but branch ${branchName} not found in GitHub (source may not be released yet)`);
           } else {
-            console.warn(`Branch ${branchName} not found (operator version may not be released yet)`);
+            console.warn(`Fetched operator ${dockerTag} from Docker Hub but branch ${branchName} not found in GitHub (source may not be released yet)`);
           }
         } else {
           if (logger) {

--- a/extensions/version-fetcher/get-latest-redpanda-helm-version-from-operator.js
+++ b/extensions/version-fetcher/get-latest-redpanda-helm-version-from-operator.js
@@ -60,10 +60,19 @@ module.exports = async (github, owner, repo, stableDockerTag, betaDockerTag, log
         const version = chartYaml.version || null;
         return version;
       } catch (error) {
-        if (logger) {
-          logger.error(`Failed to fetch Chart.yaml for branch ${branchName}:`, error.message);
+        if (error.status === 404) {
+          // Branch doesn't exist yet - this is expected for unreleased versions
+          if (logger) {
+            logger.warn(`Branch ${branchName} not found (operator version may not be released yet)`);
+          } else {
+            console.warn(`Branch ${branchName} not found (operator version may not be released yet)`);
+          }
         } else {
-          console.error(`Failed to fetch Chart.yaml for branch ${branchName}:`, error.message);
+          if (logger) {
+            logger.error(`Failed to fetch Chart.yaml for branch ${branchName}:`, error.message);
+          } else {
+            console.error(`Failed to fetch Chart.yaml for branch ${branchName}:`, error.message);
+          }
         }
         return null;
       }

--- a/extensions/version-fetcher/get-latest-redpanda-helm-version-from-operator.js
+++ b/extensions/version-fetcher/get-latest-redpanda-helm-version-from-operator.js
@@ -8,9 +8,10 @@
  * @param {string} repo - The repository name (redpanda-operator).
  * @param {string} stableDockerTag - The stable docker tag in format v<major>.<minor>.<patch>.
  * @param {string} betaDockerTag - Optional beta docker tag in format v<major>.<minor>.<patch>-beta.
+ * @param {Object} logger - Optional Antora logger instance for logging
  * @returns {Promise<{ latestStableRelease: string|null, latestBetaRelease: string|null }>}
  */
-module.exports = async (github, owner, repo, stableDockerTag, betaDockerTag) => {
+module.exports = async (github, owner, repo, stableDockerTag, betaDockerTag, logger = null) => {
   const yaml = require('js-yaml');
   const path = 'charts/redpanda/chart/Chart.yaml';
 
@@ -29,7 +30,11 @@ module.exports = async (github, owner, repo, stableDockerTag, betaDockerTag) => 
       const versionMatch = dockerTag.match(/^v(\d+)\.(\d+)(?:\.(\d+))?(?:-beta.*)?$/);
 
       if (!versionMatch) {
-        console.error(`Invalid docker tag format: ${dockerTag}`);
+        if (logger) {
+          logger.error(`Invalid docker tag format: ${dockerTag}`);
+        } else {
+          console.error(`Invalid docker tag format: ${dockerTag}`);
+        }
         return null;
       }
 
@@ -55,11 +60,19 @@ module.exports = async (github, owner, repo, stableDockerTag, betaDockerTag) => 
         const version = chartYaml.version || null;
         return version;
       } catch (error) {
-        console.error(`Failed to fetch Chart.yaml for branch ${branchName}:`, error.message);
+        if (logger) {
+          logger.error(`Failed to fetch Chart.yaml for branch ${branchName}:`, error.message);
+        } else {
+          console.error(`Failed to fetch Chart.yaml for branch ${branchName}:`, error.message);
+        }
         return null;
       }
     } catch (error) {
-      console.error(`Error processing docker tag ${dockerTag}:`, error.message);
+      if (logger) {
+        logger.error(`Error processing docker tag ${dockerTag}:`, error.message);
+      } else {
+        console.error(`Error processing docker tag ${dockerTag}:`, error.message);
+      }
       return null;
     }
   };
@@ -75,7 +88,11 @@ module.exports = async (github, owner, repo, stableDockerTag, betaDockerTag) => 
       latestBetaRelease: betaChartVersion
     };
   } catch (error) {
-    console.error('Failed to fetch chart versions:', error.message);
+    if (logger) {
+      logger.error('Failed to fetch chart versions:', error.message);
+    } else {
+      console.error('Failed to fetch chart versions:', error.message);
+    }
     return {
       latestStableRelease: null,
       latestBetaRelease: null

--- a/extensions/version-fetcher/get-latest-redpanda-version.js
+++ b/extensions/version-fetcher/get-latest-redpanda-version.js
@@ -1,6 +1,6 @@
 const { retryWithBackoff, isRetryableGitHubError } = require('./retry-util');
 
-module.exports = async (github, owner, repo) => {
+module.exports = async (github, owner, repo, logger = null) => {
   const semver = require('semver');
 
   return retryWithBackoff(
@@ -67,9 +67,14 @@ module.exports = async (github, owner, repo) => {
       initialDelay: 1000,
       shouldRetry: isRetryableGitHubError,
       operationName: `Fetch Redpanda version from ${owner}/${repo}`
-    }
+    },
+    logger
   ).catch(error => {
-    console.error('Failed to fetch Redpanda release information after retries:', error);
+    if (logger) {
+      logger.error('Failed to fetch Redpanda release information after retries:', error);
+    } else {
+      console.error('Failed to fetch Redpanda release information after retries:', error);
+    }
     return { latestRedpandaRelease: null, latestRcRelease: null };
   });
 };

--- a/extensions/version-fetcher/retry-util.js
+++ b/extensions/version-fetcher/retry-util.js
@@ -8,9 +8,10 @@
  * @param {number} options.maxDelay - Maximum delay in ms (default: 10000)
  * @param {Function} options.shouldRetry - Function to determine if error is retryable (default: all errors)
  * @param {string} options.operationName - Name for logging
+ * @param {Object} logger - Optional Antora logger instance for logging
  * @returns {Promise<*>} Result of the function
  */
-async function retryWithBackoff(fn, options = {}) {
+async function retryWithBackoff(fn, options = {}, logger = null) {
   const {
     maxRetries = 3,
     initialDelay = 1000,
@@ -37,8 +38,14 @@ async function retryWithBackoff(fn, options = {}) {
       const jitter = Math.random() * 0.3 * baseDelay; // Add up to 30% jitter
       const delay = Math.floor(baseDelay + jitter);
 
-      console.error(`⚠️  ${operationName} failed (attempt ${attempt + 1}/${maxRetries + 1}): ${error.message}`);
-      console.error(`   Retrying in ${delay}ms...`);
+      // Log retry attempt using logger if available, otherwise fall back to console
+      if (logger) {
+        logger.warn(`${operationName} failed (attempt ${attempt + 1}/${maxRetries + 1}): ${error.message}`);
+        logger.warn(`Retrying in ${delay}ms...`);
+      } else {
+        console.error(`⚠️  ${operationName} failed (attempt ${attempt + 1}/${maxRetries + 1}): ${error.message}`);
+        console.error(`   Retrying in ${delay}ms...`);
+      }
 
       // Wait before retrying
       await new Promise(resolve => setTimeout(resolve, delay));

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -37,10 +37,10 @@ module.exports.register = function ({ config }) {
         latestOperatorResult,
         latestConnectResult,
       ] = await Promise.allSettled([
-        GetLatestRedpandaVersion(github, owner, 'redpanda'),
-        GetLatestDockerTag(dockerNamespace, 'console'),
-        GetLatestDockerTag(dockerNamespace, 'redpanda-operator'),
-        GetLatestConnectVersion(github, owner, 'connect'),
+        GetLatestRedpandaVersion(github, owner, 'redpanda', logger),
+        GetLatestDockerTag(dockerNamespace, 'console', logger),
+        GetLatestDockerTag(dockerNamespace, 'redpanda-operator', logger),
+        GetLatestConnectVersion(github, owner, 'connect', logger),
       ]);
       
       // Get the Helm chart version after we have the operator version (for both stable and beta)
@@ -49,11 +49,12 @@ module.exports.register = function ({ config }) {
       if (latestOperatorResult.status === 'fulfilled') {
         try {
           const helmChartVersions = await GetLatestHelmChartVersionFromOperator(
-            github, 
-            owner, 
-            'redpanda-operator', 
+            github,
+            owner,
+            'redpanda-operator',
             latestOperatorResult.value?.latestStableRelease,
-            latestOperatorResult.value?.latestBetaRelease
+            latestOperatorResult.value?.latestBetaRelease,
+            logger
           );
           
           latestHelmChartResult = { 

--- a/macros/rp-connect-components.js
+++ b/macros/rp-connect-components.js
@@ -1067,6 +1067,21 @@ module.exports.register = function (registry, context) {
         const [currentType] = sortedTypes.splice(currentTypeIndex, 1);
         sortedTypes.unshift(currentType);
       }
+
+      // Set context-switcher attribute for UI template to render compact dropdown in sticky bar
+      if (sortedTypes.length > 1) {
+        const contextSwitcherData = {};
+        sortedTypes.forEach(typeObj => {
+          const link = (component === 'Cloud' && typeObj.redpandaCloudUrl) || typeObj.redpandaConnectUrl;
+          contextSwitcherData[typeObj.type.toLowerCase()] = {
+            name: capitalize(typeObj.type),
+            to: link
+          };
+        });
+        // Set as page attribute (not document attribute) so it's accessible in UI template
+        attributes['page-context-switcher'] = JSON.stringify(contextSwitcherData);
+        parent.getDocument().setAttribute('page-context-switcher', JSON.stringify(contextSwitcherData));
+      }
       // Check if the component requires an Enterprise license (based on support level)
       let enterpriseLicenseInfo = '';
       if (component !== 'Cloud') {
@@ -1077,6 +1092,26 @@ module.exports.register = function (registry, context) {
         }
       }
       const isCloudSupported = componentRows.some(row => row.is_cloud_supported === 'y');
+
+      // Set availability attributes for UI template badges with URLs
+      if (isCloudSupported) {
+        const cloudUrl = sortedTypes[0].redpandaCloudUrl;
+        const connectUrl = sortedTypes[0].redpandaConnectUrl;
+
+        if (component === 'Connect' && cloudUrl) {
+          // Viewing Self-Managed, but also available in Cloud - show Cloud badge with link
+          parent.getDocument().setAttribute('cloud-available', 'true');
+          parent.getDocument().setAttribute('cloud-available-url', cloudUrl);
+        } else if (component === 'Cloud' && connectUrl) {
+          // Viewing Cloud, but also available in Self-Managed - show Self-Managed badge with link
+          parent.getDocument().setAttribute('self-managed-available', 'true');
+          parent.getDocument().setAttribute('self-managed-available-url', connectUrl);
+        }
+      } else if (!isCloudSupported && component === 'Connect') {
+        // Only available in Self-Managed - show "Self-Managed Only" badge (no link)
+        parent.getDocument().setAttribute('self-managed-only', 'true');
+      }
+
       let availableInInfo = '';
 
       if (isCloudSupported) {

--- a/macros/rp-connect-components.js
+++ b/macros/rp-connect-components.js
@@ -1,4 +1,6 @@
 'use strict';
+const { posix: path } = require('path')
+
 /**
  * Registers macros for use in Redpanda Connect contexts in the Redpanda documentation.
   * @param {Registry} registry - The Antora registry where this block macro is registered.
@@ -1025,11 +1027,23 @@ module.exports.register = function (registry, context) {
       const componentRows = csvData.data.filter(row => row.connector.trim().toLowerCase() === name.trim().toLowerCase());
       if (componentRows.length === 0) {
         console.warn(`No CSV data found for connector: ${name}. The connector may have been removed or renamed.`);
-        // Build context-aware link to release notes
+        // Build link to release notes using content catalog for proper URL resolution
         const isCloud = attributes['env-cloud'] !== undefined;
-        const whatsNewUrl = isCloud
+        let whatsNewUrl = isCloud
           ? '/redpanda-cloud/develop/connect/get-started/whats-new/'
           : '/redpanda-connect/get-started/whats-new/';
+
+        // Try to resolve the page from the content catalog for accurate URLs
+        if (context.contentCatalog && context.file) {
+          const pageSpec = isCloud
+            ? 'redpanda-cloud:develop/connect/get-started:whats-new.adoc'
+            : 'redpanda-connect:get-started:whats-new.adoc';
+          const page = context.contentCatalog.resolvePage(pageSpec, context.file.src);
+          if (page) {
+            whatsNewUrl = path.relative(path.dirname(context.file.pub.url), page.pub.url);
+          }
+        }
+
         // Return a notice for removed/unknown connectors
         return self.createBlock(parent, 'pass', `
           <div class="metadata-block">

--- a/macros/rp-connect-components.js
+++ b/macros/rp-connect-components.js
@@ -1024,7 +1024,19 @@ module.exports.register = function (registry, context) {
       // Filter for the specific connector by name
       const componentRows = csvData.data.filter(row => row.connector.trim().toLowerCase() === name.trim().toLowerCase());
       if (componentRows.length === 0) {
-        console.error(`No data found for connector: ${name}`);
+        console.warn(`No CSV data found for connector: ${name}. The connector may have been removed or renamed.`);
+        // Build context-aware link to release notes
+        const isCloud = attributes['env-cloud'] !== undefined;
+        const whatsNewUrl = isCloud
+          ? '/redpanda-cloud/develop/connect/get-started/whats-new/'
+          : '/redpanda-connect/get-started/whats-new/';
+        // Return a notice for removed/unknown connectors
+        return self.createBlock(parent, 'pass', `
+          <div class="metadata-block">
+            <div class="metadata-content">
+              <p><strong>Available in:</strong> <em>This connector is no longer available. Check the <a href="${whatsNewUrl}">release notes</a> for migration guidance.</em></p>
+            </div>
+          </div>`);
       }
       // Process types and metadata from CSV
       const types = componentRows.map(row => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.17.3",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.17.3",
+      "version": "5.0.0",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.17.2",
+  "version": "4.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.17.2",
+      "version": "4.17.3",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.17.3",
+  "version": "4.18.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.18.0",
+  "version": "5.0.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.17.2",
+  "version": "4.17.3",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "./extensions/aggregate-terms": "./extensions/aggregate-terms.js",
     "./extensions/resolve-xrefs-in-attachments": "./extensions/resolve-xrefs-in-attachments.js",
     "./extensions/unified-navigation": "./extensions/unified-navigation.js",
+    "./extensions/conditional-home-redirect": "./extensions/conditional-home-redirect.js",
     "./macros/glossary": "./macros/glossary.js",
     "./macros/rp-connect-components": "./macros/rp-connect-components.js",
     "./macros/config-ref": "./macros/config-ref.js",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "./extensions/algolia-indexer/index": "./extensions/algolia-indexer/index.js",
     "./extensions/aggregate-terms": "./extensions/aggregate-terms.js",
     "./extensions/resolve-xrefs-in-attachments": "./extensions/resolve-xrefs-in-attachments.js",
+    "./extensions/unified-navigation": "./extensions/unified-navigation.js",
     "./macros/glossary": "./macros/glossary.js",
     "./macros/rp-connect-components": "./macros/rp-connect-components.js",
     "./macros/config-ref": "./macros/config-ref.js",

--- a/tools/redpanda-connect/helpers/renderConnectFields.js
+++ b/tools/redpanda-connect/helpers/renderConnectFields.js
@@ -79,7 +79,7 @@ module.exports = function renderConnectFields(children, prefix = '') {
       block += `${desc}\n\n`;
     }
     if (child.is_secret) {
-      block += `include::redpanda-connect:components:partial$secret_warning.adoc[]\n\n`;
+      block += `include::connect:components:partial$secret_warning.adoc[]\n\n`;
     }
     if (child.version) {
       block += `ifndef::env-cloud[]\nRequires version ${child.version} or later.\nendif::[]\n\n`;

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -107,6 +107,94 @@ function stripPlatformMetadata (connectors) {
 }
 
 /**
+ * Augment connector data with platform metadata from binary analysis.
+ * This adds cloudSupported/requiresCgo flags and includes CGO-only and cloud-only connectors.
+ *
+ * @param {Object} connectorData - Connector index object with arrays for each component type
+ * @param {Object} binaryAnalysis - Binary analysis results from analyzeAllBinaries()
+ * @returns {Object} Object with augmentedData, augmentedCount, addedCgoCount, addedCloudOnlyCount
+ */
+function augmentConnectorData (connectorData, binaryAnalysis) {
+  if (!binaryAnalysis) {
+    return { augmentedData: connectorData, augmentedCount: 0, addedCgoCount: 0, addedCloudOnlyCount: 0 }
+  }
+
+  // Deep clone to avoid mutating original
+  const augmentedData = JSON.parse(JSON.stringify(connectorData))
+
+  const cloudSet = new Set(
+    (binaryAnalysis.comparison?.inCloud || []).map(c => `${c.type}:${c.name}`)
+  )
+  const cgoOnlySet = new Set(
+    (binaryAnalysis.cgoOnly || []).map(c => `${c.type}:${c.name}`)
+  )
+
+  let augmentedCount = 0
+  let addedCgoCount = 0
+  let addedCloudOnlyCount = 0
+
+  const connectorTypes = ['inputs', 'outputs', 'processors', 'caches', 'rate_limits',
+    'buffers', 'metrics', 'scanners', 'tracers']
+
+  for (const type of connectorTypes) {
+    if (!Array.isArray(augmentedData[type])) {
+      augmentedData[type] = []
+    }
+
+    // Add cloudSupported and requiresCgo flags to existing connectors
+    for (const connector of augmentedData[type]) {
+      const key = `${type}:${connector.name}`
+      connector.cloudSupported = cloudSet.has(key)
+      connector.requiresCgo = cgoOnlySet.has(key)
+      augmentedCount++
+    }
+
+    // Add CGO-only connectors that aren't in the OSS list
+    if (binaryAnalysis.cgoOnly) {
+      for (const cgoConn of binaryAnalysis.cgoOnly) {
+        if (cgoConn.type === type) {
+          const exists = augmentedData[type].some(c => c.name === cgoConn.name)
+          if (!exists) {
+            // Singularize type for consistency with stored data (except "metrics" which stays plural)
+            const componentType = cgoConn.type === 'metrics' ? 'metrics' : cgoConn.type.replace(/s$/, '')
+            augmentedData[type].push({
+              ...cgoConn,
+              type: componentType,
+              cloudSupported: false,
+              requiresCgo: true
+            })
+            addedCgoCount++
+          }
+        }
+      }
+    }
+
+    // Add cloud-only connectors that aren't in the OSS list
+    if (binaryAnalysis.comparison?.cloudOnly) {
+      for (const cloudConn of binaryAnalysis.comparison.cloudOnly) {
+        if (cloudConn.type === type) {
+          const exists = augmentedData[type].some(c => c.name === cloudConn.name)
+          if (!exists) {
+            // Singularize type for consistency with stored data (except "metrics" which stays plural)
+            const componentType = cloudConn.type === 'metrics' ? 'metrics' : cloudConn.type.replace(/s$/, '')
+            augmentedData[type].push({
+              ...cloudConn,
+              type: componentType,
+              cloudSupported: true,
+              requiresCgo: false,
+              cloudOnly: true
+            })
+            addedCloudOnlyCount++
+          }
+        }
+      }
+    }
+  }
+
+  return { augmentedData, augmentedCount, addedCgoCount, addedCloudOnlyCount }
+}
+
+/**
  * Update whats-new.adoc with new release information
  * @param {Object} params - Parameters
  * @param {string} params.dataDir - Data directory path
@@ -830,13 +918,22 @@ async function handleRpcnConnectorDocs (options) {
                 }
               }
 
+              // Augment newData with binary analysis results before generating diff
+              // This ensures CGO-only and cloud-only connectors are included and metadata is accurate
+              const { augmentedData: augmentedNewData, addedCgoCount, addedCloudOnlyCount } =
+                augmentConnectorData(newData, intermediateAnalysis)
+
+              if (addedCgoCount > 0 || addedCloudOnlyCount > 0) {
+                console.log(`   • Augmented newData: +${addedCgoCount} CGO-only, +${addedCloudOnlyCount} cloud-only`)
+              }
+
               // Generate diff
               console.log(`\nGenerating diff: ${fromVer} → ${toVer}...`)
               const { generateConnectorDiffJson } = require('./report-delta.js')
 
               const diffData = generateConnectorDiffJson(
                 oldData,
-                newData,
+                augmentedNewData,
                 {
                   oldVersion: fromVer,
                   newVersion: toVer,
@@ -849,6 +946,12 @@ async function handleRpcnConnectorDocs (options) {
               const diffPath = path.join(dataDir, `connect-diff-${fromVer}_to_${toVer}.json`)
               fs.writeFileSync(diffPath, JSON.stringify(diffData, null, 2), 'utf8')
               console.log(`✓ Diff saved: ${path.basename(diffPath)}`)
+
+              // Save augmented data back to file for subsequent iterations
+              // This ensures the next version pair has consistent metadata when loading this version as oldData
+              const augmentedDataPath = path.join(dataDir, `connect-${toVer}.json`)
+              fs.writeFileSync(augmentedDataPath, JSON.stringify(augmentedNewData, null, 2), 'utf8')
+              console.log(`✓ Augmented data saved: connect-${toVer}.json`)
 
               // Update what's-new if requested
               if (options.updateWhatsNew) {
@@ -1097,73 +1200,10 @@ async function handleRpcnConnectorDocs (options) {
 
       const connectorData = JSON.parse(fs.readFileSync(dataFile, 'utf8'))
 
-      const cloudSet = new Set(
-        (binaryAnalysis.comparison?.inCloud || []).map(c => `${c.type}:${c.name}`)
-      )
-      const cgoOnlySet = new Set(
-        (binaryAnalysis.cgoOnly || []).map(c => `${c.type}:${c.name}`)
-      )
+      const { augmentedData, augmentedCount, addedCgoCount, addedCloudOnlyCount } =
+        augmentConnectorData(connectorData, binaryAnalysis)
 
-      let augmentedCount = 0
-      let addedCgoCount = 0
-      let addedCloudOnlyCount = 0
-
-      const connectorTypes = ['inputs', 'outputs', 'processors', 'caches', 'rate_limits',
-        'buffers', 'metrics', 'scanners', 'tracers']
-
-      for (const type of connectorTypes) {
-        if (!Array.isArray(connectorData[type])) {
-          connectorData[type] = []
-        }
-
-        for (const connector of connectorData[type]) {
-          const key = `${type}:${connector.name}`
-          connector.cloudSupported = cloudSet.has(key)
-          connector.requiresCgo = cgoOnlySet.has(key)
-          augmentedCount++
-        }
-
-        if (binaryAnalysis.cgoOnly) {
-          for (const cgoConn of binaryAnalysis.cgoOnly) {
-            if (cgoConn.type === type) {
-              const exists = connectorData[type].some(c => c.name === cgoConn.name)
-              if (!exists) {
-                // Singularize type for consistency with stored data (except "metrics" which stays plural)
-                const componentType = cgoConn.type === 'metrics' ? 'metrics' : cgoConn.type.replace(/s$/, '')
-                connectorData[type].push({
-                  ...cgoConn,
-                  type: componentType,
-                  cloudSupported: false,
-                  requiresCgo: true
-                })
-                addedCgoCount++
-              }
-            }
-          }
-        }
-
-        if (binaryAnalysis.comparison?.cloudOnly) {
-          for (const cloudConn of binaryAnalysis.comparison.cloudOnly) {
-            if (cloudConn.type === type) {
-              const exists = connectorData[type].some(c => c.name === cloudConn.name)
-              if (!exists) {
-                // Singularize type for consistency with stored data (except "metrics" which stays plural)
-                const componentType = cloudConn.type === 'metrics' ? 'metrics' : cloudConn.type.replace(/s$/, '')
-                connectorData[type].push({
-                  ...cloudConn,
-                  type: componentType,
-                  cloudSupported: true,
-                  requiresCgo: false,
-                  cloudOnly: true
-                })
-                addedCloudOnlyCount++
-              }
-            }
-          }
-        }
-      }
-
-      fs.writeFileSync(dataFile, JSON.stringify(connectorData, null, 2), 'utf8')
+      fs.writeFileSync(dataFile, JSON.stringify(augmentedData, null, 2), 'utf8')
       console.log(`Done: Augmented ${augmentedCount} connectors with cloud/cgo fields`)
       if (addedCgoCount > 0) {
         console.log(`   • Added ${addedCgoCount} cgo-only connectors to data file`)
@@ -1207,7 +1247,7 @@ async function handleRpcnConnectorDocs (options) {
 
       // IMPORTANT: Reload newIndex with augmented data for unified diff
       // The unified diff approach compares platform metadata to detect transitions
-      newIndex = connectorData
+      newIndex = augmentedData
       console.log(`✓ Reloaded newIndex with augmented data for diff comparison`)
     } catch (err) {
       console.error(`Warning: Failed to augment data file: ${err.message}`)

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -1212,8 +1212,7 @@ async function handleRpcnConnectorDocs (options) {
         console.log(`   • Added ${addedCloudOnlyCount} cloud-only connectors to data file`)
       }
 
-      // Keep only the latest version (delete all older versions)
-      // BUT preserve any files from intermediate processing during this run
+      // Keep only the latest 2 versions (by semver), delete all others
       const dataVersions = fs.readdirSync(dataDir)
         .filter(f => /^connect-(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)\.json$/.test(f))
         .map(f => {
@@ -1221,27 +1220,38 @@ async function handleRpcnConnectorDocs (options) {
           return match ? match[1] : null
         })
         .filter(v => v && semver.valid(v))
+        .sort((a, b) => semver.rcompare(a, b)) // Sort descending (newest first)
 
-      // Build list of versions we need to keep for this run
-      const versionsToKeep = new Set([newVersion]); // Always keep the latest
-      if (intermediateProcessingResults.length > 0) {
-        // Keep intermediate versions from this run
-        intermediateProcessingResults.forEach(r => {
-          versionsToKeep.add(r.fromVersion);
-          versionsToKeep.add(r.toVersion);
-        });
-      }
-      if (oldVersion) {
-        versionsToKeep.add(oldVersion); // Keep old version for diff
-      }
+      // Keep only the latest 2 versions
+      const versionsToKeep = new Set(dataVersions.slice(0, 2))
 
-      // Delete only files that are NOT needed for this run
+      // Delete all older versions
       for (const version of dataVersions) {
         if (!versionsToKeep.has(version)) {
           const dataFile = `connect-${version}.json`
           const dataPath = path.join(dataDir, dataFile);
           fs.unlinkSync(dataPath);
           console.log(`🧹 Deleted old version from docs-data: ${dataFile}`);
+        }
+      }
+
+      // Also clean up old CSV files (keep latest 2)
+      const csvVersions = fs.readdirSync(dataDir)
+        .filter(f => /^connect-info-(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)\.csv$/.test(f))
+        .map(f => {
+          const match = f.match(/^connect-info-(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)\.csv$/)
+          return match ? match[1] : null
+        })
+        .filter(v => v && semver.valid(v))
+        .sort((a, b) => semver.rcompare(a, b))
+
+      const csvToKeep = new Set(csvVersions.slice(0, 2))
+      for (const version of csvVersions) {
+        if (!csvToKeep.has(version)) {
+          const csvFile = `connect-info-${version}.csv`
+          const csvPath = path.join(dataDir, csvFile);
+          fs.unlinkSync(csvPath);
+          console.log(`🧹 Deleted old CSV from docs-data: ${csvFile}`);
         }
       }
 


### PR DESCRIPTION
Adds the unified navigation extension for Data Platform unified sidebar and updates component references across all extensions.

## Changes

### New Extension
- **unified-navigation.js** - Build-time extension that aggregates navigation from child components (Streaming, Connect) into a unified sidebar for Data Platform umbrella component

### Component Reference Updates
Updates component names across all extensions to align with renamed components:
- `ROOT` → `streaming`
- `redpanda-labs` → `labs`

### Modified Extensions
- **algolia-indexer/generate-index.js** - Update labs component reference
- **collect-bloblang-samples.js** - Update streaming component reference
- **find-related-docs.js** - Update streaming and labs component references
- **find-related-labs.js** - Update streaming and labs component references
- **generate-fields-only-pages.js** - Update component references
- **generate-rp-connect-categories.js** - Update component references
- **generate-rp-connect-info.js** - Update component references
- **unlisted-pages.js** - Update component references

Part of unified navigation implementation.

## Related PRs
- docs: Multiple PRs for version branch renames (#1697-1704)
- docs-ui: PR #376 (unified navigation UI)
- cloud-docs: PR #578 (component home v3)