### PR TITLE
fix(connect): render map fields as object in field reference

### DIFF
--- a/__tests__/tools/generate-rpcn-connector-docs.test.js
+++ b/__tests__/tools/generate-rpcn-connector-docs.test.js
@@ -429,6 +429,24 @@ describe('Utility Helpers', () => {
       expect(result).toContain("*Default*: `30`");
     });
 
+    it('renders a string-valued map field as object, not string', () => {
+      const mapField = [
+        { name: 'headers', type: 'string', kind: 'map', description: 'Custom headers keyed by name.' },
+      ];
+      const result = renderConnectFields(mapField).toString();
+      expect(result).toContain('=== `headers`');
+      expect(result).toContain('*Type*: `object`');
+      expect(result).not.toContain('*Type*: `string`');
+    });
+
+    it('renders any list/array field as array regardless of element type', () => {
+      const listField = [
+        { name: 'ports', type: 'int', kind: 'array', description: 'Ports.' },
+      ];
+      const result = renderConnectFields(listField).toString();
+      expect(result).toContain('*Type*: `array`');
+    });
+
     it('recursively renders nested children with correct path', () => {
       const result = renderConnectFields(nestedField).toString();
       expect(result).toContain("=== `parent`");

--- a/__tests__/tools/generate-rpcn-connector-docs.test.js
+++ b/__tests__/tools/generate-rpcn-connector-docs.test.js
@@ -439,13 +439,17 @@ describe('Utility Helpers', () => {
       expect(result).not.toContain('*Type*: `string`');
     });
 
-    it('renders any list/array field as array regardless of element type', () => {
-      const listField = [
-        { name: 'ports', type: 'int', kind: 'array', description: 'Ports.' },
-      ];
-      const result = renderConnectFields(listField).toString();
-      expect(result).toContain('*Type*: `array`');
-    });
+    it.each(['array', 'list', '2darray'])(
+      'renders a field of kind %s as array regardless of element type',
+      (kind) => {
+        const listField = [
+          { name: 'ports', type: 'int', kind, description: 'Ports.' },
+        ];
+        const result = renderConnectFields(listField).toString();
+        expect(result).toContain('*Type*: `array`');
+        expect(result).not.toContain('*Type*: `int`');
+      }
+    );
 
     it('recursively renders nested children with correct path', () => {
       const result = renderConnectFields(nestedField).toString();

--- a/__tests__/tools/generate-rpcn-connector-docs.test.js
+++ b/__tests__/tools/generate-rpcn-connector-docs.test.js
@@ -483,6 +483,17 @@ describe('Utility Helpers', () => {
       expect(result).not.toContain('array<');
     });
 
+    it('falls back to plain array when the element type is itself array (override-forced types)', () => {
+      // docs-data/overrides.json in rp-connect-docs sets `type: "array"` on
+      // some fields (for example, NATS `urls`) to force a plain-array display.
+      const listField = [
+        { name: 'urls', type: 'array', kind: 'array', description: 'URLs.' },
+      ];
+      const result = renderConnectFields(listField).toString();
+      expect(result).toContain('*Type*: `array`');
+      expect(result).not.toContain('array<');
+    });
+
     it('recursively renders nested children with correct path', () => {
       const result = renderConnectFields(nestedField).toString();
       expect(result).toContain("=== `parent`");

--- a/__tests__/tools/generate-rpcn-connector-docs.test.js
+++ b/__tests__/tools/generate-rpcn-connector-docs.test.js
@@ -429,27 +429,59 @@ describe('Utility Helpers', () => {
       expect(result).toContain("*Default*: `30`");
     });
 
-    it('renders a string-valued map field as object, not string', () => {
-      const mapField = [
-        { name: 'headers', type: 'string', kind: 'map', description: 'Custom headers keyed by name.' },
-      ];
-      const result = renderConnectFields(mapField).toString();
-      expect(result).toContain('=== `headers`');
-      expect(result).toContain('*Type*: `object`');
-      expect(result).not.toContain('*Type*: `string`');
-    });
+    it.each(['string', 'int', 'unknown'])(
+      'renders a %s-valued map field as object',
+      (type) => {
+        const mapField = [
+          { name: 'headers', type, kind: 'map', description: 'Custom headers keyed by name.' },
+        ];
+        const result = renderConnectFields(mapField).toString();
+        expect(result).toContain('=== `headers`');
+        expect(result).toContain('*Type*: `object`');
+        expect(result).not.toContain(`*Type*: \`${type}\``);
+      }
+    );
+
+    it.each([
+      ['array', 'int', 'array<int>'],
+      ['array', 'string', 'array<string>'],
+      ['array', 'object', 'array<object>'],
+      ['list', 'int', 'array<int>'],
+      ['2darray', 'string', 'array<array<string>>'],
+      ['2darray', 'object', 'array<array<object>>'],
+    ])(
+      'renders a field of kind %s with element type %s as %s',
+      (kind, type, expected) => {
+        const listField = [
+          { name: 'ports', type, kind, description: 'Ports.' },
+        ];
+        const result = renderConnectFields(listField).toString();
+        expect(result).toContain(`*Type*: \`${expected}\``);
+        expect(result).not.toContain(`*Type*: \`${type}\``);
+      }
+    );
 
     it.each(['array', 'list', '2darray'])(
-      'renders a field of kind %s as array regardless of element type',
+      'falls back to plain array for kind %s when the element type is unknown',
       (kind) => {
         const listField = [
-          { name: 'ports', type: 'int', kind, description: 'Ports.' },
+          { name: 'ports', type: 'unknown', kind, description: 'Ports.' },
         ];
         const result = renderConnectFields(listField).toString();
         expect(result).toContain('*Type*: `array`');
-        expect(result).not.toContain('*Type*: `int`');
+        expect(result).not.toContain('*Type*: `unknown`');
+        expect(result).not.toContain('array<');
       }
     );
+
+    it('falls back to plain array when the element type is absent', () => {
+      const listField = [
+        { name: 'ports', kind: 'array', description: 'Ports.' },
+      ];
+      const result = renderConnectFields(listField).toString();
+      expect(result).toContain('*Type*: `array`');
+      expect(result).not.toContain('array<');
+    });
 
     it('recursively renders nested children with correct path', () => {
       const result = renderConnectFields(nestedField).toString();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.2.4",
+      "version": "5.2.5",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/redpanda-connect/helpers/renderConnectFields.js
+++ b/tools/redpanda-connect/helpers/renderConnectFields.js
@@ -38,8 +38,10 @@ module.exports = function renderConnectFields(children, prefix = '') {
       // Arrays render as `array<element>` when the element type is known,
       // for example `array<string>`. 2D arrays nest the element type, for
       // example `array<array<string>>`. Unknown element types render as
-      // plain `array`.
-      const elementType = (typeof child.type === 'string' && child.type !== '' && child.type !== 'unknown')
+      // plain `array`. A `type` of `array` (used by some overrides to force
+      // the old plain-array display) is treated as unknown so the field
+      // renders as `array` rather than the degenerate `array<array>`.
+      const elementType = (typeof child.type === 'string' && child.type !== '' && child.type !== 'unknown' && child.type !== 'array')
         ? child.type
         : null;
       if (elementType) {

--- a/tools/redpanda-connect/helpers/renderConnectFields.js
+++ b/tools/redpanda-connect/helpers/renderConnectFields.js
@@ -31,13 +31,14 @@ module.exports = function renderConnectFields(children, prefix = '') {
     const isArrayTitle = typeof child.name === 'string' && child.name.endsWith('[]');
     if (isArrayTitle) {
       displayType = 'array<object>';
-    } else if (child.type === 'string' && child.kind === 'array') {
-      displayType = 'array';
-    } else if (child.type === 'unknown' && child.kind === 'map') {
+    } else if (child.kind === 'map') {
+      // Any map renders as an object, regardless of its value type. Previously
+      // only `type: unknown` maps were handled, so string-valued maps (for
+      // example a `map[string]string` field) fell through and rendered as
+      // `string`, which is misleading.
       displayType = 'object';
-    } else if (child.type === 'unknown' && child.kind === 'array') {
-      displayType = 'array';
-    } else if (child.type === 'unknown' && child.kind === 'list') {
+    } else if (child.kind === 'array' || child.kind === 'list') {
+      // Any list/array renders as `array` regardless of element type.
       displayType = 'array';
     } else {
       displayType = child.type;

--- a/tools/redpanda-connect/helpers/renderConnectFields.js
+++ b/tools/redpanda-connect/helpers/renderConnectFields.js
@@ -35,9 +35,20 @@ module.exports = function renderConnectFields(children, prefix = '') {
       // Maps always render as `object`, regardless of value type.
       displayType = 'object';
     } else if (child.kind === 'array' || child.kind === 'list' || child.kind === '2darray') {
-      // Lists, arrays, and 2D arrays always render as `array`, regardless of
-      // element type.
-      displayType = 'array';
+      // Arrays render as `array<element>` when the element type is known,
+      // for example `array<string>`. 2D arrays nest the element type, for
+      // example `array<array<string>>`. Unknown element types render as
+      // plain `array`.
+      const elementType = (typeof child.type === 'string' && child.type !== '' && child.type !== 'unknown')
+        ? child.type
+        : null;
+      if (elementType) {
+        displayType = child.kind === '2darray'
+          ? `array<array<${elementType}>>`
+          : `array<${elementType}>`;
+      } else {
+        displayType = 'array';
+      }
     } else {
       displayType = child.type;
     }

--- a/tools/redpanda-connect/helpers/renderConnectFields.js
+++ b/tools/redpanda-connect/helpers/renderConnectFields.js
@@ -32,13 +32,11 @@ module.exports = function renderConnectFields(children, prefix = '') {
     if (isArrayTitle) {
       displayType = 'array<object>';
     } else if (child.kind === 'map') {
-      // Any map renders as an object, regardless of its value type. Previously
-      // only `type: unknown` maps were handled, so string-valued maps (for
-      // example a `map[string]string` field) fell through and rendered as
-      // `string`, which is misleading.
+      // Maps always render as `object`, regardless of value type.
       displayType = 'object';
-    } else if (child.kind === 'array' || child.kind === 'list') {
-      // Any list/array renders as `array` regardless of element type.
+    } else if (child.kind === 'array' || child.kind === 'list' || child.kind === '2darray') {
+      // Lists, arrays, and 2D arrays always render as `array`, regardless of
+      // element type.
       displayType = 'array';
     } else {
       displayType = child.type;


### PR DESCRIPTION
## Problem

In the connector field reference, string-valued **map** fields render `*Type*: string`, which is misleading — they accept a map/object, not a string. Examples: `redpanda_migrator.headers` and `oracledb_cdc.snapshot_filters` (both `type: string, kind: map`). Flagged during review of rp-connect-docs#466.

## Cause

`renderConnectFields` normalized types with type-restricted cases:

```js
} else if (child.type === 'unknown' && child.kind === 'map') {
  displayType = 'object';
} else if (child.type === 'string' && child.kind === 'array') {
  displayType = 'array';
...
} else {
  displayType = child.type;   // string map lands here -> "string"
}
```

Only `type: unknown` maps became `object`; a `type: string, kind: map` field fell through to `child.type` (`string`).

## Fix

Detect maps and lists/arrays by **`kind`**, regardless of the value type:

```js
} else if (child.kind === 'map') {
  displayType = 'object';
} else if (child.kind === 'array' || child.kind === 'list') {
  displayType = 'array';
} else {
  displayType = child.type;
}
```

This also generalizes array handling (e.g. an `int` array now renders `array` instead of `int`, consistent with how string arrays already rendered).

## Tests

`npx jest __tests__/tools/generate-rpcn-connector-docs.test.js` → 25 passing, including two new cases: a string-valued map renders as `object` (not `string`), and a non-string array renders as `array`.

## Release / merge order

Bumped to **5.2.5**. #218 is still open at **5.2.4** — please merge **#218 before this PR** so both publish (publish is skipped if a version already exists on npm). If this merges first, #218 must rebase and re-bump.