### PR TITLE
feat: point UI meta tags at JSON attachments that actually exist

### DIFF
--- a/__tests__/extensions/set-available-attachment-versions.test.js
+++ b/__tests__/extensions/set-available-attachment-versions.test.js
@@ -103,15 +103,18 @@ describe('set-available-attachment-versions extension', () => {
   })
 
   it('sets available-connect-version to the newest connect JSON, comparing numerically', () => {
+    // Production shape: rp-connect-docs is `name: connect` and versionless
+    // (`version: null`), which Antora represents as version '' on both the
+    // component version and the attachment src.
     const compVer = {
-      version: 'current',
+      version: '',
       asciidoc: { attributes: { 'latest-connect-version': '4.102.0' } },
     }
     run(
-      [{ name: 'redpanda-connect', versions: [compVer] }],
+      [{ name: 'connect', versions: [compVer] }],
       [
-        makeAttachment('redpanda-connect', 'current', 'components', 'connect-4.100.0.json'),
-        makeAttachment('redpanda-connect', 'current', 'components', 'connect-4.99.0.json'),
+        makeAttachment('connect', '', 'components', 'connect-4.100.0.json'),
+        makeAttachment('connect', '', 'components', 'connect-4.99.0.json'),
       ]
     )
     expect(compVer.asciidoc.attributes['available-connect-version']).toBe('4.100.0')

--- a/__tests__/extensions/set-available-attachment-versions.test.js
+++ b/__tests__/extensions/set-available-attachment-versions.test.js
@@ -1,0 +1,135 @@
+const { describe, it, expect, beforeEach } = require('@jest/globals')
+
+const extension = require('../../extensions/set-available-attachment-versions.js')
+
+function makeAttachment (component, version, module, relative) {
+  return { src: { component, version, module, family: 'attachment', relative } }
+}
+
+describe('set-available-attachment-versions extension', () => {
+  let mockLogger
+  let handlers
+  let extensionContext
+
+  beforeEach(() => {
+    mockLogger = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }
+    handlers = {}
+    extensionContext = {
+      once: jest.fn((event, handler) => {
+        handlers[event] = handler
+      }),
+      getLogger: jest.fn(() => mockLogger),
+    }
+  })
+
+  function run (components, attachments) {
+    const contentCatalog = {
+      getComponents: jest.fn(() => components),
+      findBy: jest.fn(({ component, version }) =>
+        attachments.filter((a) => a.src.component === component && a.src.version === version)
+      ),
+    }
+    extension.register.call(extensionContext)
+    handlers.contentClassified({ contentCatalog })
+    return contentCatalog
+  }
+
+  it('sets available-properties-tag to the newest properties JSON in the catalog', () => {
+    const compVer = {
+      version: '26.1',
+      asciidoc: { attributes: { 'latest-redpanda-tag': 'v26.1.14' } },
+    }
+    run(
+      [{ name: 'ROOT', versions: [compVer] }],
+      [
+        makeAttachment('ROOT', '26.1', 'reference', 'redpanda-properties-v26.1.12.json'),
+        makeAttachment('ROOT', '26.1', 'reference', 'redpanda-properties-v26.1.13.json'),
+        makeAttachment('ROOT', '26.1', 'reference', 'redpanda-properties-v26.1.9.json'),
+      ]
+    )
+    expect(compVer.asciidoc.attributes['available-properties-tag']).toBe('v26.1.13')
+    expect(compVer.asciidoc.attributes['page-disable-property-tooltips']).toBeUndefined()
+  })
+
+  it('disables property tooltips when a version has no properties JSON', () => {
+    const compVer = {
+      version: '25.2',
+      asciidoc: { attributes: { 'latest-redpanda-tag': 'v25.2.1' } },
+    }
+    run([{ name: 'ROOT', versions: [compVer] }], [])
+    expect(compVer.asciidoc.attributes['available-properties-tag']).toBeUndefined()
+    expect(compVer.asciidoc.attributes['page-disable-property-tooltips']).toBe('true')
+  })
+
+  it('leaves versions without latest-redpanda-tag untouched', () => {
+    const compVer = { version: 'shared', asciidoc: { attributes: {} } }
+    run([{ name: 'ROOT', versions: [compVer] }], [])
+    expect(compVer.asciidoc.attributes).toEqual({})
+  })
+
+  it('does not overwrite an author-pinned available-properties-tag', () => {
+    const compVer = {
+      version: '26.1',
+      asciidoc: {
+        attributes: {
+          'latest-redpanda-tag': 'v26.1.14',
+          'available-properties-tag': 'v26.1.10',
+        },
+      },
+    }
+    run(
+      [{ name: 'ROOT', versions: [compVer] }],
+      [makeAttachment('ROOT', '26.1', 'reference', 'redpanda-properties-v26.1.13.json')]
+    )
+    expect(compVer.asciidoc.attributes['available-properties-tag']).toBe('v26.1.10')
+  })
+
+  it('ignores attachments outside the reference module', () => {
+    const compVer = {
+      version: '26.1',
+      asciidoc: { attributes: { 'latest-redpanda-tag': 'v26.1.14' } },
+    }
+    run(
+      [{ name: 'ROOT', versions: [compVer] }],
+      [makeAttachment('ROOT', '26.1', 'console', 'redpanda-properties-v26.1.13.json')]
+    )
+    expect(compVer.asciidoc.attributes['available-properties-tag']).toBeUndefined()
+    expect(compVer.asciidoc.attributes['page-disable-property-tooltips']).toBe('true')
+  })
+
+  it('sets available-connect-version to the newest connect JSON, comparing numerically', () => {
+    const compVer = {
+      version: 'current',
+      asciidoc: { attributes: { 'latest-connect-version': '4.102.0' } },
+    }
+    run(
+      [{ name: 'redpanda-connect', versions: [compVer] }],
+      [
+        makeAttachment('redpanda-connect', 'current', 'components', 'connect-4.100.0.json'),
+        makeAttachment('redpanda-connect', 'current', 'components', 'connect-4.99.0.json'),
+      ]
+    )
+    expect(compVer.asciidoc.attributes['available-connect-version']).toBe('4.100.0')
+  })
+
+  it('handles missing asciidoc config without throwing', () => {
+    const compVer = { version: '26.1' }
+    run(
+      [{ name: 'streaming', versions: [compVer] }],
+      [makeAttachment('streaming', '26.1', 'reference', 'redpanda-properties-v26.1.13.json')]
+    )
+    expect(compVer.asciidoc.attributes['available-properties-tag']).toBe('v26.1.13')
+  })
+
+  it('ignores components that are neither streaming nor connect', () => {
+    const compVer = { version: 'main', asciidoc: { attributes: {} } }
+    const catalog = run([{ name: 'labs', versions: [compVer] }], [])
+    expect(catalog.findBy).not.toHaveBeenCalled()
+    expect(compVer.asciidoc.attributes).toEqual({})
+  })
+})

--- a/extensions/README.adoc
+++ b/extensions/README.adoc
@@ -84,9 +84,9 @@ IMPORTANT: Extensions must be registered under the `antora.extensions` key in yo
 
 === Content enhancement
 * **add-global-attributes** - Add attributes globally to all pages
-* **set-available-attachment-versions** - Point UI templates at the newest generated JSON attachments that exist in the catalog
 * **add-pages-to-root** - Add pages to the root navigation
 * **process-context-switcher** - Handle context-dependent content
+* **set-available-attachment-versions** - Point UI templates at the newest generated JSON attachments that exist in the catalog
 * **validate-attributes** - Validate AsciiDoc attributes
 
 === AI-friendly documentation

--- a/extensions/README.adoc
+++ b/extensions/README.adoc
@@ -84,6 +84,7 @@ IMPORTANT: Extensions must be registered under the `antora.extensions` key in yo
 
 === Content enhancement
 * **add-global-attributes** - Add attributes globally to all pages
+* **set-available-attachment-versions** - Point UI templates at the newest generated JSON attachments that exist in the catalog
 * **add-pages-to-root** - Add pages to the root navigation
 * **process-context-switcher** - Handle context-dependent content
 * **validate-attributes** - Validate AsciiDoc attributes

--- a/extensions/REFERENCE.adoc
+++ b/extensions/REFERENCE.adoc
@@ -456,6 +456,35 @@ antora:
   - '@redpanda-data/docs-extensions-and-macros/extensions/version-fetcher/set-latest-version'
 ```
 
+== Set available attachment versions
+
+This extension scans the content catalog for generated JSON attachments and sets attributes that point UI templates at the newest file that actually exists, instead of the newest released version. Release-tracking attributes such as `latest-redpanda-tag` and `latest-connect-version` can be ahead of the newest generated JSON in the catalog; without this extension, the docs-ui `head-meta` partial falls back to a constructed production URL that returns 404 on every page view.
+
+It sets the following attributes on component versions (never overwriting a value that is already set, so they can be pinned in `antora.yml`):
+
+* `available-properties-tag`: newest `redpanda-properties-<tag>.json` attachment in the `reference` module of each streaming (`ROOT`) component version.
+* `available-connect-version`: newest `connect-<version>.json` attachment in the `components` module of the `connect` component.
+* `page-disable-property-tooltips`: set to `true` on streaming versions that have no properties JSON at all, so browsers never request a URL that cannot exist.
+
+=== Environment variables
+
+This extension does not require any environment variables.
+
+=== Configuration options
+
+There are no configurable options for this extension.
+
+=== Registration
+
+Register the `set-available-attachment-versions` extension in the Antora playbook under the `antora.extensions` key like so:
+
+[source,yaml]
+----
+antora:
+  extensions:
+    - require: '@redpanda-data/docs-extensions-and-macros/extensions/set-available-attachment-versions'
+----
+
 == Validate attributes
 
 This extension ensures the consistency and validity of page attributes, focusing on validating page categories against a predefined list of valid categories and subcategories. It automatically adds missing parent categories for any specified subcategories and removes any specified categories that are invalid. Additionally, it processes specific environment attributes, setting corresponding page-level attributes when environment conditions are met.

--- a/extensions/REFERENCE.adoc
+++ b/extensions/REFERENCE.adoc
@@ -462,8 +462,8 @@ This extension scans the content catalog for generated JSON attachments and sets
 
 It sets the following attributes on component versions (never overwriting a value that is already set, so they can be pinned in `antora.yml`):
 
-* `available-properties-tag`: newest `redpanda-properties-<tag>.json` attachment in the `reference` module of each streaming (`ROOT`) component version.
-* `available-connect-version`: newest `connect-<version>.json` attachment in the `components` module of the `connect` component.
+* `available-properties-tag`: newest `redpanda-properties-<tag>.json` attachment in the `reference` module of each version of the streaming component (`streaming`, or `ROOT` on older branches).
+* `available-connect-version`: newest `connect-<version>.json` attachment in the `components` module of the connect component (`connect`, or `redpanda-connect` on older branches).
 * `page-disable-property-tooltips`: set to `true` on streaming versions that have no properties JSON at all, so browsers never request a URL that cannot exist.
 
 === Environment variables

--- a/extensions/set-available-attachment-versions.js
+++ b/extensions/set-available-attachment-versions.js
@@ -1,0 +1,105 @@
+'use strict'
+
+const semver = require('semver')
+
+/**
+ * Points UI templates at generated JSON attachments that actually exist.
+ *
+ * The docs-ui head-meta partial builds <meta name="properties-json-url"> and
+ * <meta name="connect-json-url"> tags from version attributes such as
+ * latest-redpanda-tag and latest-connect-version. Those attributes track the
+ * newest GitHub release, which can be ahead of the newest generated JSON in
+ * the content catalog. When that happens the template's production fallback
+ * URL points at a file that does not exist, and every page view requests a
+ * guaranteed 404.
+ *
+ * This extension scans the catalog on contentClassified and sets, per
+ * component version:
+ *
+ * - available-properties-tag: newest redpanda-properties-<tag>.json attachment
+ *   in the reference module of each streaming (ROOT) component version
+ * - available-connect-version: newest connect-<version>.json attachment in the
+ *   components module of the connect component
+ * - page-disable-property-tooltips: 'true' on streaming versions that have no
+ *   properties JSON at all, so browsers never request a URL that cannot exist
+ *
+ * Attributes already set (for example, pinned in antora.yml) are never
+ * overwritten.
+ */
+
+const PROPERTIES_COMPONENTS = ['ROOT', 'streaming']
+const CONNECT_COMPONENTS = ['connect', 'redpanda-connect']
+
+const PROPERTIES_JSON_RX = /^redpanda-properties-(v\d+\.\d+\.\d+(?:-[\w.]+)?)\.json$/
+const CONNECT_JSON_RX = /^connect-(\d+\.\d+\.\d+(?:-[\w.]+)?)\.json$/
+
+module.exports.register = function () {
+  const logger = this.getLogger('set-available-attachment-versions-extension')
+
+  this.once('contentClassified', ({ contentCatalog }) => {
+    contentCatalog.getComponents().forEach((component) => {
+      const isProperties = PROPERTIES_COMPONENTS.includes(component.name)
+      const isConnect = CONNECT_COMPONENTS.includes(component.name)
+      if (!isProperties && !isConnect) return
+
+      component.versions.forEach((compVer) => {
+        const attributes = ((compVer.asciidoc = compVer.asciidoc || {}).attributes =
+          compVer.asciidoc.attributes || {})
+        const attachments = contentCatalog.findBy({
+          component: component.name,
+          version: compVer.version,
+          family: 'attachment',
+        })
+
+        if (isProperties) {
+          const newest = findNewestVersion(attachments, 'reference', PROPERTIES_JSON_RX)
+          if (newest) {
+            if (!attributes['available-properties-tag']) {
+              attributes['available-properties-tag'] = newest
+              logger.info(
+                `Set available-properties-tag=${newest} for ${component.name}@${compVer.version}`
+              )
+            }
+          } else if (attributes['latest-redpanda-tag'] && !attributes['available-properties-tag']) {
+            // Tooltips would request a JSON that does not exist for this version
+            if (!attributes['page-disable-property-tooltips']) {
+              attributes['page-disable-property-tooltips'] = 'true'
+              logger.info(
+                `No properties JSON found for ${component.name}@${compVer.version}; disabling property tooltips`
+              )
+            }
+          }
+        }
+
+        if (isConnect) {
+          const newest = findNewestVersion(attachments, 'components', CONNECT_JSON_RX)
+          if (newest && !attributes['available-connect-version']) {
+            attributes['available-connect-version'] = newest
+            logger.info(
+              `Set available-connect-version=${newest} for ${component.name}@${compVer.version}`
+            )
+          }
+        }
+      })
+    })
+  })
+}
+
+function findNewestVersion (attachments, module, rx) {
+  let newestRaw = null
+  let newestSemver = null
+  attachments.forEach((attachment) => {
+    if (attachment.src.module !== module) return
+    const basename = attachment.src.relative.split('/').pop()
+    const match = basename.match(rx)
+    if (!match) return
+    const raw = match[1]
+    const parsed = semver.coerce(raw, { includePrerelease: true })
+    if (!parsed) return
+    if (!newestSemver || semver.gt(parsed, newestSemver)) {
+      newestSemver = parsed
+      newestRaw = raw
+    }
+  })
+  return newestRaw
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.3.4",
+      "version": "5.3.5",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
## Problem

The top 404s on docs.redpanda.com (~25k requests/day) are versioned JSON attachments that were never generated:

| Resource | Requests/day |
|---|---|
| `/streaming/current/reference/_attachments/redpanda-properties-v26.1.14.json` | 17,658 |
| `/connect/components/_attachments/connect-4.102.0.json` | 6,389 |
| `/streaming/{25.2,25.1,24.3}/reference/_attachments/redpanda-properties-*.json` | ~1,800 |

Root cause: the docs-ui `head-meta.hbs` partial builds `properties-json-url` / `connect-json-url` meta tags from release-tracking attributes (`latest-redpanda-tag`, `latest-connect-version`). Those follow the newest GitHub release, which drifts ahead of the newest generated JSON in the catalog. When `resolve-resource` fails, the template emits a constructed production fallback URL that is guaranteed to 404 — and the property-tooltip script retries it on every page view because failures are never cached. Property tooltips are currently silently broken on `streaming/current`, and the Bloblang tooltip data fetch 404-chains on every page.

The template already prefers `available-properties-tag` / `available-connect-version` (comments say "set by extension to highest version with JSON in catalog") — but that extension was never implemented. This PR implements it.

## What it does

On `contentClassified`, scans attachments and sets per component version (never overwriting values pinned in `antora.yml`):

- `available-properties-tag`: newest `redpanda-properties-<tag>.json` in the `reference` module of each streaming (`ROOT`) version
- `available-connect-version`: newest `connect-<version>.json` in the `components` module of the connect component
- `page-disable-property-tooltips: true` on streaming versions with no properties JSON at all (24.3/25.1/25.2), so tooltips stop fetching a URL that cannot exist

## Testing

- 8 new unit tests (`npx jest __tests__/extensions/set-available-attachment-versions.test.js`)
- Full extension suite passes (60 tests)

## Rollout

After release, register in the docs-site playbook:
```yaml
antora:
  extensions:
    - require: '@redpanda-data/docs-extensions-and-macros/extensions/set-available-attachment-versions'
```
Companion PRs: docs-ui negative caching (incoming), props v26.1.14 + connect 4.102.0 regeneration (already open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)