### PR TITLE
Add available-properties-tag and available-connect-version attributes

### DIFF
--- a/__tests__/extensions/version-fetcher/available-json-versions.test.js
+++ b/__tests__/extensions/version-fetcher/available-json-versions.test.js
@@ -33,7 +33,11 @@ function filterConnectFiles(files) {
 function extractLatestPropertiesVersion(files) {
   const versions = files
     .map(f => f.src.stem.replace('redpanda-properties-', ''))
-    .filter(v => semver.valid(v.replace(/^v/, '')));
+    // Only accept stable versions (no prerelease suffix like -backup, -rc1, etc.)
+    .filter(v => {
+      const normalized = v.replace(/^v/, '');
+      return semver.valid(normalized) && semver.prerelease(normalized) === null;
+    });
 
   if (versions.length === 0) return null;
 
@@ -45,7 +49,8 @@ function extractLatestPropertiesVersion(files) {
 function extractLatestConnectVersion(files) {
   const versions = files
     .map(f => f.src.stem.replace('connect-', ''))
-    .filter(v => semver.valid(v));
+    // Only accept stable versions (no prerelease suffix)
+    .filter(v => semver.valid(v) && semver.prerelease(v) === null);
 
   if (versions.length === 0) return null;
 
@@ -170,30 +175,31 @@ describe('Properties JSON file detection', () => {
       expect(result).toBeNull();
     });
 
-    it('should handle prerelease versions correctly', () => {
+    it('should reject prerelease versions and use stable', () => {
       const files = [
         { src: { stem: 'redpanda-properties-v25.3.1' } },
         { src: { stem: 'redpanda-properties-v26.0.0-rc1' } },
       ];
 
       const result = extractLatestPropertiesVersion(files);
-      // v26.0.0-rc1 is higher than v25.3.1 in semver (26 > 25)
-      // If a prerelease JSON exists, we should use it
-      expect(result).toBe('v26.0.0-rc1');
+      // v26.0.0-rc1 is filtered out as a prerelease, so v25.3.1 wins
+      expect(result).toBe('v25.3.1');
     });
 
-    it('should prefer stable over prerelease of same major.minor', () => {
+    it('should reject all prerelease suffixes (-rc1, -beta1, -backup, etc.)', () => {
       const files = [
         { src: { stem: 'redpanda-properties-v25.3.1' } },
         { src: { stem: 'redpanda-properties-v25.3.2-rc1' } },
+        { src: { stem: 'redpanda-properties-v26.0.0-backup' } },
+        { src: { stem: 'redpanda-properties-v25.4.0-beta1' } },
       ];
 
       const result = extractLatestPropertiesVersion(files);
-      // v25.3.2-rc1 < v25.3.2 but > v25.3.1, so rc1 wins
-      expect(result).toBe('v25.3.2-rc1');
+      // All prerelease/suffixed versions are filtered out
+      expect(result).toBe('v25.3.1');
     });
 
-    it('should sort prereleases correctly against each other', () => {
+    it('should return null if only prerelease versions exist', () => {
       const files = [
         { src: { stem: 'redpanda-properties-v25.4.0-rc1' } },
         { src: { stem: 'redpanda-properties-v25.4.0-rc2' } },
@@ -201,8 +207,8 @@ describe('Properties JSON file detection', () => {
       ];
 
       const result = extractLatestPropertiesVersion(files);
-      // rc2 > rc1 > beta1
-      expect(result).toBe('v25.4.0-rc2');
+      // All are prereleases, so no valid versions
+      expect(result).toBeNull();
     });
   });
 });
@@ -305,7 +311,7 @@ describe('Edge cases', () => {
     expect(extractLatestConnectVersion(filterConnectFiles(connectFiles))).toBe('4.93.0');
   });
 
-  it('should handle files with similar names', () => {
+  it('should handle files with similar names and reject suffixed versions', () => {
     const files = [
       { src: { stem: 'redpanda-properties-v25.3.1', component: 'streaming', module: 'reference' } },
       { src: { stem: 'redpanda-properties-schema', component: 'streaming', module: 'reference' } },
@@ -313,10 +319,26 @@ describe('Edge cases', () => {
     ];
 
     const filtered = filterPropertiesFiles(files);
-    expect(filtered).toHaveLength(3); // All match the prefix filter
+    expect(filtered).toHaveLength(3); // All match the prefix filter (file discovery stage)
 
     const version = extractLatestPropertiesVersion(filtered);
-    expect(version).toBe('v25.3.1'); // Only valid semver
+    // extractLatestPropertiesVersion filters out:
+    // - 'schema' (not valid semver)
+    // - 'v25.3.1-backup' (valid semver prerelease, but we only accept stable versions)
+    // Only 'v25.3.1' remains as a stable release
+    expect(version).toBe('v25.3.1');
+  });
+
+  it('should pick stable version even when higher-versioned suffixed file exists', () => {
+    const files = [
+      { src: { stem: 'redpanda-properties-v25.3.1', component: 'streaming', module: 'reference' } },
+      { src: { stem: 'redpanda-properties-v26.0.0-backup', component: 'streaming', module: 'reference' } },
+    ];
+
+    const filtered = filterPropertiesFiles(files);
+    const version = extractLatestPropertiesVersion(filtered);
+    // v26.0.0-backup has higher base version but is rejected as prerelease
+    expect(version).toBe('v25.3.1');
   });
 
   it('should handle very old versions', () => {

--- a/__tests__/extensions/version-fetcher/available-json-versions.test.js
+++ b/__tests__/extensions/version-fetcher/available-json-versions.test.js
@@ -1,0 +1,332 @@
+'use strict';
+
+/**
+ * Tests for the available JSON version detection logic in set-latest-version.js
+ *
+ * These tests verify the filtering and version sorting logic used to find
+ * the latest available properties and connect JSON files in the content catalog.
+ */
+
+const semver = require('semver');
+
+// Extract the filtering logic from set-latest-version.js for testing
+function filterPropertiesFiles(files) {
+  return files.filter(f => {
+    if (!f?.src?.stem || !f?.src?.component) return false;
+    const isStreamingComponent = f.src.component === 'streaming' || f.src.component === 'ROOT';
+    const isReferenceModule = f.src.module === 'reference';
+    const isPropertiesFile = f.src.stem.startsWith('redpanda-properties-');
+    return isStreamingComponent && isReferenceModule && isPropertiesFile;
+  });
+}
+
+function filterConnectFiles(files) {
+  return files.filter(f => {
+    if (!f?.src?.stem || !f?.src?.component) return false;
+    const isConnectComponent = f.src.component === 'connect' || f.src.component === 'redpanda-connect';
+    const isComponentsModule = f.src.module === 'components';
+    const isConnectFile = f.src.stem.startsWith('connect-');
+    return isConnectComponent && isComponentsModule && isConnectFile;
+  });
+}
+
+function extractLatestPropertiesVersion(files) {
+  const versions = files
+    .map(f => f.src.stem.replace('redpanda-properties-', ''))
+    .filter(v => semver.valid(v.replace(/^v/, '')));
+
+  if (versions.length === 0) return null;
+
+  return versions.sort((a, b) =>
+    semver.rcompare(a.replace(/^v/, ''), b.replace(/^v/, ''))
+  )[0];
+}
+
+function extractLatestConnectVersion(files) {
+  const versions = files
+    .map(f => f.src.stem.replace('connect-', ''))
+    .filter(v => semver.valid(v));
+
+  if (versions.length === 0) return null;
+
+  return versions.sort((a, b) => semver.rcompare(a, b))[0];
+}
+
+describe('Properties JSON file detection', () => {
+  describe('filterPropertiesFiles', () => {
+    it('should filter files from streaming component with reference module', () => {
+      const files = [
+        { src: { stem: 'redpanda-properties-v25.3.1', component: 'streaming', module: 'reference' } },
+        { src: { stem: 'redpanda-properties-v25.2.0', component: 'streaming', module: 'reference' } },
+        { src: { stem: 'other-file', component: 'streaming', module: 'reference' } },
+      ];
+
+      const result = filterPropertiesFiles(files);
+      expect(result).toHaveLength(2);
+      expect(result[0].src.stem).toBe('redpanda-properties-v25.3.1');
+    });
+
+    it('should accept ROOT component for backwards compatibility', () => {
+      const files = [
+        { src: { stem: 'redpanda-properties-v25.3.1', component: 'ROOT', module: 'reference' } },
+      ];
+
+      const result = filterPropertiesFiles(files);
+      expect(result).toHaveLength(1);
+    });
+
+    it('should reject files from wrong component', () => {
+      const files = [
+        { src: { stem: 'redpanda-properties-v25.3.1', component: 'cloud', module: 'reference' } },
+        { src: { stem: 'redpanda-properties-v25.3.1', component: 'connect', module: 'reference' } },
+      ];
+
+      const result = filterPropertiesFiles(files);
+      expect(result).toHaveLength(0);
+    });
+
+    it('should reject files from wrong module', () => {
+      const files = [
+        { src: { stem: 'redpanda-properties-v25.3.1', component: 'streaming', module: 'deploy' } },
+        { src: { stem: 'redpanda-properties-v25.3.1', component: 'streaming', module: 'ROOT' } },
+      ];
+
+      const result = filterPropertiesFiles(files);
+      expect(result).toHaveLength(0);
+    });
+
+    it('should handle null/undefined src properties gracefully', () => {
+      const files = [
+        { src: null },
+        { src: { stem: null, component: 'streaming', module: 'reference' } },
+        { src: { stem: 'redpanda-properties-v25.3.1', component: null, module: 'reference' } },
+        {},
+        null,
+        undefined,
+      ].filter(Boolean); // Remove null/undefined from array
+
+      const result = filterPropertiesFiles(files);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('extractLatestPropertiesVersion', () => {
+    it('should find the highest semver version with v prefix', () => {
+      const files = [
+        { src: { stem: 'redpanda-properties-v25.1.0' } },
+        { src: { stem: 'redpanda-properties-v25.3.1' } },
+        { src: { stem: 'redpanda-properties-v25.2.5' } },
+        { src: { stem: 'redpanda-properties-v24.3.0' } },
+      ];
+
+      const result = extractLatestPropertiesVersion(files);
+      expect(result).toBe('v25.3.1');
+    });
+
+    it('should handle versions without v prefix', () => {
+      const files = [
+        { src: { stem: 'redpanda-properties-25.1.0' } },
+        { src: { stem: 'redpanda-properties-25.3.1' } },
+      ];
+
+      const result = extractLatestPropertiesVersion(files);
+      expect(result).toBe('25.3.1');
+    });
+
+    it('should handle mixed v-prefix and non-v-prefix versions', () => {
+      const files = [
+        { src: { stem: 'redpanda-properties-v25.1.0' } },
+        { src: { stem: 'redpanda-properties-25.3.1' } },
+      ];
+
+      const result = extractLatestPropertiesVersion(files);
+      // Both are valid, should return the higher one
+      expect(result).toBe('25.3.1');
+    });
+
+    it('should filter out invalid version strings', () => {
+      const files = [
+        { src: { stem: 'redpanda-properties-invalid' } },
+        { src: { stem: 'redpanda-properties-v25.3.1' } },
+        { src: { stem: 'redpanda-properties-latest' } },
+      ];
+
+      const result = extractLatestPropertiesVersion(files);
+      expect(result).toBe('v25.3.1');
+    });
+
+    it('should return null for empty array', () => {
+      const result = extractLatestPropertiesVersion([]);
+      expect(result).toBeNull();
+    });
+
+    it('should return null if no valid versions found', () => {
+      const files = [
+        { src: { stem: 'redpanda-properties-invalid' } },
+        { src: { stem: 'redpanda-properties-not-a-version' } },
+      ];
+
+      const result = extractLatestPropertiesVersion(files);
+      expect(result).toBeNull();
+    });
+
+    it('should handle prerelease versions correctly', () => {
+      const files = [
+        { src: { stem: 'redpanda-properties-v25.3.1' } },
+        { src: { stem: 'redpanda-properties-v26.0.0-rc1' } },
+      ];
+
+      const result = extractLatestPropertiesVersion(files);
+      // v26.0.0-rc1 is higher than v25.3.1 in semver (26 > 25)
+      // If a prerelease JSON exists, we should use it
+      expect(result).toBe('v26.0.0-rc1');
+    });
+
+    it('should prefer stable over prerelease of same major.minor', () => {
+      const files = [
+        { src: { stem: 'redpanda-properties-v25.3.1' } },
+        { src: { stem: 'redpanda-properties-v25.3.2-rc1' } },
+      ];
+
+      const result = extractLatestPropertiesVersion(files);
+      // v25.3.2-rc1 < v25.3.2 but > v25.3.1, so rc1 wins
+      expect(result).toBe('v25.3.2-rc1');
+    });
+
+    it('should sort prereleases correctly against each other', () => {
+      const files = [
+        { src: { stem: 'redpanda-properties-v25.4.0-rc1' } },
+        { src: { stem: 'redpanda-properties-v25.4.0-rc2' } },
+        { src: { stem: 'redpanda-properties-v25.4.0-beta1' } },
+      ];
+
+      const result = extractLatestPropertiesVersion(files);
+      // rc2 > rc1 > beta1
+      expect(result).toBe('v25.4.0-rc2');
+    });
+  });
+});
+
+describe('Connect JSON file detection', () => {
+  describe('filterConnectFiles', () => {
+    it('should filter files from connect component with components module', () => {
+      const files = [
+        { src: { stem: 'connect-4.93.0', component: 'connect', module: 'components' } },
+        { src: { stem: 'connect-4.92.0', component: 'connect', module: 'components' } },
+        { src: { stem: 'other-file', component: 'connect', module: 'components' } },
+      ];
+
+      const result = filterConnectFiles(files);
+      expect(result).toHaveLength(2);
+    });
+
+    it('should accept redpanda-connect component for backwards compatibility', () => {
+      const files = [
+        { src: { stem: 'connect-4.93.0', component: 'redpanda-connect', module: 'components' } },
+      ];
+
+      const result = filterConnectFiles(files);
+      expect(result).toHaveLength(1);
+    });
+
+    it('should reject files from wrong component', () => {
+      const files = [
+        { src: { stem: 'connect-4.93.0', component: 'streaming', module: 'components' } },
+        { src: { stem: 'connect-4.93.0', component: 'cloud', module: 'components' } },
+      ];
+
+      const result = filterConnectFiles(files);
+      expect(result).toHaveLength(0);
+    });
+
+    it('should reject files from wrong module', () => {
+      const files = [
+        { src: { stem: 'connect-4.93.0', component: 'connect', module: 'reference' } },
+        { src: { stem: 'connect-4.93.0', component: 'connect', module: 'ROOT' } },
+      ];
+
+      const result = filterConnectFiles(files);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('extractLatestConnectVersion', () => {
+    it('should find the highest semver version', () => {
+      const files = [
+        { src: { stem: 'connect-4.91.0' } },
+        { src: { stem: 'connect-4.93.0' } },
+        { src: { stem: 'connect-4.92.5' } },
+        { src: { stem: 'connect-4.78.0' } },
+      ];
+
+      const result = extractLatestConnectVersion(files);
+      expect(result).toBe('4.93.0');
+    });
+
+    it('should filter out invalid version strings', () => {
+      const files = [
+        { src: { stem: 'connect-invalid' } },
+        { src: { stem: 'connect-4.93.0' } },
+        { src: { stem: 'connect-latest' } },
+      ];
+
+      const result = extractLatestConnectVersion(files);
+      expect(result).toBe('4.93.0');
+    });
+
+    it('should return null for empty array', () => {
+      const result = extractLatestConnectVersion([]);
+      expect(result).toBeNull();
+    });
+
+    it('should handle patch versions correctly', () => {
+      const files = [
+        { src: { stem: 'connect-4.93.0' } },
+        { src: { stem: 'connect-4.93.1' } },
+        { src: { stem: 'connect-4.93.10' } },
+      ];
+
+      const result = extractLatestConnectVersion(files);
+      expect(result).toBe('4.93.10');
+    });
+  });
+});
+
+describe('Edge cases', () => {
+  it('should handle single file correctly', () => {
+    const propertiesFiles = [
+      { src: { stem: 'redpanda-properties-v25.3.1', component: 'streaming', module: 'reference' } },
+    ];
+    const connectFiles = [
+      { src: { stem: 'connect-4.93.0', component: 'connect', module: 'components' } },
+    ];
+
+    expect(extractLatestPropertiesVersion(filterPropertiesFiles(propertiesFiles))).toBe('v25.3.1');
+    expect(extractLatestConnectVersion(filterConnectFiles(connectFiles))).toBe('4.93.0');
+  });
+
+  it('should handle files with similar names', () => {
+    const files = [
+      { src: { stem: 'redpanda-properties-v25.3.1', component: 'streaming', module: 'reference' } },
+      { src: { stem: 'redpanda-properties-schema', component: 'streaming', module: 'reference' } },
+      { src: { stem: 'redpanda-properties-v25.3.1-backup', component: 'streaming', module: 'reference' } },
+    ];
+
+    const filtered = filterPropertiesFiles(files);
+    expect(filtered).toHaveLength(3); // All match the prefix filter
+
+    const version = extractLatestPropertiesVersion(filtered);
+    expect(version).toBe('v25.3.1'); // Only valid semver
+  });
+
+  it('should handle very old versions', () => {
+    const files = [
+      { src: { stem: 'redpanda-properties-v21.1.0' } },
+      { src: { stem: 'redpanda-properties-v25.3.1' } },
+      { src: { stem: 'redpanda-properties-v22.0.0' } },
+    ];
+
+    const result = extractLatestPropertiesVersion(files);
+    expect(result).toBe('v25.3.1');
+  });
+});

--- a/__tests__/extensions/version-fetcher/available-json-versions.test.js
+++ b/__tests__/extensions/version-fetcher/available-json-versions.test.js
@@ -9,52 +9,21 @@
 
 const semver = require('semver');
 
-// Extract the filtering logic from set-latest-version.js for testing
-function filterPropertiesFiles(files) {
-  return files.filter(f => {
-    if (!f?.src?.stem || !f?.src?.component) return false;
-    const isStreamingComponent = f.src.component === 'streaming' || f.src.component === 'ROOT';
-    const isReferenceModule = f.src.module === 'reference';
-    const isPropertiesFile = f.src.stem.startsWith('redpanda-properties-');
-    return isStreamingComponent && isReferenceModule && isPropertiesFile;
-  });
-}
+// Import the actual filtering logic from set-latest-version.js
+const {
+  filterPropertiesFiles,
+  filterConnectFiles,
+  extractLatestPropertiesVersion: _extractLatestPropertiesVersion,
+  extractLatestConnectVersion: _extractLatestConnectVersion
+} = require('../../../extensions/version-fetcher/set-latest-version');
 
-function filterConnectFiles(files) {
-  return files.filter(f => {
-    if (!f?.src?.stem || !f?.src?.component) return false;
-    const isConnectComponent = f.src.component === 'connect' || f.src.component === 'redpanda-connect';
-    const isComponentsModule = f.src.module === 'components';
-    const isConnectFile = f.src.stem.startsWith('connect-');
-    return isConnectComponent && isComponentsModule && isConnectFile;
-  });
-}
-
+// Wrap the version extractors to inject semver dependency
 function extractLatestPropertiesVersion(files) {
-  const versions = files
-    .map(f => f.src.stem.replace('redpanda-properties-', ''))
-    // Only accept stable versions (no prerelease suffix like -backup, -rc1, etc.)
-    .filter(v => {
-      const normalized = v.replace(/^v/, '');
-      return semver.valid(normalized) && semver.prerelease(normalized) === null;
-    });
-
-  if (versions.length === 0) return null;
-
-  return versions.sort((a, b) =>
-    semver.rcompare(a.replace(/^v/, ''), b.replace(/^v/, ''))
-  )[0];
+  return _extractLatestPropertiesVersion(files, semver);
 }
 
 function extractLatestConnectVersion(files) {
-  const versions = files
-    .map(f => f.src.stem.replace('connect-', ''))
-    // Only accept stable versions (no prerelease suffix)
-    .filter(v => semver.valid(v) && semver.prerelease(v) === null);
-
-  if (versions.length === 0) return null;
-
-  return versions.sort((a, b) => semver.rcompare(a, b))[0];
+  return _extractLatestConnectVersion(files, semver);
 }
 
 describe('Properties JSON file detection', () => {

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -135,12 +135,92 @@ module.exports.register = function ({ config }) {
         }
       });
 
+      // Find latest available Redpanda properties JSON in content catalog
+      // This ensures we use a version that actually exists, even if latest-redpanda-tag
+      // points to a newer release that doesn't have docs/attachments yet
+      // Component name is 'streaming' (or 'ROOT' for backwards compatibility)
+      const propertiesFiles = contentCatalog.findBy({
+        family: 'attachment'
+      }).filter(f => {
+        if (!f?.src?.stem || !f?.src?.component) return false;
+        const isStreamingComponent = f.src.component === 'streaming' || f.src.component === 'ROOT';
+        const isReferenceModule = f.src.module === 'reference';
+        const isPropertiesFile = f.src.stem.startsWith('redpanda-properties-');
+        return isStreamingComponent && isReferenceModule && isPropertiesFile;
+      });
+
+      let availablePropertiesTag = null;
+      if (propertiesFiles.length > 0) {
+        const versions = propertiesFiles
+          .map(f => f.src.stem.replace('redpanda-properties-', ''))
+          .filter(v => semver.valid(v.replace(/^v/, '')));
+
+        if (versions.length > 0) {
+          availablePropertiesTag = versions.sort((a, b) =>
+            semver.rcompare(a.replace(/^v/, ''), b.replace(/^v/, ''))
+          )[0];
+
+          // Set on all component versions
+          components.forEach(component => {
+            component.versions.forEach(({ asciidoc }) => {
+              asciidoc.attributes['available-properties-tag'] = availablePropertiesTag;
+            });
+          });
+
+          logger.debug(`Found ${propertiesFiles.length} properties JSON files, latest available: ${availablePropertiesTag}`);
+        }
+      } else {
+        logger.debug('No properties JSON files found in content catalog');
+      }
+
+      // Find latest available Connect JSON in content catalog
+      // Component name is 'connect' (or 'redpanda-connect' for backwards compatibility)
+      const connectFiles = contentCatalog.findBy({
+        family: 'attachment'
+      }).filter(f => {
+        if (!f?.src?.stem || !f?.src?.component) return false;
+        const isConnectComponent = f.src.component === 'connect' || f.src.component === 'redpanda-connect';
+        const isComponentsModule = f.src.module === 'components';
+        const isConnectFile = f.src.stem.startsWith('connect-');
+        return isConnectComponent && isComponentsModule && isConnectFile;
+      });
+
+      let availableConnectVersion = null;
+      if (connectFiles.length > 0) {
+        const versions = connectFiles
+          .map(f => f.src.stem.replace('connect-', ''))
+          .filter(v => semver.valid(v));
+
+        if (versions.length > 0) {
+          availableConnectVersion = versions.sort((a, b) =>
+            semver.rcompare(a, b)
+          )[0];
+
+          // Set on all component versions
+          components.forEach(component => {
+            component.versions.forEach(({ asciidoc }) => {
+              asciidoc.attributes['available-connect-version'] = availableConnectVersion;
+            });
+          });
+
+          logger.debug(`Found ${connectFiles.length} connect JSON files, latest available: ${availableConnectVersion}`);
+        }
+      } else {
+        logger.debug('No connect JSON files found in content catalog');
+      }
+
       logger.info('Updated Redpanda documentation versions successfully:');
       logger.info(`- Redpanda: ${latestVersions.redpanda.latestRedpandaRelease.version}${latestVersions.redpanda.latestRcRelease ? ', beta: ' + latestVersions.redpanda.latestRcRelease.version : ''}`);
       logger.info(`- Connect: ${latestVersions.connect}`);
       logger.info(`- Console: ${latestVersions.console.latestStableRelease}${latestVersions.console.latestBetaRelease ? ', beta: ' + latestVersions.console.latestBetaRelease : ''}`);
       logger.info(`- Operator: ${latestVersions.operator?.latestStableRelease || 'unknown'}${latestVersions.operator?.latestBetaRelease ? ', beta: ' + latestVersions.operator.latestBetaRelease : ''}`);
       logger.info(`- Helm chart: ${latestVersions.helmChart?.latestStableRelease || 'unknown'}${latestVersions.helmChart?.latestBetaRelease ? ', beta: ' + latestVersions.helmChart.latestBetaRelease : ''}`);
+      if (availablePropertiesTag) {
+        logger.info(`- Available properties JSON: ${availablePropertiesTag}`);
+      }
+      if (availableConnectVersion) {
+        logger.info(`- Available Connect JSON: ${availableConnectVersion}`);
+      }
     } catch (error) {
       logger.error(`Error updating versions: ${error}`);
     }

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -153,7 +153,11 @@ module.exports.register = function ({ config }) {
       if (propertiesFiles.length > 0) {
         const versions = propertiesFiles
           .map(f => f.src.stem.replace('redpanda-properties-', ''))
-          .filter(v => semver.valid(v.replace(/^v/, '')));
+          // Only accept stable versions (no prerelease suffix like -backup, -rc1, etc.)
+          .filter(v => {
+            const normalized = v.replace(/^v/, '');
+            return semver.valid(normalized) && semver.prerelease(normalized) === null;
+          });
 
         if (versions.length > 0) {
           availablePropertiesTag = versions.sort((a, b) =>
@@ -189,7 +193,8 @@ module.exports.register = function ({ config }) {
       if (connectFiles.length > 0) {
         const versions = connectFiles
           .map(f => f.src.stem.replace('connect-', ''))
-          .filter(v => semver.valid(v));
+          // Only accept stable versions (no prerelease suffix)
+          .filter(v => semver.valid(v) && semver.prerelease(v) === null);
 
         if (versions.length > 0) {
           availableConnectVersion = versions.sort((a, b) =>

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -260,3 +260,49 @@ module.exports.register = function ({ config }) {
     });
   }
 };
+
+// Export helper functions for testing
+module.exports.filterPropertiesFiles = function(files) {
+  return files.filter(f => {
+    if (!f?.src?.stem || !f?.src?.component) return false;
+    const isStreamingComponent = f.src.component === 'streaming' || f.src.component === 'ROOT';
+    const isReferenceModule = f.src.module === 'reference';
+    const isPropertiesFile = f.src.stem.startsWith('redpanda-properties-');
+    return isStreamingComponent && isReferenceModule && isPropertiesFile;
+  });
+};
+
+module.exports.filterConnectFiles = function(files) {
+  return files.filter(f => {
+    if (!f?.src?.stem || !f?.src?.component) return false;
+    const isConnectComponent = f.src.component === 'connect' || f.src.component === 'redpanda-connect';
+    const isComponentsModule = f.src.module === 'components';
+    const isConnectFile = f.src.stem.startsWith('connect-');
+    return isConnectComponent && isComponentsModule && isConnectFile;
+  });
+};
+
+module.exports.extractLatestPropertiesVersion = function(files, semver) {
+  const versions = files
+    .map(f => f.src.stem.replace('redpanda-properties-', ''))
+    .filter(v => {
+      const normalized = v.replace(/^v/, '');
+      return semver.valid(normalized) && semver.prerelease(normalized) === null;
+    });
+
+  if (versions.length === 0) return null;
+
+  return versions.sort((a, b) =>
+    semver.rcompare(a.replace(/^v/, ''), b.replace(/^v/, ''))
+  )[0];
+};
+
+module.exports.extractLatestConnectVersion = function(files, semver) {
+  const versions = files
+    .map(f => f.src.stem.replace('connect-', ''))
+    .filter(v => semver.valid(v) && semver.prerelease(v) === null);
+
+  if (versions.length === 0) return null;
+
+  return versions.sort((a, b) => semver.rcompare(a, b))[0];
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.0.3",
+      "version": "5.0.4",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
## Summary

The `set-latest-version` extension now scans the content catalog for available JSON attachment files and sets attributes that point to versions that actually exist:

- `available-properties-tag`: Latest `redpanda-properties-*.json` version found in `streaming:reference` module
- `available-connect-version`: Latest `connect-*.json` version found in `connect:components` module

## Problem

The existing `latest-redpanda-tag` and `latest-connect-version` attributes are set from GitHub releases, which may point to versions that don't have docs/attachments published yet. This causes unresolved resource errors when the UI tries to load JSON files for property tooltips.

## Solution

After fetching GitHub release versions, the extension now:
1. Scans the content catalog for attachment files matching the JSON patterns
2. Extracts versions from filenames and sorts by semver
3. Sets `available-*` attributes to the highest available version

The UI can then use `available-properties-tag` (with fallback to `latest-redpanda-tag`) to ensure it always references a JSON file that exists.

## Changes

- **`extensions/version-fetcher/set-latest-version.js`**: Added content catalog scanning logic
- **`__tests__/extensions/version-fetcher/available-json-versions.test.js`**: 25 unit tests

## Backwards Compatibility

- Supports both `streaming` and `ROOT` component names
- Supports both `connect` and `redpanda-connect` component names
- New attributes are additive - existing attributes unchanged

## Test plan

- [x] All 25 unit tests pass
- [ ] Test with local Antora build to verify attributes are set correctly

🤖 Generated with [Claude Code](https://claude.ai/code)