### PR TITLE
fix: render connector sticky-bar metadata server-side, keep license notice visible

### DIFF
--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -30,9 +30,23 @@ module.exports.register = function ({ config }) {
     return require('../cli-utils/octokit-client')
   }
 
+  // Translated CSV rows, kept for the documentsConverted hook below
+  let translatedRows = null
+
   // Use 'on' and return the promise so Antora waits for async completion
   this.on('contentClassified', ({ contentCatalog }) => {
     return processContent(contentCatalog)
+  })
+
+  // Set sticky-bar page attributes (type context switcher and availability badges) so the UI
+  // templates (article.hbs) render them server-side, with no flash of client-side rearranging.
+  // This must run on documentsConverted: Antora extracts page attributes for UI templates in a
+  // header-only parse with Asciidoctor extensions disabled, so these attributes cannot be set
+  // from the component_type_dropdown macro during conversion. Mutating page.asciidoc.attributes
+  // after conversion is the supported way to feed computed attributes to UI templates.
+  this.on('documentsConverted', ({ contentCatalog }) => {
+    if (!translatedRows) return
+    setStickyBarPageAttributes(contentCatalog, translatedRows, logger)
   })
 
   async function processContent (contentCatalog) {
@@ -56,6 +70,7 @@ module.exports.register = function ({ config }) {
       const parsedData = Papa.parse(csvData, { header: true, skipEmptyLines: true })
       const enrichedData = translateCsvData(parsedData, pages, logger)
       parsedData.data = enrichedData
+      translatedRows = enrichedData
 
       // Set csvData on all relevant components
       const componentsToEnrich = [redpandaConnect, redpandaCloud, preview].filter(Boolean)
@@ -342,5 +357,84 @@ module.exports.register = function ({ config }) {
     logger.info(`Enriched ${enrichedCount} component pages with commercial names`)
 
     return csvCommercialNames
+  }
+
+  /**
+   * Sets sticky-bar metadata attributes on connector pages after conversion, so the UI templates
+   * (article.hbs and the context-switcher partial) render the Type dropdown and availability
+   * badges server-side:
+   * - page-context-switcher: Type dropdown entries (when the connector has multiple types)
+   * - page-cloud-available + page-cloud-available-url: on Self-Managed pages with a Cloud variant
+   * - page-self-managed-available + page-self-managed-available-url: on Cloud pages with a
+   *   Self-Managed variant
+   * - page-self-managed-only: on Self-Managed pages with no Cloud variant
+   */
+  function setStickyBarPageAttributes (contentCatalog, rows, logger) {
+    const pagesByUrl = new Map()
+    contentCatalog.getPages((page) => page.out && page.pub && page.asciidoc).forEach((page) => {
+      pagesByUrl.set(page.pub.url, page)
+    })
+
+    // Group CSV rows by connector name; each row is one type (input, output, and so on)
+    const rowsByConnector = new Map()
+    for (const row of rows) {
+      const connector = (row.connector || '').trim().toLowerCase()
+      if (!connector) continue
+      if (!rowsByConnector.has(connector)) rowsByConnector.set(connector, [])
+      rowsByConnector.get(connector).push(row)
+    }
+
+    let decoratedCount = 0
+    for (const connectorRows of rowsByConnector.values()) {
+      const isCloudSupported = connectorRows.some((row) => row.is_cloud_supported === 'y')
+      for (const row of connectorRows) {
+        // Self-Managed (Connect) variant of this connector page
+        const connectPage = row.redpandaConnectUrl && pagesByUrl.get(row.redpandaConnectUrl)
+        if (connectPage) {
+          const attrs = connectPage.asciidoc.attributes
+          if (connectorRows.length > 1) {
+            attrs['page-context-switcher'] = buildContextSwitcher(connectorRows, row, 'connect')
+          }
+          if (isCloudSupported && row.redpandaCloudUrl) {
+            attrs['page-cloud-available'] = 'true'
+            attrs['page-cloud-available-url'] = row.redpandaCloudUrl
+          } else if (!isCloudSupported) {
+            attrs['page-self-managed-only'] = 'true'
+          }
+          decoratedCount++
+        }
+        // Cloud variant of this connector page
+        const cloudPage = row.redpandaCloudUrl && pagesByUrl.get(row.redpandaCloudUrl)
+        if (cloudPage) {
+          const attrs = cloudPage.asciidoc.attributes
+          if (connectorRows.length > 1) {
+            attrs['page-context-switcher'] = buildContextSwitcher(connectorRows, row, 'cloud')
+          }
+          if (row.redpandaConnectUrl) {
+            attrs['page-self-managed-available'] = 'true'
+            attrs['page-self-managed-available-url'] = row.redpandaConnectUrl
+          }
+          decoratedCount++
+        }
+      }
+    }
+    logger.info(`Set sticky-bar metadata attributes on ${decoratedCount} connector pages`)
+  }
+
+  /**
+   * Builds the page-context-switcher JSON: one Type dropdown entry per connector type, linking to
+   * that type's page in the current site variant. The current page's type is listed first.
+   */
+  function buildContextSwitcher (connectorRows, currentRow, variant) {
+    const capitalize = (value) => value.charAt(0).toUpperCase() + value.slice(1)
+    const orderedRows = [currentRow, ...connectorRows.filter((row) => row !== currentRow)]
+    const data = {}
+    for (const row of orderedRows) {
+      const link = (variant === 'cloud' && row.redpandaCloudUrl) || row.redpandaConnectUrl
+      if (!link) continue
+      const type = row.type.trim()
+      data[type.toLowerCase()] = { name: capitalize(type), to: link }
+    }
+    return JSON.stringify(data)
   }
 }

--- a/macros/rp-connect-components.js
+++ b/macros/rp-connect-components.js
@@ -1053,36 +1053,6 @@ module.exports.register = function (registry, context) {
             </div>
           </div>`);
       }
-      // Process types and metadata from CSV
-      const types = componentRows.map(row => ({
-        type: row.type.trim(),
-        support: row.support_level.trim(),
-        isCloudSupported: row.is_cloud_supported === 'y',
-        redpandaConnectUrl: row.redpandaConnectUrl,
-        redpandaCloudUrl: row.redpandaCloudUrl
-      }));
-      // Move the current page's type to the first position in the dropdown
-      const sortedTypes = [...types];
-      const currentTypeIndex = sortedTypes.findIndex(typeObj => typeObj.type === type);
-      if (currentTypeIndex !== -1) {
-        const [currentType] = sortedTypes.splice(currentTypeIndex, 1);
-        sortedTypes.unshift(currentType);
-      }
-
-      // Set context-switcher attribute for UI template to render compact dropdown in sticky bar
-      if (sortedTypes.length > 1) {
-        const contextSwitcherData = {};
-        sortedTypes.forEach(typeObj => {
-          const link = (component === 'Cloud' && typeObj.redpandaCloudUrl) || typeObj.redpandaConnectUrl;
-          contextSwitcherData[typeObj.type.toLowerCase()] = {
-            name: capitalize(typeObj.type),
-            to: link
-          };
-        });
-        // Set as page attribute (not document attribute) so it's accessible in UI template
-        attributes['page-context-switcher'] = JSON.stringify(contextSwitcherData);
-        parent.getDocument().setAttribute('page-context-switcher', JSON.stringify(contextSwitcherData));
-      }
       // Check if the component requires an Enterprise license (based on support level)
       let enterpriseLicenseInfo = '';
       if (component !== 'Cloud') {
@@ -1092,121 +1062,23 @@ module.exports.register = function (registry, context) {
             <p><strong>License</strong>: This component requires an <a href="https://docs.redpanda.com/redpanda-connect/get-started/licensing/" target="_blank">enterprise license</a>. You can either <a href="https://www.redpanda.com/upgrade" target="_blank">upgrade to an Enterprise Edition license</a>, or <a href="http://redpanda.com/try-enterprise" target="_blank" rel="noopener">generate a trial license key</a> that's valid for 30 days.</p>`;
         }
       }
