### PR TITLE
fix(rpcn-docs): whats-new xref truncation and config-component cloud metadata

### DIFF
--- a/__tests__/tools/rpcn-connector-summaries.test.js
+++ b/__tests__/tools/rpcn-connector-summaries.test.js
@@ -18,7 +18,7 @@
 // Jest); stub it out since these tests never touch GitHub.
 jest.mock('../../cli-utils/octokit-client', () => ({}));
 
-const { capToTwoSentences, augmentConnectorData } = require('../../tools/redpanda-connect/rpcn-connector-docs-handler');
+const { capToTwoSentences, augmentConnectorData, buildCleanOssData } = require('../../tools/redpanda-connect/rpcn-connector-docs-handler');
 const { generateConnectorDiffJson } = require('../../tools/redpanda-connect/report-delta');
 
 describe('capToTwoSentences - xref and filename protection', () => {
@@ -155,5 +155,85 @@ describe('generateConnectorDiffJson - config component status and cloud support'
 
     expect(inDetails).toBe(true);
     expect(added.cloudSupported).toBe(true);
+  });
+});
+
+describe('buildCleanOssData - pure OSS snapshot for binary analysis', () => {
+  // Simulate the persisted data file after a previous run's augmentation: the
+  // handler writes augmentConnectorData() output back to connect-<version>.json,
+  // so the next run reloads augmentation-only cloud-only/cgo-only entries.
+  const makeAugmentedIndex = () => {
+    const raw = {
+      processors: [
+        { name: 'mapping', type: 'processor', config: { children: [] } }
+      ],
+      config: [
+        { name: 'error_handling', type: 'object', kind: 'scalar', description: 'Engine-wide error handling.' }
+      ]
+    };
+    const binaryAnalysis = {
+      comparison: {
+        inCloud: [
+          { type: 'processors', name: 'mapping', status: 'stable' },
+          { type: 'config', name: 'error_handling', status: '' }
+        ],
+        cloudOnly: [
+          { type: 'config', name: 'cloud_only_block', status: '' },
+          { type: 'processors', name: 'cloud_only_proc', status: '' }
+        ]
+      },
+      cgoOnly: [
+        { type: 'config', name: 'cgo_only_block' }
+      ]
+    };
+    return augmentConnectorData(raw, binaryAnalysis).augmentedData;
+  };
+
+  test('drops augmentation-only cloud-only and cgo-only config entries', () => {
+    const augmented = makeAugmentedIndex();
+    // Sanity: augmentation added the extra config entries this run.
+    expect(augmented.config.map(c => c.name).sort())
+      .toEqual(['cgo_only_block', 'cloud_only_block', 'error_handling']);
+
+    const clean = buildCleanOssData(augmented);
+
+    // Only the genuine OSS config entry survives.
+    expect(clean.config.map(c => c.name)).toEqual(['error_handling']);
+  });
+
+  test('strips platform metadata from surviving config entries', () => {
+    const clean = buildCleanOssData(makeAugmentedIndex());
+    const errorHandling = clean.config.find(c => c.name === 'error_handling');
+
+    expect(errorHandling).toBeDefined();
+    expect(errorHandling).not.toHaveProperty('cloudSupported');
+    expect(errorHandling).not.toHaveProperty('requiresCgo');
+    expect(errorHandling).not.toHaveProperty('cloudOnly');
+    // Genuine OSS content is preserved.
+    expect(errorHandling.kind).toBe('scalar');
+    expect(errorHandling.description).toBe('Engine-wide error handling.');
+  });
+
+  test('still drops augmentation-only entries from standard connector types', () => {
+    const clean = buildCleanOssData(makeAugmentedIndex());
+    // cloud_only_proc has no config/fields wrapper, so it is dropped;
+    // the genuine mapping processor is kept with metadata stripped.
+    expect(clean.processors.map(c => c.name)).toEqual(['mapping']);
+    expect(clean.processors[0]).not.toHaveProperty('cloudSupported');
+    expect(clean.processors[0]).not.toHaveProperty('requiresCgo');
+  });
+
+  test('leaves a raw OSS index (no augmentation markers) unchanged in membership', () => {
+    const raw = {
+      config: [
+        { name: 'error_handling', type: 'object', kind: 'scalar', description: 'x' }
+      ],
+      processors: [
+        { name: 'mapping', type: 'processor', config: { children: [] } }
+      ]
+    };
+    const clean = buildCleanOssData(raw);
+    expect(clean.config.map(c => c.name)).toEqual(['error_handling']);
+    expect(clean.processors.map(c => c.name)).toEqual(['mapping']);
   });
 });

