### PR TITLE
DOC-1878: Chunk long reference pages for Algolia indexing

### DIFF
--- a/__tests__/extensions/algolia-indexer.test.js
+++ b/__tests__/extensions/algolia-indexer.test.js
@@ -1,0 +1,132 @@
+'use strict'
+
+const generateIndex = require('../../extensions/algolia-indexer/generate-index.js')
+
+const noopLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
+
+// Build HTML mirroring Antora's render of a doc page: an `article.doc` with an
+// h1, an intro paragraph, and a set of section headings (with ids) plus body text.
+function buildArticle ({ h1 = 'Reference', intro = 'Intro paragraph.', sections = [] }) {
+  const body = sections
+    .map(({ name, level = 'h3' }) =>
+      `<div class="sect2"><${level} id="${name}">${name}</${level}>` +
+      `<div class="paragraph"><p>Description for ${name}.</p></div></div>`)
+    .join('')
+  return `<article class="doc"><h1>${h1}</h1>` +
+    `<div class="paragraph"><p>${intro}</p></div>${body}</article>`
+}
+
+const component = { name: 'redpanda', title: 'Self-Managed', latest: { version: '25.3' } }
+
+function makePage (html, overrides = {}) {
+  return {
+    contents: Buffer.from(html),
+    out: { dirname: 'current/reference', basename: 'page.html' },
+    pub: { url: '/current/reference/page' },
+    src: { component: 'redpanda', version: '25.3', origin: {} },
+    asciidoc: { attributes: {} },
+    ...overrides
+  }
+}
+
+function runIndex (page) {
+  const result = generateIndex(
+    { site: { url: 'https://docs.redpanda.com' } },
+    {
+      getPages: (fn) => [page].filter((p) => fn(p) !== undefined),
+      getComponent: () => component,
+      getComponentVersion: () => component.latest,
+      getComponents: () => [component]
+    },
+    { logger: noopLogger }
+  )
+  return result[component.name][page.src.version]
+}
+
+// Approximate the same tokenization the indexer uses to size chunks.
+function tokenCount (titles) {
+  return titles.reduce(
+    (sum, t) => sum + (String(t.t).split(/[\s_./:-]+/).filter(Boolean).length || 1),
+    0
+  )
+}
+
+describe('algolia-indexer generate-index (DOC-1878 chunking)', () => {
+  // Algolia only indexes ~the first 290 words of a record. Long reference pages put
+  // hundreds of property/metric names in the titles array, so names past that window
+  // were unsearchable. The indexer now splits those pages into multiple records.
+  test('long /properties/ pages are split into multiple bounded records', () => {
+    const sections = Array.from({ length: 400 }, (_, i) => ({
+      name: `cluster_property_number_${i}_setting_ms`
+    }))
+    const page = makePage(
+      buildArticle({ h1: 'Cluster Configuration Properties', sections }),
+      { pub: { url: '/current/reference/properties/cluster-properties' } }
+    )
+
+    const records = runIndex(page)
+
+    // More than one record, and each record's titles stay within the budget.
+    expect(records.length).toBeGreaterThan(1)
+    for (const rec of records) {
+      expect(tokenCount(rec.titles)).toBeLessThanOrEqual(180)
+    }
+
+    // Every heading is present across the chunks (none dropped).
+    const allTitles = records.flatMap((r) => r.titles.map((t) => t.t))
+    expect(allTitles).toHaveLength(400)
+    // A name that previously fell past the indexing window now lives in a small,
+    // fully-indexed chunk.
+    const deepName = 'cluster_property_number_300_setting_ms'
+    const owning = records.filter((r) => r.titles.some((t) => t.t === deepName))
+    expect(owning).toHaveLength(1)
+    expect(tokenCount(owning[0].titles)).toBeLessThanOrEqual(180)
+  })
+
+  test('chunk objectIDs are unique; first keeps the page URL, rest deep-link to anchors', () => {
+    const sections = Array.from({ length: 400 }, (_, i) => ({ name: `prop_${i}_value_ms` }))
+    const page = makePage(
+      buildArticle({ h1: 'Cluster Configuration Properties', sections }),
+      { pub: { url: '/current/reference/properties/cluster-properties' } }
+    )
+
+    const records = runIndex(page)
+    const ids = records.map((r) => r.objectID)
+
+    expect(new Set(ids).size).toBe(ids.length) // unique
+    expect(ids[0]).toBe('/current/reference/properties/cluster-properties')
+    for (const id of ids.slice(1)) {
+      expect(id).toMatch(/^\/current\/reference\/properties\/cluster-properties#prop_\d+_value_ms$/)
+    }
+
+    // Every chunk shares one clean `url` (no #fragment) for deep-link href + dedupe.
+    for (const rec of records) {
+      expect(rec.url).toBe('/current/reference/properties/cluster-properties')
+      expect(rec.url).not.toContain('#')
+    }
+  })
+
+  test('metrics-style pages (>30 headings, no /properties/ url) are also chunked', () => {
+    const sections = Array.from({ length: 200 }, (_, i) => ({ name: `redpanda_metric_${i}_total` }))
+    const page = makePage(buildArticle({ h1: 'Public Metrics', sections }))
+
+    const records = runIndex(page)
+
+    expect(records.length).toBeGreaterThan(1)
+    expect(records.flatMap((r) => r.titles.map((t) => t.t)))
+      .toContain('redpanda_metric_150_total')
+  })
+
+  test('normal short pages remain a single record with the base objectID', () => {
+    const page = makePage(buildArticle({
+      h1: 'Some guide',
+      sections: [{ name: 'step-one' }, { name: 'step-two' }]
+    }))
+
+    const records = runIndex(page)
+
+    expect(records).toHaveLength(1)
+    expect(records[0].objectID).toBe('/current/reference/page')
+    expect(records[0].text).toContain('Description for step-one')
+  })
+})

--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -303,10 +303,10 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
     const baseObjectID = urlPath + page.pub.url
     const titleChunks = isPropertiesPage ? chunkTitles(titles) : [titles]
 
-    titleChunks.forEach((chunkTitles, chunkIndex) => {
+    titleChunks.forEach((chunk, chunkIndex) => {
       const objectID = chunkIndex === 0
         ? baseObjectID
-        : `${baseObjectID}#${chunkTitles[0].h}`
+        : `${baseObjectID}#${chunk[0].h}`
 
       // keywords included in index item
       const indexItem = {
@@ -320,7 +320,7 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
         // anchor, so chunk objectIDs (which carry a #anchor for uniqueness) must not
         // be used for the href. `url` is also the attribute to dedupe chunks on.
         url: baseObjectID,
-        titles: chunkTitles,
+        titles: chunk,
         keywords: keywords,
         categories: categories,
         commercialNames: commercialNames,

--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -292,38 +292,93 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
       ? page.asciidoc.attributes['page-commercial-names'].split(',').map(name => name.trim())
       : []
 
-    // FIXED: keywords now included in index item
-    const indexItem = {
-      title: documentTitle,
-      version: version,
-      text: text,
-      intro: intro,
-      objectID: urlPath + page.pub.url,
-      titles: titles,
-      keywords: keywords,
-      categories: categories,
-      commercialNames: commercialNames,
-      unixTimestamp: unixTimestamp
-    }
+    // Algolia only indexes roughly the first ~290 words of any single record. On
+    // long reference pages (cluster/topic properties, metrics) every property or
+    // metric name lives in the `titles` array, and there can be hundreds of them, so
+    // every name past that window is stored but NOT searchable (DOC-1878). Split the
+    // titles of such pages across multiple records, each small enough to be fully
+    // indexed. Normal pages keep a single record. Chunks after the first get a unique
+    // objectID anchored to their first heading so search results deep-link into the
+    // page; the first chunk keeps the page's base objectID.
+    const baseObjectID = urlPath + page.pub.url
+    const titleChunks = isPropertiesPage ? chunkTitles(titles) : [titles]
 
-    if (component.name !== 'labs') {
-      indexItem.product = component.title
-      indexItem.breadcrumbs = breadcrumbs
-      indexItem.type = 'Doc'
-      indexItem._tags = Array.isArray(tag) ? tag : [tag]
-    } else {
-      indexItem.deployment = deployment
-      indexItem.type = 'Lab'
-      indexItem.interactive = false
-      indexItem._tags = Array.isArray(tag) ? tag : [tag]
-    }
+    titleChunks.forEach((chunkTitles, chunkIndex) => {
+      const objectID = chunkIndex === 0
+        ? baseObjectID
+        : `${baseObjectID}#${chunkTitles[0].h}`
 
-    algolia[cname][version].push(indexItem)
-    algoliaCount++
+      // keywords included in index item
+      const indexItem = {
+        title: documentTitle,
+        version: version,
+        text: text,
+        intro: intro,
+        objectID: objectID,
+        // Clean page path (no #fragment) shared by every chunk of a page. The search
+        // UI builds result links from `url` and appends its own matched-heading
+        // anchor, so chunk objectIDs (which carry a #anchor for uniqueness) must not
+        // be used for the href. `url` is also the attribute to dedupe chunks on.
+        url: baseObjectID,
+        titles: chunkTitles,
+        keywords: keywords,
+        categories: categories,
+        commercialNames: commercialNames,
+        unixTimestamp: unixTimestamp
+      }
+
+      if (component.name !== 'labs') {
+        indexItem.product = component.title
+        indexItem.breadcrumbs = breadcrumbs
+        indexItem.type = 'Doc'
+        indexItem._tags = Array.isArray(tag) ? tag : [tag]
+      } else {
+        indexItem.deployment = deployment
+        indexItem.type = 'Lab'
+        indexItem.interactive = false
+        indexItem._tags = Array.isArray(tag) ? tag : [tag]
+      }
+
+      algolia[cname][version].push(indexItem)
+      algoliaCount++
+    })
   }
 
   logger.info(`Indexed ${algoliaCount} pages`)
   return algolia
+}
+
+/**
+ * Split a titles array into chunks whose combined token count stays within
+ * Algolia's per-record indexing window (~290 words; we leave a safety margin).
+ * Each returned chunk is small enough that every heading it contains is actually
+ * indexed for search, which keeps property/metric names on long reference pages
+ * searchable (DOC-1878).
+ *
+ * @param {Array<{t: string, h: string}>} titles - Section headings for a page.
+ * @param {number} [maxTokens=180] - Approximate token budget per chunk.
+ * @returns {Array<Array<{t: string, h: string}>>} One or more title chunks. An
+ *   empty input yields a single empty chunk so the page still gets a record.
+ */
+function chunkTitles (titles, maxTokens = 180) {
+  if (!titles.length) return [[]]
+  const chunks = []
+  let current = []
+  let tokens = 0
+  for (const entry of titles) {
+    // Algolia tokenizes on separators (whitespace, underscores, dots, etc.), so a
+    // name like `partition_autobalancing_mode` counts as several tokens.
+    const entryTokens = String(entry.t || '').split(/[\s_./:-]+/).filter(Boolean).length || 1
+    if (current.length && tokens + entryTokens > maxTokens) {
+      chunks.push(current)
+      current = []
+      tokens = 0
+    }
+    current.push(entry)
+    tokens += entryTokens
+  }
+  if (current.length) chunks.push(current)
+  return chunks
 }
 
 /**


### PR DESCRIPTION
## What

Splits long reference pages (cluster/topic properties, metrics) into multiple Algolia records in `extensions/algolia-indexer/generate-index.js`, so each record's `titles` array stays small, and adds a clean `url` attribute (base page path) to every record.

- `chunkTitles()` groups headings into ~180-word chunks; the first chunk keeps the page's base `objectID`, later chunks use `objectID = base#<firstHeadingAnchor>`.
- `url` = base page path (no `#fragment`) — used by the search UI for result links and as the attribute to de-duplicate chunks on (`attributeForDistinct`).
- New tests in `__tests__/extensions/algolia-indexer.test.js`.

## Why

Investigation for [DOC-1878](https://redpandadata.atlassian.net/browse/DOC-1878). The **primary** root cause is an Algolia index setting (`separatorsToIndex` includes `_`, which breaks exact underscored-name search on large pages) — fixed separately in the Algolia dashboard, not in this repo.

This change is **defense-in-depth / record-size hygiene**: it keeps records small enough that the per-record indexing cliff can't recur (e.g. if `topic-properties` ever grew large). Safe to land independently; not required to fix the bug on its own.

## Testing

- `npm test -- __tests__/extensions/algolia-indexer.test.js` — 4 new tests pass.
- Validated against real index data: the 429-entry cluster-properties page chunks into 11 records with every name preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-1878]: https://redpandadata.atlassian.net/browse/DOC-1878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