### PR TITLE
Fix setup-mcp: add --package flag so npx can resolve doc-tools-mcp bin

### DIFF
--- a/cli-utils/setup-mcp.js
+++ b/cli-utils/setup-mcp.js
@@ -141,7 +141,8 @@ async function setupMCP(options = {}) {
 
         // Check if configuration matches desired mode
         const isCorrectNpxConfig = mode === 'npx' && existingCommand === 'npx' &&
-                                    existingArgs.includes('doc-tools-mcp');
+                                    existingArgs.includes('doc-tools-mcp') &&
+                                    existingArgs.some(a => a === `--package=${packageName}`);
         const isCorrectLocalConfig = mode === 'local' && existingCommand === 'node' &&
                                       existingArgs[0] === localPath;
 
@@ -149,7 +150,7 @@ async function setupMCP(options = {}) {
           needsUpdate = true;
           console.log(chalk.yellow('⚠ ') + ' MCP server configured but with different setup:');
           console.log(chalk.gray(`  Current: ${existingCommand} ${existingArgs.join(' ')}`));
-          const newSetup = mode === 'local' ? `node ${localPath}` : 'npx -y doc-tools-mcp';
+          const newSetup = mode === 'local' ? `node ${localPath}` : `npx -y --package=${packageName} doc-tools-mcp`;
           console.log(chalk.gray(`  New:     ${newSetup}\n`));
         } else {
           console.log(chalk.green('✓') + ` MCP server already configured correctly\n`);
@@ -197,7 +198,7 @@ async function setupMCP(options = {}) {
   if (mode === 'local') {
     command = `claude mcp add --transport stdio --scope user ${serverName} -- node ${localPath}`;
   } else {
-    command = `claude mcp add --transport stdio --scope user ${serverName} -- npx -y doc-tools-mcp`;
+    command = `claude mcp add --transport stdio --scope user ${serverName} -- npx -y --package=${packageName} doc-tools-mcp`;
   }
 
   // Execute the command

--- a/mcp/USER_GUIDE.adoc
+++ b/mcp/USER_GUIDE.adoc
@@ -1202,7 +1202,7 @@ claude mcp add --transport stdio --scope user redpanda-docs-tool-assistant -- \
 [,bash]
 ----
 claude mcp add --transport stdio --scope user redpanda-docs-tool-assistant -- \
-  npx -y doc-tools-mcp
+  npx -y --package=@redpanda-data/docs-extensions-and-macros doc-tools-mcp
 ----
 
 This adds the MCP server configuration to `~/.claude.json`.


### PR DESCRIPTION
## Summary

The `npx doc-tools setup-mcp` command was registering the MCP server with:

```
claude mcp add --transport stdio --scope user redpanda-doc-tools-assistant -- npx -y doc-tools-mcp
```

This fails on every session start because npx treats `doc-tools-mcp` as a top-level package name and looks it up on the registry:

```
npm error 404 Not Found - GET https://registry.npmjs.org/doc-tools-mcp
npm error 404  The requested resource 'doc-tools-mcp@*' could not be found
```

`doc-tools-mcp` is the **bin** name of `@redpanda-data/docs-extensions-and-macros`, not its own published package. Without `--package=`, npx has no way to find the parent. The result: every user who followed the README's `npx doc-tools setup-mcp` instruction ended up with an MCP server that **failed to connect** on every Claude Code session start. The check shows:

```
redpanda-doc-tools-assistant: npx -y doc-tools-mcp - ✗ Failed to connect
```

## Fix

Register the command with the `--package` flag so npx knows where the bin lives:

```
npx -y --package=@redpanda-data/docs-extensions-and-macros doc-tools-mcp
```

## Changes

- **`cli-utils/setup-mcp.js`**
  - Build the `claude mcp add` command with `--package=${packageName}` (already a variable in this file).
  - Update the display string used in the "configuration mismatch" upgrade prompt.
  - Tighten the "is correctly configured" validation check so users with the previously-broken registration are detected as outdated and offered a re-setup (instead of being told they're already correct).
- **`mcp/USER_GUIDE.adoc`**
  - Update the published "manual install" code example to match.

## Verification

Locally:

```bash
# Before fix
$ npx -y doc-tools-mcp --help
npm error 404 Not Found - GET https://registry.npmjs.org/doc-tools-mcp

# After fix
$ npx -y --package=@redpanda-data/docs-extensions-and-macros doc-tools-mcp --help
Redpanda Doc Tools MCP Server running
Server version: 4.17.3
```

After re-running `setup-mcp` with this patch applied, `claude mcp list` reports the server as `✓ Connected`.

## Impact on existing users

Anyone who currently has the broken `npx -y doc-tools-mcp` registration will, on next run of `setup-mcp`, be told their config is outdated and offered an upgrade (because of the tightened validation check). They won't need to manually `claude mcp remove` first.

## Test plan

- [x] Verified the npx command works locally with the new flag.
- [x] Verified `claude mcp list` reports the server as connected after the fix.
- [ ] Re-run `npx doc-tools setup-mcp` with this branch applied and confirm the "upgrade" path triggers for users with the old registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)