--- a/__tests__/tools/rpcn-connector-summaries.test.js
+++ b/__tests__/tools/rpcn-connector-summaries.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+/**
+ * Tests for whats-new description summarization and config-component
+ * platform metadata in the Redpanda Connect docs generator.
+ *
+ * Covers two bugs observed in rp-connect-docs auto-docs PR output:
+ * 1. capToTwoSentences truncated descriptions containing Antora xref
+ *    macros (periods inside try.adoc / catch.adoc broke sentence
+ *    splitting, discarding all leading text).
+ * 2. config-type components (e.g. error_handling) never received a
+ *    cloudSupported flag from binary analysis, so the diff JSON marked
+ *    them cloudSupported: false while binaryAnalysis.details listed
+ *    them as cloud-supported.
+ */
+
+// The handler transitively requires the Octokit client (ESM-only under
+// Jest); stub it out since these tests never touch GitHub.
+jest.mock('../../cli-utils/octokit-client', () => ({}));
+
+const { capToTwoSentences, augmentConnectorData } = require('../../tools/redpanda-connect/rpcn-connector-docs-handler');
+const { generateConnectorDiffJson } = require('../../tools/redpanda-connect/report-delta');
+
+describe('capToTwoSentences - xref and filename protection', () => {
+  test('does not truncate descriptions containing xref macros', () => {
+    const description = 'This processor combines the behaviour of the xref:components:processors/try.adoc[`try`] and xref:components:processors/catch.adoc[`catch`] processors into a single block with an explicit recovery path. Because it contains both the fallible step and its recovery within a single processor, it is the recommended way to handle expected errors when strict error handling is enabled.';
+
+    const result = capToTwoSentences(description);
+
+    // The regression produced the fragment "adoc[`catch`] processors into..."
+    expect(result.startsWith('This processor combines')).toBe(true);
+    expect(result).toContain('xref:components:processors/try.adoc[`try`]');
+    expect(result).toContain('xref:components:processors/catch.adoc[`catch`]');
+    expect(result.startsWith('adoc[')).toBe(false);
+  });
+
+  test('splits at real sentence boundaries around bare filenames', () => {
+    const description = 'Reads settings from config.yaml at startup. Changes require a restart. A third sentence should be dropped.';
+
+    const result = capToTwoSentences(description);
+
+    expect(result).toBe('Reads settings from config.yaml at startup. Changes require a restart.');
+  });
+
+  test('keeps leading text when an unprotected mid-token period precedes the first boundary', () => {
+    const description = 'Uses internal.token values here. Second sentence follows.';
+
+    const result = capToTwoSentences(description);
+
+    expect(result.startsWith('Uses internal.token values here.')).toBe(true);
+  });
+
+  test('still caps plain descriptions to two sentences', () => {
+    const description = 'First sentence. Second sentence. Third sentence.';
+
+    expect(capToTwoSentences(description)).toBe('First sentence. Second sentence.');
+  });
+});
+
+describe('augmentConnectorData - config components', () => {
+  const binaryAnalysis = {
+    comparison: {
+      inCloud: [
+        { type: 'processors', name: 'mapping', status: 'stable' },
+        { type: 'config', name: 'error_handling', status: '' }
+      ]
+    },
+    cgoOnly: []
+  };
+
+  test('stamps cloudSupported on config components found in the cloud binary', () => {
+    const connectorData = {
+      processors: [{ name: 'mapping', type: 'processor', status: 'stable' }],
+      config: [{ name: 'error_handling', type: 'object', kind: 'scalar' }]
+    };
+
+    const { augmentedData } = augmentConnectorData(connectorData, binaryAnalysis);
+
+    const errorHandling = augmentedData.config.find(c => c.name === 'error_handling');
+    expect(errorHandling.cloudSupported).toBe(true);
+    expect(errorHandling.requiresCgo).toBe(false);
+  });
+
+  test('marks config components absent from the cloud binary as not cloud supported', () => {
+    const connectorData = {
+      config: [{ name: 'self_managed_only_block', type: 'object', kind: 'scalar' }]
+    };
+
+    const { augmentedData } = augmentConnectorData(connectorData, binaryAnalysis);
+
+    const block = augmentedData.config.find(c => c.name === 'self_managed_only_block');
+    expect(block.cloudSupported).toBe(false);
+  });
+});
+
+describe('generateConnectorDiffJson - config component status and cloud support', () => {
+  test('new config component without a status does not report its type as status', () => {
+    const oldIndex = { config: [] };
+    const newIndex = {
+      config: [
+        {
+          name: 'error_handling',
+          type: 'object',
+          kind: 'scalar',
+          description: 'Configures engine-wide error handling behaviour.',
+          cloudSupported: true
+        }
+      ]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.97.0',
+      newVersion: '4.98.0'
+    });
+
+    const added = diff.details.newComponents.find(c => c.name === 'error_handling');
+    expect(added).toBeDefined();
+    expect(added.status).toBe('');
+    expect(added.status).not.toBe('object');
+    expect(added.cloudSupported).toBe(true);
+  });
+
+  test('diff component entry agrees with binaryAnalysis cloud-supported details', () => {
+    const oldIndex = { config: [] };
+    const newIndex = {
+      config: [
+        {
+          name: 'error_handling',
+          type: 'object',
+          kind: 'scalar',
+          description: 'Configures engine-wide error handling behaviour.',
+          cloudSupported: true
+        }
+      ]
+    };
+    const binaryAnalysis = {
+      ossVersion: '4.98.0',
+      cloudVersion: '4.98.0',
+      comparison: {
+        inCloud: [{ type: 'config', name: 'error_handling', status: '' }],
+        ossOnly: [],
+        cloudOnly: []
+      }
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.97.0',
+      newVersion: '4.98.0',
+      binaryAnalysis
+    });
+
+    const added = diff.details.newComponents.find(c => c.name === 'error_handling');
+    const inDetails = (diff.binaryAnalysis.details.cloudSupported || [])
+      .some(c => c.type === 'config' && c.name === 'error_handling');
+
+    expect(inDetails).toBe(true);
+    expect(added.cloudSupported).toBe(true);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/redpanda-connect/pr-summary-formatter.js
+++ b/tools/redpanda-connect/pr-summary-formatter.js
@@ -235,7 +235,7 @@ function generateMultiVersionPRSummary(masterDiff, binaryAnalysis = null, drafte
         else if (isSelfHostedOnly) platformIndicator = ' 🖥️';
         if (isCgoOnly) platformIndicator += ' 🔧';
 
-        lines.push(`##### \`${comp.name}\` (${comp.type}, ${comp.status})${platformIndicator}`);
+        lines.push(`##### \`${comp.name}\` (${comp.status ? `${comp.type}, ${comp.status}` : comp.type})${platformIndicator}`);
 
         // Add description (truncated to 2 sentences)
         if (comp.description) {
@@ -982,7 +982,7 @@ function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = 
         lines.push('**☁️ Cloud Supported:**');
         lines.push('');
         cloudSupportedNew.forEach(c => {
-          lines.push(`- **${c.name}** (${c.type}, ${c.status})`);
+          lines.push(`- **${c.name}** (${c.status ? `${c.type}, ${c.status}` : c.type})`);
           const desc = c.summary || c.description;
           if (desc) {
             const shortDesc = truncateToSentence(desc, 2);
@@ -996,7 +996,7 @@ function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = 
         lines.push('**Self-Hosted Only:**');
         lines.push('');
         selfHostedOnlyNew.forEach(c => {
-          lines.push(`- **${c.name}** (${c.type}, ${c.status})`);
+          lines.push(`- **${c.name}** (${c.status ? `${c.type}, ${c.status}` : c.type})`);
           const desc = c.summary || c.description;
           if (desc) {
             const shortDesc = truncateToSentence(desc, 2);
@@ -1008,7 +1008,7 @@ function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = 
     } else {
       // No cloud support info, just list all
       diffData.details.newComponents.forEach(c => {
-        lines.push(`- **${c.name}** (${c.type}, ${c.status})`);
+        lines.push(`- **${c.name}** (${c.status ? `${c.type}, ${c.status}` : c.type})`);
         const desc = c.summary || c.description;
         if (desc) {
           const shortDesc = truncateToSentence(desc, 2);
@@ -1247,7 +1247,7 @@ function generatePRSummary(diffData, binaryAnalysis = null, draftedConnectors = 
     Object.entries(gapsByType).forEach(([type, connectors]) => {
       lines.push(`**${type}:**`);
       connectors.forEach(c => {
-        lines.push(`- ${c.name} (${c.status})`);
+        lines.push(`- ${c.name}${c.status ? ` (${c.status})` : ''}`);
       });
       lines.push('');
     });

--- a/tools/redpanda-connect/report-delta.js
+++ b/tools/redpanda-connect/report-delta.js
@@ -21,7 +21,7 @@ function generateConnectorDiffJson(oldIndex, newIndex, opts = {}) {
     return {
       name,
       type,
-      status: raw.status || raw.type || '',
+      status: raw.status || '',
       version: raw.version || raw.introducedInVersion || '',
       description: raw.description || '',
       requiresCgo: metadata.requiresCgo || false,
@@ -39,7 +39,7 @@ function generateConnectorDiffJson(oldIndex, newIndex, opts = {}) {
     return {
       name,
       type,
-      status: raw.status || raw.type || '',
+      status: raw.status || '',
       version: raw.version || raw.introducedInVersion || '',
       description: raw.description || '',
       requiresCgo: metadata.requiresCgo || false,
@@ -101,7 +101,7 @@ function generateConnectorDiffJson(oldIndex, newIndex, opts = {}) {
       deprecatedComponents.push({
         name,
         type,
-        status: raw.status || raw.type || '',
+        status: raw.status || '',
         version: raw.version || raw.introducedInVersion || '',
         description: raw.description || ''
       });
@@ -561,7 +561,7 @@ function printDeltaReport(oldIndex, newIndex) {
     newComponentKeys.forEach(key => {
       const [type, name] = key.split(':');
       const raw = newMap[key].raw;
-      const status = raw.status || raw.type || '';
+      const status = raw.status || '';
       const version = raw.version || raw.introducedInVersion || '';
       console.log(
         `   • ${type}/${name}${

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -208,6 +208,47 @@ function augmentConnectorData (connectorData, binaryAnalysis) {
 }
 
 /**
+ * Build a pure-OSS snapshot from a (possibly augmented) connector index, for use
+ * as the baseline in binary analysis. Removes augmentation-only entries (the
+ * cloud-only and cgo-only connectors that augmentConnectorData() adds and persists
+ * back into the data file) and strips platform metadata so the snapshot reflects
+ * only what the standard OSS rpk build reports.
+ *
+ * @param {Object} connectorIndex - Connector index object with arrays per type
+ * @returns {Object} Deep-cloned clean copy safe to diff as pure OSS data
+ */
+function buildCleanOssData (connectorIndex) {
+  const cleanData = JSON.parse(JSON.stringify(connectorIndex))
+  const connectorTypes = ['inputs', 'outputs', 'processors', 'caches', 'rate_limits',
+    'buffers', 'metrics', 'scanners', 'tracers']
+
+  for (const type of connectorTypes) {
+    if (Array.isArray(cleanData[type])) {
+      // Keep only connectors from OSS rpk (have config/fields)
+      // Remove augmentation-only connectors (added by previous binary analysis)
+      cleanData[type] = cleanData[type].filter(c => c.config || c.fields)
+
+      // Remove platform metadata from remaining connectors
+      stripPlatformMetadata(cleanData[type])
+    }
+  }
+
+  // Config components have no config/fields wrappers, so the filter above
+  // can't distinguish OSS entries from augmentation-only ones. augmentConnectorData()
+  // adds cloud-only and cgo-only config entries and persists them back to the data
+  // file, so on subsequent runs they would otherwise be copied into the clean OSS
+  // snapshot and pollute binary analysis. Drop those augmentation-only entries by
+  // their platform markers (genuine OSS config entries never carry cloudOnly, and
+  // a standard-build component is never cgo-only) before stripping metadata.
+  if (Array.isArray(cleanData.config)) {
+    cleanData.config = cleanData.config.filter(c => c.cloudOnly !== true && c.requiresCgo !== true)
+    stripPlatformMetadata(cleanData.config)
+  }
+
+  return cleanData
+}
+
+/**
  * Update whats-new.adoc with new release information
  * @param {Object} params - Parameters
  * @param {string} params.dataDir - Data directory path
@@ -1109,26 +1150,7 @@ async function handleRpcnConnectorDocs (options) {
   const cleanOssDataPath = path.join(dataDir, `._connect-${newVersion}-clean.json`)
 
   // Create clean version by removing augmented connectors
-  const cleanData = JSON.parse(JSON.stringify(newIndex))
-  const connectorTypes = ['inputs', 'outputs', 'processors', 'caches', 'rate_limits',
-    'buffers', 'metrics', 'scanners', 'tracers']
-
-  for (const type of connectorTypes) {
-    if (Array.isArray(cleanData[type])) {
-      // Keep only connectors from OSS rpk (have config/fields)
-      // Remove augmentation-only connectors (added by previous binary analysis)
-      cleanData[type] = cleanData[type].filter(c => c.config || c.fields)
-
-      // Remove platform metadata from remaining connectors
-      stripPlatformMetadata(cleanData[type])
-    }
-  }
-
-  // Config components have no config/fields wrappers, so skip the
-  // augmentation filter above and only strip platform metadata
-  if (Array.isArray(cleanData.config)) {
-    stripPlatformMetadata(cleanData.config)
-  }
+  const cleanData = buildCleanOssData(newIndex)
 
   fs.writeFileSync(cleanOssDataPath, JSON.stringify(cleanData, null, 2), 'utf8')
 
@@ -1989,5 +2011,6 @@ module.exports = {
   handleRpcnConnectorDocs,
   updateWhatsNew,
   capToTwoSentences,
-  augmentConnectorData
+  augmentConnectorData,
+  buildCleanOssData
 }

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -30,6 +30,8 @@ function capToTwoSentences (description) {
 
   const abbreviations = [
     /https?:\/\/[^\s]+?(?=[.!?](?:\s|$)|\s|$)/gi,  // Protect URLs from being split by sentence detection (non-greedy, preserve trailing punctuation)
+    /\bxref:[^\s[\]]+\[[^\]]*\]/g,  // Protect Antora xref macros (e.g. xref:components:processors/try.adoc[`try`]) whose targets contain periods
+    /\b[\w/-]+\.(?:adoc|md|ya?ml|json|html)\b/gi,  // Protect bare doc/config filenames (try.adoc, config.yaml) from splitting
     /\bv\d+\.\d+(?:\.\d+)?/gi,
     /\d+\.\d+/g,
     /\be\.g\./gi,
@@ -63,6 +65,16 @@ function capToTwoSentences (description) {
 
   const sentenceRegex = /[^.!?]+[.!?]+(?:\s|$)/g
   const sentences = normalized.match(sentenceRegex)
+
+  // If an unprotected mid-token period prevented the leading text from
+  // forming a complete match, merge that dropped prefix into the first
+  // sentence rather than silently discarding it.
+  if (sentences && sentences.length > 0) {
+    const firstIndex = normalized.indexOf(sentences[0])
+    if (firstIndex > 0) {
+      sentences[0] = normalized.slice(0, firstIndex) + sentences[0]
+    }
+  }
 
   if (!sentences || sentences.length === 0) {
     let result = normalized
@@ -135,7 +147,7 @@ function augmentConnectorData (connectorData, binaryAnalysis) {
   let addedCloudOnlyCount = 0
 
   const connectorTypes = ['inputs', 'outputs', 'processors', 'caches', 'rate_limits',
-    'buffers', 'metrics', 'scanners', 'tracers']
+    'buffers', 'metrics', 'scanners', 'tracers', 'config']
 
   for (const type of connectorTypes) {
     if (!Array.isArray(augmentedData[type])) {
@@ -1112,6 +1124,12 @@ async function handleRpcnConnectorDocs (options) {
     }
   }
 
+  // Config components have no config/fields wrappers, so skip the
+  // augmentation filter above and only strip platform metadata
+  if (Array.isArray(cleanData.config)) {
+    stripPlatformMetadata(cleanData.config)
+  }
+
   fs.writeFileSync(cleanOssDataPath, JSON.stringify(cleanData, null, 2), 'utf8')
 
   const versionsMatch = oldVersion && newVersion && oldVersion === newVersion
@@ -1357,7 +1375,7 @@ async function handleRpcnConnectorDocs (options) {
       // Strip CGO/cloud-only connectors and metadata from old data
       oldIndexForDiff = JSON.parse(JSON.stringify(oldIndex))
       const connectorTypes = ['inputs', 'outputs', 'processors', 'caches', 'rate_limits',
-        'buffers', 'metrics', 'scanners', 'tracers']
+        'buffers', 'metrics', 'scanners', 'tracers', 'config']
 
       let totalStripped = 0
       for (const type of connectorTypes) {
@@ -1970,5 +1988,6 @@ async function handleRpcnConnectorDocs (options) {
 module.exports = {
   handleRpcnConnectorDocs,
   updateWhatsNew,
-  capToTwoSentences
+  capToTwoSentences,
+  augmentConnectorData
 }


### PR DESCRIPTION
## Summary

Fixes three generator bugs observed in the auto-docs output for redpanda-data/rp-connect-docs#452 (the 4.96.3 → 4.98.0 update):

### 1. whats-new descriptions truncated by xref targets

`capToTwoSentences` in `rpcn-connector-docs-handler.js` split sentences on the periods inside Antora xref targets (`try.adoc`, `catch.adoc`), and `String.match` silently discarded all leading text that never formed a complete sentence match. The `try_catch` whats-new entry rendered as the fragment:

> adoc[`catch`] processors into a single block with an explicit recovery path.

**Fix:** protect `xref:...[...]` macros and bare doc/config filenames with placeholders before sentence splitting (same mechanism as the existing URL protection), and merge any dropped leading fragment into the first sentence as a general hardening.

### 2. config components missing cloudSupported (self-contradictory diff JSON)

`augmentConnectorData` stamps `cloudSupported`/`requiresCgo` using a hardcoded `connectorTypes` list that omitted `'config'`, so the new `error_handling` config component was emitted with `cloudSupported: false` in its component entry while `binaryAnalysis.details.cloudSupported` (which is type-agnostic) listed it as cloud-supported — flagged by CodeRabbit on the rp-connect-docs PR.

**Fix:** add `'config'` to the augmentation list and the no-binary-analysis fallback list, and strip platform metadata from `config` entries in the clean-OSS copy (they have no `config`/`fields` wrappers, so they bypass the existing filter).

### 3. Status column showed "object" for status-less components

`report-delta.js` fell back to `raw.type` when a component had no `status`, so the whats-new Status column and PR summary showed the type `object` for `error_handling`. Removed the type fallback and made PR summaries/gap reports render `(type)` instead of `(type, )` when status is empty.

## Testing

- New suite `__tests__/tools/rpcn-connector-summaries.test.js` (8 tests) covering all three fixes, including the exact `try_catch` description regression.
- Full run: 30 suites, 674 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)