### PR TITLE
Fix old component name in attribute replacer extension

### DIFF
--- a/extensions/replace-attributes-in-attachments.js
+++ b/extensions/replace-attributes-in-attachments.js
@@ -181,7 +181,7 @@ function getDynamicReplacements(componentVersion, logger) {
   const isPrerelease = attrs['page-component-version-is-prerelease'];
   const versionNum = formatVersion(componentVersion.version || '', semver);
   const is24_3plus =
-    versionNum && semver.gte(versionNum, '24.3.0') && componentVersion.title === 'Self-Managed';
+    versionNum && semver.gte(versionNum, '24.3.0') && componentVersion.title === 'Streaming';
   const useTagAttributes = isPrerelease || is24_3plus || componentVersion.title === 'Labs';
 
   // Derive Redpanda / Console versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
This pull request includes a version bump for the `@redpanda-data/docs-extensions-and-macros` package and an update to the logic for determining when to use tag attributes in `replace-attributes-in-attachments.js`.

Version update:

* Bumped the package version in `package.json` from `5.0.1` to `5.0.2`.

Logic update:

* Changed the condition in `getDynamicReplacements` so that the `is24_3plus` flag now checks for `componentVersion.title === 'Streaming'` instead of `'Self-Managed'`. This affects how tag attributes are applied for different component versions.