-      const isCloudSupported = componentRows.some(row => row.is_cloud_supported === 'y');
-
-      // Set availability attributes for UI template badges with URLs
-      if (isCloudSupported) {
-        const cloudUrl = sortedTypes[0].redpandaCloudUrl;
-        const connectUrl = sortedTypes[0].redpandaConnectUrl;
-
-        if (component === 'Connect' && cloudUrl) {
-          // Viewing Self-Managed, but also available in Cloud - show Cloud badge with link
-          parent.getDocument().setAttribute('cloud-available', 'true');
-          parent.getDocument().setAttribute('cloud-available-url', cloudUrl);
-        } else if (component === 'Cloud' && connectUrl) {
-          // Viewing Cloud, but also available in Self-Managed - show Self-Managed badge with link
-          parent.getDocument().setAttribute('self-managed-available', 'true');
-          parent.getDocument().setAttribute('self-managed-available-url', connectUrl);
-        }
-      } else if (!isCloudSupported && component === 'Connect') {
-        // Only available in Self-Managed - show "Self-Managed Only" badge (no link)
-        parent.getDocument().setAttribute('self-managed-only', 'true');
+      // The Type dropdown and availability info are rendered server-side in the sticky bar by the
+      // UI (article.hbs) from page attributes (page-context-switcher, page-cloud-available, and
+      // so on). Those attributes cannot be set from this macro: Antora extracts page attributes
+      // for UI templates in a header-only parse that runs before conversion with Asciidoctor
+      // extensions disabled, so anything set here never reaches the templates. The
+      // generate-rp-connect-info extension sets them on page.asciidoc.attributes on the
+      // documentsConverted event instead. Only the license notice belongs in the page body,
+      // where it must stay visible.
+      if (!enterpriseLicenseInfo) {
+        return self.createBlock(parent, 'pass', '');
       }
-
-      let availableInInfo = '';
-
-      if (isCloudSupported) {
-        const availableInLinks = [];
-
-        // Check if the component is Cloud and apply the `current-version` class
-        if (sortedTypes[0].redpandaCloudUrl) {
-          if (component === 'Cloud') {
-            availableInLinks.push('<span title="You are viewing the Cloud version of this component" class="current-version">Cloud</span>'); // Highlight the current version
-          } else {
-            availableInLinks.push(`<a title="View the Cloud version of this component" href="${sortedTypes[0].redpandaCloudUrl}">Cloud</a>`);
-          }
-        }
-
-        // Check if the component is Connect and apply the `current-version` class
-        if (sortedTypes[0].redpandaConnectUrl) {
-          if (component === 'Connect') {
-            availableInLinks.push('<span title="You are viewing the Self-Managed version of this component" class="current-version">Self-Managed</span>'); // Highlight the current version
-          } else {
-            availableInLinks.push(`<a title="View the Self-Managed version of this component" href="${sortedTypes[0].redpandaConnectUrl}">Self-Managed</a>`);
-          }
-        }
-        availableInInfo = `<p><strong>Available in:</strong> ${availableInLinks.join(', ')}</p>`;
-      } else {
-        availableInInfo = `<p><strong>Available in:</strong> <span title="You are viewing the Self-Managed version of this component" class="current-version">Self-Managed</span></p>`;
-      }
-      // Build the dropdown for types with links depending on the current component
-      let typeDropdown = '';
-      if (sortedTypes.length > 1) {
-        const dropdownOptions = sortedTypes.map(typeObj => {
-          const link = (component === 'Cloud' && typeObj.redpandaCloudUrl) || typeObj.redpandaConnectUrl;
-          return `<a href="${link}" class="dropdown-option" role="menuitem" tabindex="-1">${capitalize(typeObj.type)}</a>`;
-        }).join('');
-        typeDropdown = `
-          <div class="dropdown-wrapper">
-            <p class="type-dropdown-container"><strong>Type:</strong>
-              <button type="button" class="dropdown-toggle" id="componentTypeDropdownToggle" onclick="toggleComponentTypeDropdown()" aria-expanded="false" aria-haspopup="true" aria-controls="componentTypeDropdownMenu">
-                <span class="dropdown-text">${capitalize(sortedTypes[0].type)}</span>
-                <span class="dropdown-arrow">▼</span>
-              </button>
-              <div class="dropdown-menu" id="componentTypeDropdownMenu" role="menu" aria-labelledby="componentTypeDropdownToggle">
-                ${dropdownOptions}
-              </div>
-            </p>
-          </div>`;
-      }
-      // Return the metadata block with consistent layout
       return self.createBlock(parent, 'pass', `
         <div class="metadata-block">
           <div class="metadata-content">
-          ${typeDropdown}
-          ${availableInInfo}
           ${enterpriseLicenseInfo}
           </div>
-        </div>
-        <script>
-          // Define global dropdown functions directly (shared between macros)
-          if (!window.toggleComponentTypeDropdown) {
-            window.toggleComponentTypeDropdown = function() {
-              const toggle = document.getElementById('componentTypeDropdownToggle');
-              const menu = document.getElementById('componentTypeDropdownMenu');
-              
-              if (!toggle || !menu) return;
-              
-              const isOpen = menu.classList.contains('show');
-              
-              // Close all other dropdowns first (including filter dropdowns)
-              document.querySelectorAll('.dropdown-checkbox-menu.show, .dropdown-menu.show').forEach(dropdown => {
-                if (dropdown !== menu) {
-                  dropdown.classList.remove('show');
-                  const otherToggle = dropdown.parentNode.querySelector('.dropdown-checkbox-toggle, .dropdown-toggle');
-                  if (otherToggle) {
-                    otherToggle.classList.remove('open');
-                    otherToggle.setAttribute('aria-expanded', 'false');
-                  }
-                }
-              });
-              
-              // Toggle current dropdown
-              if (isOpen) {
-                menu.classList.remove('show');
-                toggle.classList.remove('open');
-                toggle.setAttribute('aria-expanded', 'false');
-              } else {
-                menu.classList.add('show');
-                toggle.classList.add('open');
-                toggle.setAttribute('aria-expanded', 'true');
-                // Focus first option
-                const firstOption = menu.querySelector('.dropdown-option');
-                if (firstOption) firstOption.focus();
-              }
-            };
-          }
-        </script>`);
+        </div>`);
     });
   });
 


### PR DESCRIPTION
## Problem

Connector pages flash their metadata on load, and the enterprise license notice disappears entirely ([DOC-2383](https://redpandadata.atlassian.net/browse/DOC-2383)): the `component_type_dropdown` macro emits a `.metadata-block` in the body, and the docs-ui client-side script moves the Type dropdown and availability info into the sticky bar after `DOMContentLoaded`, hiding the whole block - including the license notice it never moved.

The macro already tried to set the sticky-bar page attributes that the UI renders server-side (`article.hbs`), but they can never reach UI templates from an Asciidoctor extension: Antora extracts page attributes in a **header-only parse with extensions disabled**, and `convertDocument` only re-extracts metadata when `page.asciidoc` is unset - which it never is, because `convertDocuments` always sets it in that header-only pass. The availability attributes were also missing the `page-` prefix that Antora requires to expose them to templates.

## Changes

- **`extensions/generate-rp-connect-info.js`**: new `documentsConverted` handler sets `page-context-switcher`, `page-cloud-available(-url)`, `page-self-managed-available(-url)`, and `page-self-managed-only` directly on `page.asciidoc.attributes`, matching translated CSV rows to pages by `pub.url`. Mutating page metadata after conversion is the only way computed attributes reach UI templates.
- **`macros/rp-connect-components.js`**: `component_type_dropdown` no longer emits the in-body Type dropdown, "Available in:" paragraph, or inline dropdown script (all now rendered server-side by the UI from the attributes above). It emits only the license notice, which stays visible in the body. The dead attribute-setting code is removed with a comment explaining why it can never work.

## Testing

Verified end-to-end in an isolated Antora build using this branch, a CSV fixture, and the current UI bundle plus the companion docs-ui change (redpanda-data/docs-ui#403):

- Sticky-bar metadata renders at build time (no flash): context switcher with the current type first and correct per-variant links, "Also in Cloud" / "Also in Self-Managed" / "Self-Managed Only" badges all correct.
- License notice stays visible in the body for enterprise connectors.
- No duplicated in-body metadata; the docs-ui script early-returns when the server-rendered sticky bar is present, and remains a fallback for content built with older extension versions.

## Rollout

Release the docs-ui change first (redpanda-data/docs-ui#403 - fixes the disappearing license notice on its own), then this package, then rebuild the docs to eliminate the flash entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-2383]: https://redpandadata.atlassian.net/browse/DOC-2383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