### PR TITLE
Bump version to 5.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
## What

Bumps the package version `5.1.0` → `5.1.1` (patch) and updates `package-lock.json` to match.

## Why

Follow-up to #205 (Algolia record chunking), which merged without a version bump. This releases the chunking changes.

cc @micheleRP

🤖 Generated with [Claude Code](https://claude.com/claude-code)