### PR TITLE
feat(rpk-docs): refresh a single plugin's docs with --plugin

### DIFF
--- a/CLI_REFERENCE.adoc
+++ b/CLI_REFERENCE.adoc
@@ -699,6 +699,9 @@ Refresh a single rpk plugin's docs (ai, connect, k8s, check). Requires --from-js
 `--plugin-version <version>`::
 Plugin version to install and record (for example, 4.102.0). Defaults to the latest published version.
 
+`--plugin-pin <name=version>`::
+Pin a plugin version for the installs during full generation (repeatable, for example --plugin-pin k8s=26.3.1-beta.1). Required for pre-GA plugins with no promoted latest version. (default: {})
+
 `--rpk-bin <path>`::
 Path to an existing rpk binary for the plugin refresh (skips download/build)
 

--- a/CLI_REFERENCE.adoc
+++ b/CLI_REFERENCE.adoc
@@ -490,6 +490,7 @@ display help for command
 * `migrate-rpcn-metadata` - One-time migration of inline connector == Metadata blocks into regenerated partials. Dry run unless --write is given.
 * `property-docs` - Generate JSON and consolidated AsciiDoc partials for Redpanda configuration properties. Defaults to branch "dev" if neither --tag nor --branch is specified.
 * `rpk-docs` - Generate rpk CLI documentation from source. Builds rpk and parses source for platform detection.
+* `rpk-plugin-stubs` - Reconcile single-source stub pages and nav against the docs repo's rpk plugin partials. Run from the consumer repo root.
 * `rpk-overrides` - Validate rpk-overrides.json against schema and check for common issues
 * `helm-spec` - Generate AsciiDoc documentation for Helm charts. Requires either --tag or --branch for GitHub URLs.
 * `cloud-regions` - Generate Markdown table of cloud regions and tiers from GitHub YAML file

--- a/CLI_REFERENCE.adoc
+++ b/CLI_REFERENCE.adoc
@@ -693,6 +693,15 @@ Path to local rpk source (src/go/rpk directory)
 `--from-json <path>`::
 Regenerate docs from an existing versioned JSON file (skips building)
 
+`--plugin <name>`::
+Refresh a single rpk plugin's docs (ai, connect, k8s, check). Requires --from-json. Installs the plugin, splices its fresh subtree into the snapshot, and re-renders.
+
+`--plugin-version <version>`::
+Plugin version to install and record (for example, 4.102.0). Defaults to the latest published version.
+
+`--rpk-bin <path>`::
+Path to an existing rpk binary for the plugin refresh (skips download/build)
+
 `--overrides <path>`::
 Path to overrides JSON file (default: "docs-data/rpk-overrides.json")
 

--- a/__tests__/tools/rpk-docs/generate-rpk-docs.test.js
+++ b/__tests__/tools/rpk-docs/generate-rpk-docs.test.js
@@ -239,6 +239,22 @@ describe('rpk Docs Generation', () => {
       expect(formatDescription(undefined)).toBe('')
     })
 
+    test('strips a dangling e.g. with nothing after it', () => {
+      // Upstream rpai help ends some flag descriptions mid-example; the
+      // e.g. transform would otherwise render "for example,."
+      const input = 'fields optionally suffixed with " desc" (default ascending), e.g.'
+      expect(formatDescription(input)).toBe('fields optionally suffixed with " desc" (default ascending)')
+    })
+
+    test('keeps e.g. transform when an example follows', () => {
+      expect(formatDescription('durations, e.g. 30s or 1.5m')).toBe('durations, for example, 30s or 1.5m')
+    })
+
+    test('removes stray space before a closing parenthesis', () => {
+      const input = 'topic:partition_id (repeatable; e.g. -t foo:0,1,2 )'
+      expect(formatDescription(input)).toBe('topic:partition_id (repeatable; for example, `-t` foo:0,1,2)')
+    })
+
     test('converts markdown-style dash lists to AsciiDoc asterisk lists', () => {
       const input = 'States:\n  - Active: The item is active.\n  - Inactive: The item is inactive.'
       const result = formatDescription(input)

--- a/__tests__/tools/rpk-docs/generate-rpk-docs.test.js
+++ b/__tests__/tools/rpk-docs/generate-rpk-docs.test.js
@@ -18,7 +18,8 @@ const {
   shouldUsePartialDir,
   updateNavFile,
   getOutputPath,
-  findTopLevelWithSubcommands
+  findTopLevelWithSubcommands,
+  generateRpkDocs
 } = require('../../../tools/rpk-docs/generate-rpk-docs.js')
 
 describe('rpk Docs Generation', () => {
@@ -947,5 +948,192 @@ Specify a time range.`
       expect(result.navUpdated).toBe(true)
       expect(result.navEntriesGenerated).toBe(3)
     })
+
+    test('preserves nav entries for protected plugins absent from the tree', () => {
+      const nav = [
+        '** xref:reference:rpk/index.adoc[rpk Commands]',
+        '*** xref:reference:rpk/rpk-connect/rpk-connect.adoc[]',
+        '**** xref:reference:rpk/rpk-connect/rpk-connect-run.adoc[]',
+        '*** xref:reference:rpk/rpk-topic/rpk-topic.adoc[]',
+        '** xref:reference:glossary.adoc[]',
+      ].join('\n')
+
+      const navPath = makeNav(nav)
+      // connect is entirely absent from this run's tree
+      const tree = makeTree(['rpk topic', 'rpk topic create'])
+      const commands = flattenCommands(tree)
+      const topLevel = findTopLevelWithSubcommands(tree)
+      updateNavFile(navPath, commands, {}, topLevel, ['connect'])
+
+      const written = fs.readFileSync(navPath, 'utf8')
+      expect(written).toContain('*** xref:reference:rpk/rpk-connect/rpk-connect.adoc[]')
+      expect(written).toContain('**** xref:reference:rpk/rpk-connect/rpk-connect-run.adoc[]')
+      expect(written).toContain('*** xref:reference:rpk/rpk-topic/rpk-topic.adoc[]')
+    })
+
+    test('does not duplicate preserved entries that also exist in regenerated output', () => {
+      const nav = [
+        '** xref:reference:rpk/index.adoc[rpk Commands]',
+        '*** xref:reference:rpk/rpk-connect/rpk-connect.adoc[]',
+        '**** xref:reference:rpk/rpk-connect/rpk-connect-run.adoc[]',
+        '** xref:reference:glossary.adoc[]',
+      ].join('\n')
+
+      const navPath = makeNav(nav)
+      // connect IS in this run's tree, so its entries are regenerated; the
+      // protected-plugin preservation must not append them a second time.
+      const tree = makeTree(['rpk connect', 'rpk connect run', 'rpk topic', 'rpk topic create'])
+      const commands = flattenCommands(tree)
+      const topLevel = findTopLevelWithSubcommands(tree)
+      updateNavFile(navPath, commands, {}, topLevel, ['connect'])
+
+      const written = fs.readFileSync(navPath, 'utf8')
+      const count = (needle) => written.split('\n').filter(l => l.includes(needle)).length
+      expect(count('rpk-connect/rpk-connect.adoc')).toBe(1)
+      expect(count('rpk-connect/rpk-connect-run.adoc')).toBe(1)
+      expect(count('rpk-topic/rpk-topic.adoc')).toBe(1)
+    })
+
+    test('protected-plugin preservation is idempotent across runs', () => {
+      const nav = [
+        '** xref:reference:rpk/index.adoc[rpk Commands]',
+        '*** xref:reference:rpk/rpk-connect/rpk-connect.adoc[]',
+        '** xref:reference:glossary.adoc[]',
+      ].join('\n')
+
+      const navPath = makeNav(nav)
+      const tree = makeTree(['rpk topic', 'rpk topic create'])
+      const commands = flattenCommands(tree)
+      const topLevel = findTopLevelWithSubcommands(tree)
+
+      updateNavFile(navPath, commands, {}, topLevel, ['connect'])
+      const firstRun = fs.readFileSync(navPath, 'utf8')
+      updateNavFile(navPath, commands, {}, topLevel, ['connect'])
+      const secondRun = fs.readFileSync(navPath, 'utf8')
+
+      expect(firstRun).toBe(secondRun)
+      expect(firstRun.split('\n').filter(l => l.includes('rpk-connect/rpk-connect.adoc')).length).toBe(1)
+    })
+  })
+
+  describe('stale file cleanup with protected plugins', () => {
+    let tmpDir
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rpk-cleanup-test-'))
+    })
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    const writePage = (...segments) => {
+      const filePath = path.join(tmpDir, ...segments)
+      fs.mkdirSync(path.dirname(filePath), { recursive: true })
+      fs.writeFileSync(filePath, '= Existing page\n', 'utf8')
+      return filePath
+    }
+
+    const cmd = (name, extra = {}) => ({
+      name,
+      description: `${name} command.`,
+      usage: `rpk ${name} [flags]`,
+      flags: [],
+      ...extra
+    })
+
+    test('pages under a protected plugin dir survive the sweep while a stale non-plugin page is deleted', async () => {
+      // Pre-existing pages from an earlier run where the connect plugin
+      // installed successfully and rpk topic had a "describe" subcommand.
+      const connectRoot = writePage('rpk-connect', 'rpk-connect.adoc')
+      const connectRun = writePage('rpk-connect', 'rpk-connect-run.adoc')
+      const staleTopic = writePage('rpk-topic', 'rpk-topic-describe.adoc')
+
+      // This run's tree: connect is entirely absent (failed plugin install),
+      // and rpk topic no longer has "describe".
+      const tree = {
+        name: 'rpk',
+        description: 'Root command',
+        commands: [
+          cmd('topic', { commands: [cmd('create')] })
+        ],
+        global_flags: []
+      }
+
+      const result = await generateRpkDocs({
+        tree,
+        outputDir: tmpDir,
+        rpkVersion: 'test',
+        pluginVersions: {}
+      })
+
+      // Protected plugin pages must survive: connect is a known plugin whose
+      // subtree is absent from this run's tree.
+      expect(fs.existsSync(connectRoot)).toBe(true)
+      expect(fs.existsSync(connectRun)).toBe(true)
+
+      // The genuinely stale non-plugin page must be swept.
+      expect(fs.existsSync(staleTopic)).toBe(false)
+      expect(result.filesDeleted).toBe(1)
+
+      // Regenerated pages exist as usual.
+      expect(fs.existsSync(path.join(tmpDir, 'rpk-topic', 'rpk-topic.adoc'))).toBe(true)
+      expect(fs.existsSync(path.join(tmpDir, 'rpk-topic', 'rpk-topic-create.adoc'))).toBe(true)
+    }, 30000)
+
+    test('shim-only plugin subtree still protects the plugin dir', async () => {
+      // Page from an earlier run where the plugin binary was installed.
+      const connectRun = writePage('rpk-connect', 'rpk-connect-run.adoc')
+
+      // This run's tree has the connect shim (install/uninstall/upgrade)
+      // but none of the real plugin commands: the plugin failed to install.
+      const tree = {
+        name: 'rpk',
+        description: 'Root command',
+        commands: [
+          cmd('connect', { commands: [cmd('install'), cmd('uninstall'), cmd('upgrade')] }),
+          cmd('topic', { commands: [cmd('create')] })
+        ],
+        global_flags: []
+      }
+
+      const result = await generateRpkDocs({
+        tree,
+        outputDir: tmpDir,
+        rpkVersion: 'test',
+        pluginVersions: {}
+      })
+
+      // The shim-only subtree marks connect as auto-protected, so the page
+      // written by the earlier (successful) run is not treated as stale.
+      expect(fs.existsSync(connectRun)).toBe(true)
+      expect(result.filesDeleted).toBe(0)
+    }, 30000)
+
+    test('explicitly protected plugins are honored alongside auto-protection', async () => {
+      const aiPage = writePage('rpk-ai', 'rpk-ai-agent.adoc')
+      const stale = writePage('rpk-cluster', 'rpk-cluster-old.adoc')
+
+      const tree = {
+        name: 'rpk',
+        description: 'Root command',
+        commands: [
+          cmd('cluster', { commands: [cmd('health')] })
+        ],
+        global_flags: []
+      }
+
+      const result = await generateRpkDocs({
+        tree,
+        outputDir: tmpDir,
+        rpkVersion: 'test',
+        pluginVersions: {},
+        protectedPlugins: ['ai']
+      })
+
+      expect(fs.existsSync(aiPage)).toBe(true)
+      expect(fs.existsSync(stale)).toBe(false)
+      expect(result.filesDeleted).toBe(1)
+    }, 30000)
   })
 })

--- a/__tests__/tools/rpk-docs/generate-rpk-docs.test.js
+++ b/__tests__/tools/rpk-docs/generate-rpk-docs.test.js
@@ -1325,3 +1325,23 @@ describe('capToTwoSentences with code blocks', () => {
     expect(capToTwoSentences(input)).toBe('Reports progress. Use --detailed for more.')
   })
 })
+
+describe('placeholder brace escaping', () => {
+  const { formatDescription } = require('../../../tools/rpk-docs/generate-rpk-docs.js')
+
+  test('escapes template placeholders so Asciidoctor keeps them', () => {
+    const input = 'Enable code mode: adds {name}_search and {name}_execute tools.'
+    const out = formatDescription(input)
+    expect(out).toContain('\\{name}_search')
+    expect(out).toContain('\\{name}_execute')
+  })
+
+  test('leaves a bare vbar attribute in prose alone', () => {
+    // {vbar} in prose is a real attribute (pipe escaping); placeholders in
+    // backtick spans were already escaped by the span-protection step
+    const input = 'Format: `table{vbar}json` uses {vbar} in prose.'
+    const out = formatDescription(input)
+    expect(out).toContain('uses {vbar} in prose')
+    expect(out).toContain('`table\\{vbar}json`')
+  })
+})

--- a/__tests__/tools/rpk-docs/generate-rpk-docs.test.js
+++ b/__tests__/tools/rpk-docs/generate-rpk-docs.test.js
@@ -1310,3 +1310,18 @@ Specify a time range.`
     }, 30000)
   })
 })
+
+describe('capToTwoSentences with code blocks', () => {
+  const { capToTwoSentences } = require('../../../tools/rpk-docs/generate-rpk-docs.js')
+
+  test('ends the summary at a colon that introduces a code block', () => {
+    const input = 'Prints a config according to an expression. The expression takes three lists, divided by slashes:\n\n[,text]\n----\nredpanda-connect create stdin/bloblang,awk/nats\n----\n\nIf omitted a default config is created.'
+    // The block and its dangling colon introducer are both dropped
+    expect(capToTwoSentences(input)).toBe('Prints a config according to an expression.')
+  })
+
+  test('drops a mid-prose block and keeps surrounding sentences', () => {
+    const input = 'Reports progress.\n\n[,bash]\n----\nrpk thing status 4\n----\n\nUse --detailed for more.'
+    expect(capToTwoSentences(input)).toBe('Reports progress. Use --detailed for more.')
+  })
+})

--- a/__tests__/tools/rpk-docs/generate-rpk-docs.test.js
+++ b/__tests__/tools/rpk-docs/generate-rpk-docs.test.js
@@ -980,8 +980,9 @@ Specify a time range.`
       ].join('\n')
 
       const navPath = makeNav(nav)
-      // connect IS in this run's tree, so its entries are regenerated; the
-      // protected-plugin preservation must not append them a second time.
+      // connect IS in this run's tree, but protection wins: no connect
+      // entries are generated, and the previous nav block is preserved in
+      // place exactly once — never regenerated AND preserved.
       const tree = makeTree(['rpk connect', 'rpk connect run', 'rpk topic', 'rpk topic create'])
       const commands = flattenCommands(tree)
       const topLevel = findTopLevelWithSubcommands(tree)
@@ -1013,6 +1014,75 @@ Specify a time range.`
 
       expect(firstRun).toBe(secondRun)
       expect(firstRun.split('\n').filter(l => l.includes('rpk-connect/rpk-connect.adoc')).length).toBe(1)
+    })
+
+    test('splices preserved plugin entries in place under the plugin parent, not at the end', () => {
+      // Realistic pre-GA shim scenario: the previous nav has the full k8s
+      // block; this run's tree has only the k8s shim.
+      const nav = [
+        '** xref:reference:rpk/index.adoc[rpk Commands]',
+        '*** xref:reference:rpk/rpk-commands.adoc[]',
+        '*** xref:reference:rpk/rpk-x-options.adoc[rpk -X]',
+        '*** xref:reference:rpk/rpk-iotune.adoc[]',
+        '*** xref:reference:rpk/rpk-k8s/rpk-k8s.adoc[]',
+        '**** xref:reference:rpk/rpk-k8s/rpk-k8s-install.adoc[]',
+        '**** xref:reference:rpk/rpk-k8s/rpk-k8s-multicluster.adoc[]',
+        '***** xref:reference:rpk/rpk-k8s/rpk-k8s-multicluster-bootstrap.adoc[]',
+        '**** xref:reference:rpk/rpk-k8s/rpk-k8s-uninstall.adoc[]',
+        '*** xref:reference:rpk/rpk-version.adoc[]',
+        '** xref:reference:glossary.adoc[]',
+      ].join('\n')
+
+      const navPath = makeNav(nav)
+      const tree = makeTree([
+        'rpk iotune',
+        'rpk k8s', 'rpk k8s install', 'rpk k8s uninstall', 'rpk k8s upgrade',
+        'rpk version'
+      ])
+      const commands = flattenCommands(tree)
+      const topLevel = findTopLevelWithSubcommands(tree)
+      updateNavFile(navPath, commands, {}, topLevel, ['k8s'])
+
+      const written = fs.readFileSync(navPath, 'utf8')
+      const outLines = written.split('\n')
+      const idx = (needle) => outLines.findIndex(l => l.includes(needle))
+
+      // The whole k8s block stays together, in its original position:
+      // directly after rpk-iotune, parent first, children nested under it,
+      // and rpk-version still follows the block — nothing lands at the end.
+      const parentIdx = idx('rpk-k8s/rpk-k8s.adoc')
+      expect(parentIdx).toBe(idx('rpk-iotune.adoc') + 1)
+      expect(idx('rpk-k8s-install.adoc')).toBe(parentIdx + 1)
+      expect(idx('rpk-k8s-multicluster.adoc')).toBe(parentIdx + 2)
+      expect(idx('rpk-k8s-multicluster-bootstrap.adoc')).toBe(parentIdx + 3)
+      expect(idx('rpk-k8s-uninstall.adoc')).toBe(parentIdx + 4)
+      expect(idx('rpk-version.adoc')).toBe(parentIdx + 5)
+
+      // In this scenario the rebuilt nav is byte-identical to the input.
+      expect(written).toBe(nav)
+    })
+
+    test('keeps a fully absent plugin block in its original position', () => {
+      const nav = [
+        '** xref:reference:rpk/index.adoc[rpk Commands]',
+        '*** xref:reference:rpk/rpk-commands.adoc[]',
+        '*** xref:reference:rpk/rpk-x-options.adoc[rpk -X]',
+        '*** xref:reference:rpk/rpk-connect/rpk-connect.adoc[]',
+        '**** xref:reference:rpk/rpk-connect/rpk-connect-run.adoc[]',
+        '*** xref:reference:rpk/rpk-topic/rpk-topic.adoc[]',
+        '**** xref:reference:rpk/rpk-topic/rpk-topic-create.adoc[]',
+        '** xref:reference:glossary.adoc[]',
+      ].join('\n')
+
+      const navPath = makeNav(nav)
+      // connect is entirely absent from this run's tree
+      const tree = makeTree(['rpk topic', 'rpk topic create'])
+      const commands = flattenCommands(tree)
+      const topLevel = findTopLevelWithSubcommands(tree)
+      updateNavFile(navPath, commands, {}, topLevel, ['connect'])
+
+      const written = fs.readFileSync(navPath, 'utf8')
+      expect(written).toBe(nav)
     })
   })
 
@@ -1132,6 +1202,87 @@ Specify a time range.`
       })
 
       expect(fs.existsSync(aiPage)).toBe(true)
+      expect(fs.existsSync(stale)).toBe(false)
+      expect(result.filesDeleted).toBe(1)
+    }, 30000)
+
+    test('shim-only plugin pages are not rewritten — parent page content stays untouched', async () => {
+      // Pages from an earlier run where the connect plugin was installed:
+      // the parent page documents the full plugin (including `run` in its
+      // Subcommands table) and a child page exists for the real command.
+      const parentContent = '= rpk connect\n\nFull plugin page with run subcommand.\n'
+      const parent = path.join(tmpDir, 'rpk-connect', 'rpk-connect.adoc')
+      fs.mkdirSync(path.dirname(parent), { recursive: true })
+      fs.writeFileSync(parent, parentContent, 'utf8')
+      const childRun = writePage('rpk-connect', 'rpk-connect-run.adoc')
+      const childContent = fs.readFileSync(childRun, 'utf8')
+
+      // This run's tree has only the connect shim.
+      const tree = {
+        name: 'rpk',
+        description: 'Root command',
+        commands: [
+          cmd('connect', { commands: [cmd('install'), cmd('uninstall'), cmd('upgrade')] }),
+          cmd('topic', { commands: [cmd('create')] })
+        ],
+        global_flags: []
+      }
+
+      await generateRpkDocs({
+        tree,
+        outputDir: tmpDir,
+        rpkVersion: 'test',
+        pluginVersions: {}
+      })
+
+      // The parent page must not be regenerated with shim-only content, and
+      // the child page must not become an orphan or change.
+      expect(fs.readFileSync(parent, 'utf8')).toBe(parentContent)
+      expect(fs.readFileSync(childRun, 'utf8')).toBe(childContent)
+
+      // No shim pages are written under the protected subtree.
+      expect(fs.existsSync(path.join(tmpDir, 'rpk-connect', 'rpk-connect-install.adoc'))).toBe(false)
+      expect(fs.existsSync(path.join(tmpDir, 'rpk-connect', 'rpk-connect-uninstall.adoc'))).toBe(false)
+      expect(fs.existsSync(path.join(tmpDir, 'rpk-connect', 'rpk-connect-upgrade.adoc'))).toBe(false)
+
+      // Non-plugin pages regenerate as usual.
+      expect(fs.existsSync(path.join(tmpDir, 'rpk-topic', 'rpk-topic.adoc'))).toBe(true)
+      expect(fs.existsSync(path.join(tmpDir, 'rpk-topic', 'rpk-topic-create.adoc'))).toBe(true)
+    }, 30000)
+
+    test('fully installed plugin regenerates pages and sweeps its stale files as usual', async () => {
+      // Previous run left a page for a subcommand that no longer exists.
+      const stale = writePage('rpk-connect', 'rpk-connect-removed.adoc')
+      const parent = path.join(tmpDir, 'rpk-connect', 'rpk-connect.adoc')
+      fs.writeFileSync(parent, '= Old parent page\n', 'utf8')
+
+      // This run's tree has the real plugin commands (beyond the shim), so
+      // connect is NOT protected and generation proceeds normally.
+      const tree = {
+        name: 'rpk',
+        description: 'Root command',
+        commands: [
+          cmd('connect', {
+            commands: [cmd('install'), cmd('uninstall'), cmd('upgrade'), cmd('run')]
+          })
+        ],
+        global_flags: []
+      }
+
+      const result = await generateRpkDocs({
+        tree,
+        outputDir: tmpDir,
+        rpkVersion: 'test',
+        pluginVersions: {}
+      })
+
+      // Parent page is regenerated (content replaced) and the real
+      // subcommand page is written.
+      expect(fs.readFileSync(parent, 'utf8')).not.toBe('= Old parent page\n')
+      expect(fs.readFileSync(parent, 'utf8')).toContain('rpk connect')
+      expect(fs.existsSync(path.join(tmpDir, 'rpk-connect', 'rpk-connect-run.adoc'))).toBe(true)
+
+      // The genuinely stale page is swept.
       expect(fs.existsSync(stale)).toBe(false)
       expect(result.filesDeleted).toBe(1)
     }, 30000)

--- a/__tests__/tools/rpk-docs/generate-rpk-docs.test.js
+++ b/__tests__/tools/rpk-docs/generate-rpk-docs.test.js
@@ -803,6 +803,7 @@ Specify a time range.`
       const nav = [
         '* xref:get-started:index.adoc[]',
         '** xref:reference:rpk/index.adoc[rpk Commands]',
+        '*** xref:reference:rpk/rpk.adoc[]',
         '*** xref:reference:rpk/rpk-commands.adoc[]',
         '*** xref:reference:rpk/rpk-x-options.adoc[rpk -X]',
         '*** xref:reference:rpk/rpk-topic/rpk-topic.adoc[]',
@@ -820,9 +821,12 @@ Specify a time range.`
       expect(written).toContain('** xref:reference:rpk/index.adoc[rpk Commands]')
       expect(written).toContain('*** xref:reference:rpk/rpk-commands.adoc[]')
       expect(written).toContain('*** xref:reference:rpk/rpk-x-options.adoc[rpk -X]')
-      // The root rpk command is represented by the hand-written index.adoc
-      // landing page; it must not get its own generated rpk.adoc nav entry.
-      expect(written).not.toContain('xref:reference:rpk/rpk.adoc[]')
+      // The generated root rpk.adoc page is listed ahead of the hand-written
+      // entries; without it Antora reports the page as unlisted.
+      const lines = written.split('\n')
+      const rootIdx = lines.indexOf('*** xref:reference:rpk/rpk.adoc[]')
+      expect(rootIdx).toBeGreaterThan(-1)
+      expect(rootIdx).toBeLessThan(lines.indexOf('*** xref:reference:rpk/rpk-commands.adoc[]'))
     })
 
     test('generates entries at correct nesting depths', () => {
@@ -1037,6 +1041,7 @@ Specify a time range.`
       // block; this run's tree has only the k8s shim.
       const nav = [
         '** xref:reference:rpk/index.adoc[rpk Commands]',
+        '*** xref:reference:rpk/rpk.adoc[]',
         '*** xref:reference:rpk/rpk-commands.adoc[]',
         '*** xref:reference:rpk/rpk-x-options.adoc[rpk -X]',
         '*** xref:reference:rpk/rpk-iotune.adoc[]',
@@ -1081,6 +1086,7 @@ Specify a time range.`
     test('keeps a fully absent plugin block in its original position', () => {
       const nav = [
         '** xref:reference:rpk/index.adoc[rpk Commands]',
+        '*** xref:reference:rpk/rpk.adoc[]',
         '*** xref:reference:rpk/rpk-commands.adoc[]',
         '*** xref:reference:rpk/rpk-x-options.adoc[rpk -X]',
         '*** xref:reference:rpk/rpk-connect/rpk-connect.adoc[]',

--- a/__tests__/tools/rpk-docs/plugin-flags.test.js
+++ b/__tests__/tools/rpk-docs/plugin-flags.test.js
@@ -144,3 +144,37 @@ describe('mergeVisibleDeprecationsIntoOverrides', () => {
     expect(fs.readFileSync(overridesPath, 'utf8')).toBe(before)
   })
 })
+
+describe('parseUrfaveFlags (Redpanda Connect help format)', () => {
+  const { parseUrfaveFlags, parseHelpFlags } = require('../../../tools/rpk-docs/rpk-docs-handler.js')
+
+  const HELP = [
+    'NAME:',
+    '   redpanda-connect run - Run',
+    '',
+    'OPTIONS:',
+    '   --log.level value                     override the log level',
+    '   --set value, -s value [ --set value, -s value ]   set a field',
+    '   --chilled                             continue on lint errors (default: false)',
+    '   --watcher, -w                         watch config files (default: false)',
+    '',
+    'GLOBAL OPTIONS:',
+    '   --verbose   noisy'
+  ].join('\n')
+
+  test('parses names, shorthands, types, and defaults', () => {
+    const flags = parseUrfaveFlags(HELP)
+    const byName = Object.fromEntries(flags.map(f => [f.name, f]))
+    expect(byName['log.level']).toMatchObject({ type: 'string' })
+    expect(byName['set']).toMatchObject({ shorthand: 's', type: 'strings' })
+    expect(byName['chilled']).toMatchObject({ type: 'bool', default: 'false' })
+    expect(byName['watcher']).toMatchObject({ shorthand: 'w', type: 'bool' })
+    expect(flags.map(f => f.name)).not.toContain('verbose')
+  })
+
+  test('parseHelpFlags dispatches by section header', () => {
+    expect(parseHelpFlags(HELP).length).toBe(4)
+    expect(parseHelpFlags('Flags:\n      --no-browser   print URL\n').length).toBe(1)
+    expect(parseHelpFlags('Usage: nothing here')).toEqual([])
+  })
+})

--- a/__tests__/tools/rpk-docs/plugin-flags.test.js
+++ b/__tests__/tools/rpk-docs/plugin-flags.test.js
@@ -85,3 +85,62 @@ describe('enrichPluginTreeWithFlags', () => {
     expect(node.commands[0].flags).toBeUndefined()
   })
 })
+
+describe('mergeVisibleDeprecationsIntoOverrides', () => {
+  const fs = require('fs')
+  const path = require('path')
+  const os = require('os')
+  const { mergeVisibleDeprecationsIntoOverrides } = require('../../../tools/rpk-docs/rpk-docs-handler.js')
+
+  const tree = {
+    name: 'rpk',
+    commands: [
+      { name: 'oldcmd', commands: [] },
+      { name: 'topic', commands: [] }
+    ]
+  }
+
+  let dir, overridesPath
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dep-merge-'))
+    overridesPath = path.join(dir, 'overrides.json')
+  })
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+  test('annotates visible deprecated commands, skips hidden ones', () => {
+    fs.writeFileSync(overridesPath, JSON.stringify({ commands: {} }))
+    mergeVisibleDeprecationsIntoOverrides({
+      'rpk oldcmd': { deprecated: true, deprecatedMessage: 'use rpk newcmd', replacement: 'See `rpk newcmd`.' },
+      'rpk hiddencmd': { deprecated: true, _note: 'Hidden: true' }
+    }, tree, overridesPath)
+
+    const result = JSON.parse(fs.readFileSync(overridesPath, 'utf8'))
+    expect(result.commands['rpk oldcmd']).toMatchObject({
+      deprecated: true,
+      deprecatedMessage: 'use rpk newcmd',
+      replacement: 'See `rpk newcmd`.'
+    })
+    // hiddencmd is not in the tree: no page to annotate
+    expect(result.commands['rpk hiddencmd']).toBeUndefined()
+  })
+
+  test('never overwrites curated deprecation overrides', () => {
+    fs.writeFileSync(overridesPath, JSON.stringify({
+      commands: { 'rpk oldcmd': { deprecated: false, deprecatedMessage: 'curated text' } }
+    }))
+    mergeVisibleDeprecationsIntoOverrides({
+      'rpk oldcmd': { deprecated: true, deprecatedMessage: 'scanner text' }
+    }, tree, overridesPath)
+
+    const result = JSON.parse(fs.readFileSync(overridesPath, 'utf8'))
+    expect(result.commands['rpk oldcmd'].deprecated).toBe(false)
+    expect(result.commands['rpk oldcmd'].deprecatedMessage).toBe('curated text')
+  })
+
+  test('no-op when nothing to annotate', () => {
+    fs.writeFileSync(overridesPath, JSON.stringify({ commands: {} }))
+    const before = fs.readFileSync(overridesPath, 'utf8')
+    mergeVisibleDeprecationsIntoOverrides({}, tree, overridesPath)
+    expect(fs.readFileSync(overridesPath, 'utf8')).toBe(before)
+  })
+})

--- a/__tests__/tools/rpk-docs/plugin-flags.test.js
+++ b/__tests__/tools/rpk-docs/plugin-flags.test.js
@@ -1,0 +1,87 @@
+'use strict'
+
+const { parseCobraFlags, enrichPluginTreeWithFlags } = require('../../../tools/rpk-docs/rpk-docs-handler.js')
+
+describe('parseCobraFlags', () => {
+  const HELP = [
+    'Reconcile LLM providers from one or more YAML manifests.',
+    '',
+    'Usage:',
+    '  rpk ai llm-provider apply [flags]',
+    '',
+    'Flags:',
+    '      --allow-empty            Allow applying zero manifests',
+    '  -f, --file strings           Manifest paths, - for stdin (default [])',
+    '  -h, --help                   help for apply',
+    '      --timeout duration       How long to wait for the reconcile to',
+    '                               complete before giving up (default 30s)',
+    '  -o, --format string          Output format (default "text")',
+    '',
+    'Global Flags:',
+    '  -c, --config string   rpk config file',
+    '  -v, --verbose         enable verbose logging',
+    '',
+    'Use "rpk ai llm-provider apply [command] --help" for more information.'
+  ].join('\n')
+
+  test('parses local flags with shorthand, type, and default', () => {
+    const flags = parseCobraFlags(HELP)
+    const byName = Object.fromEntries(flags.map(f => [f.name, f]))
+
+    expect(byName['allow-empty']).toMatchObject({ type: 'bool' })
+    expect(byName['file']).toMatchObject({ shorthand: 'f', type: 'strings', default: '[]' })
+    expect(byName['format']).toMatchObject({ shorthand: 'o', type: 'string', default: '"text"' })
+  })
+
+  test('joins wrapped descriptions and extracts trailing defaults', () => {
+    const flags = parseCobraFlags(HELP)
+    const timeout = flags.find(f => f.name === 'timeout')
+    expect(timeout.description).toBe('How long to wait for the reconcile to complete before giving up')
+    expect(timeout.default).toBe('30s')
+  })
+
+  test('skips --help and the Global Flags section', () => {
+    const flags = parseCobraFlags(HELP)
+    expect(flags.map(f => f.name)).not.toContain('help')
+    expect(flags.map(f => f.name)).not.toContain('config')
+    expect(flags.map(f => f.name)).not.toContain('verbose')
+  })
+
+  test('returns empty for help without a Flags section', () => {
+    expect(parseCobraFlags('Usage:\n  rpk ai\n\nUse "rpk ai --help".')).toEqual([])
+    expect(parseCobraFlags('')).toEqual([])
+  })
+})
+
+describe('enrichPluginTreeWithFlags', () => {
+  test('fills flagless commands and leaves shim flags alone', () => {
+    const node = {
+      name: 'ai',
+      commands: [
+        { name: 'install', flags: [{ name: 'ai-version', type: 'string' }], commands: [] },
+        { name: 'auth', commands: [{ name: 'login', commands: [] }] }
+      ]
+    }
+    const calls = []
+    const enriched = enrichPluginTreeWithFlags(node, (argPath) => {
+      calls.push(argPath.join(' '))
+      return 'Flags:\n      --no-browser   Print the URL instead of opening it\n'
+    })
+
+    // install already has flags: not queried
+    expect(calls).not.toContain('ai install')
+    expect(calls).toContain('ai auth login')
+    const login = node.commands[1].commands[0]
+    expect(login.flags).toHaveLength(1)
+    expect(login.flags[0]).toMatchObject({ name: 'no-browser', type: 'bool' })
+    expect(node.commands[0].flags[0].name).toBe('ai-version')
+    expect(enriched).toBeGreaterThanOrEqual(2) // root + auth + login minus empties
+  })
+
+  test('help failures are non-fatal', () => {
+    const node = { name: 'ai', commands: [{ name: 'run', commands: [] }] }
+    const enriched = enrichPluginTreeWithFlags(node, () => null)
+    expect(enriched).toBe(0)
+    expect(node.commands[0].flags).toBeUndefined()
+  })
+})

--- a/__tests__/tools/rpk-docs/plugin-refresh.test.js
+++ b/__tests__/tools/rpk-docs/plugin-refresh.test.js
@@ -1,0 +1,96 @@
+'use strict'
+
+const {
+  splicePluginNode,
+  pluginNodeHasRealCommands,
+  REFRESHABLE_PLUGINS,
+  PLUGIN_INSTALL_VERSION_FLAGS,
+  PLUGIN_MANIFEST_SLUGS
+} = require('../../../tools/rpk-docs/rpk-docs-handler.js')
+
+describe('Plugin refresh (--plugin mode)', () => {
+  const shimOnlyNode = {
+    name: 'k8s',
+    description: 'Kubernetes plugin',
+    commands: [
+      { name: 'install' },
+      { name: 'uninstall' },
+      { name: 'upgrade' }
+    ]
+  }
+
+  const installedNode = {
+    name: 'connect',
+    description: 'Redpanda Connect plugin',
+    commands: [
+      { name: 'install' },
+      { name: 'uninstall' },
+      { name: 'upgrade' },
+      { name: 'run', description: 'Run a pipeline' },
+      { name: 'lint', description: 'Lint a config' }
+    ]
+  }
+
+  const baseTree = {
+    name: 'rpk',
+    global_flags: [{ name: '--config' }],
+    commands: [
+      { name: 'topic', commands: [{ name: 'create' }] },
+      { name: 'connect', commands: [{ name: 'install' }, { name: 'run', description: 'old run' }] },
+      { name: 'cluster', commands: [{ name: 'health' }] }
+    ]
+  }
+
+  describe('pluginNodeHasRealCommands', () => {
+    test('false for a shim-only node (install/uninstall/upgrade)', () => {
+      expect(pluginNodeHasRealCommands(shimOnlyNode)).toBe(false)
+    })
+
+    test('true when real plugin commands are present', () => {
+      expect(pluginNodeHasRealCommands(installedNode)).toBe(true)
+    })
+
+    test('false for a node with no subcommands', () => {
+      expect(pluginNodeHasRealCommands({ name: 'ai' })).toBe(false)
+    })
+  })
+
+  describe('splicePluginNode', () => {
+    test('replaces the plugin node and keeps everything else', () => {
+      const result = splicePluginNode(baseTree, 'connect', installedNode)
+
+      expect(result.commands.map(c => c.name)).toEqual(['topic', 'connect', 'cluster'])
+      const connect = result.commands.find(c => c.name === 'connect')
+      expect(connect.commands.map(c => c.name)).toContain('lint')
+      expect(result.commands.find(c => c.name === 'topic')).toBe(baseTree.commands[0])
+      expect(result.global_flags).toEqual(baseTree.global_flags)
+    })
+
+    test('does not mutate the input tree', () => {
+      splicePluginNode(baseTree, 'connect', installedNode)
+      const connect = baseTree.commands.find(c => c.name === 'connect')
+      expect(connect.commands.find(c => c.name === 'run').description).toBe('old run')
+    })
+
+    test('throws when the plugin is not in the base tree', () => {
+      expect(() => splicePluginNode(baseTree, 'k8s', shimOnlyNode))
+        .toThrow(/not present in the base tree/)
+    })
+  })
+
+  describe('plugin constants', () => {
+    test('every refreshable plugin has a version pin flag', () => {
+      for (const plugin of REFRESHABLE_PLUGINS) {
+        expect(PLUGIN_INSTALL_VERSION_FLAGS[plugin]).toMatch(/^--[a-z-]+$/)
+      }
+    })
+
+    test('oxla is not refreshable (stub with no installable binary)', () => {
+      expect(REFRESHABLE_PLUGINS).not.toContain('oxla')
+    })
+
+    test('ai maps to the rpai manifest slug', () => {
+      expect(PLUGIN_MANIFEST_SLUGS.ai).toBe('rpai')
+    })
+  })
+})

--- a/__tests__/tools/rpk-docs/plugin-refresh.test.js
+++ b/__tests__/tools/rpk-docs/plugin-refresh.test.js
@@ -2,6 +2,7 @@
 
 const {
   splicePluginNode,
+  preserveLinuxOnlyCommands,
   pluginNodeHasRealCommands,
   REFRESHABLE_PLUGINS,
   PLUGIN_INSTALL_VERSION_FLAGS,
@@ -75,6 +76,63 @@ describe('Plugin refresh (--plugin mode)', () => {
     test('throws when the plugin is not in the base tree', () => {
       expect(() => splicePluginNode(baseTree, 'k8s', shimOnlyNode))
         .toThrow(/not present in the base tree/)
+    })
+
+    test('keeps the tree linux_only_commands list through a splice', () => {
+      const treeWithMarkers = { ...baseTree, linux_only_commands: ['rpk debug bundle', 'rpk iotune'] }
+      const result = splicePluginNode(treeWithMarkers, 'connect', installedNode)
+      expect(result.linux_only_commands).toEqual(['rpk debug bundle', 'rpk iotune'])
+    })
+  })
+
+  describe('preserveLinuxOnlyCommands', () => {
+    const linuxOnly = ['rpk debug bundle', 'rpk iotune']
+
+    test('inherits the snapshot list when the working tree lacks it', () => {
+      const result = preserveLinuxOnlyCommands(baseTree, { ...baseTree, linux_only_commands: linuxOnly })
+      expect(result.linux_only_commands).toEqual(linuxOnly)
+      // Copies, not aliases: mutating the result must not touch the snapshot
+      expect(result.linux_only_commands).not.toBe(linuxOnly)
+      expect(result.commands).toBe(baseTree.commands)
+    })
+
+    test('keeps the working tree list when it already has one', () => {
+      const tree = { ...baseTree, linux_only_commands: linuxOnly }
+      const result = preserveLinuxOnlyCommands(tree, { ...baseTree, linux_only_commands: ['rpk other'] })
+      expect(result).toBe(tree)
+      expect(result.linux_only_commands).toEqual(linuxOnly)
+    })
+
+    test('is a no-op when neither tree carries the list', () => {
+      expect(preserveLinuxOnlyCommands(baseTree, baseTree)).toBe(baseTree)
+      expect(preserveLinuxOnlyCommands(baseTree, undefined)).toBe(baseTree)
+      expect(preserveLinuxOnlyCommands(null, baseTree)).toBe(null)
+    })
+
+    test('refresh persistence chain keeps markers for the saved snapshot', () => {
+      // Mirrors the --plugin save path: derive the working tree from the
+      // snapshot, splice the fresh subtree, then preserve before persisting.
+      const snapshot = {
+        raw_tree: { ...baseTree, linux_only_commands: linuxOnly },
+        tree: { ...baseTree, linux_only_commands: linuxOnly }
+      }
+      let tree = snapshot.raw_tree || snapshot.tree
+      tree = preserveLinuxOnlyCommands(tree, snapshot.tree || snapshot.raw_tree)
+      tree = splicePluginNode(tree, 'connect', installedNode)
+      tree = preserveLinuxOnlyCommands(tree, snapshot.raw_tree || snapshot.tree)
+      expect(tree.linux_only_commands).toEqual(linuxOnly)
+    })
+
+    test('refresh persistence chain restores markers when only the enhanced tree has them', () => {
+      // Older snapshots may carry the field on only one stored tree; the
+      // derivation step must inherit it so the re-saved snapshot keeps it.
+      const snapshot = {
+        raw_tree: { ...baseTree },
+        tree: { ...baseTree, linux_only_commands: linuxOnly }
+      }
+      let tree = snapshot.raw_tree || snapshot.tree
+      tree = preserveLinuxOnlyCommands(tree, snapshot.tree || snapshot.raw_tree)
+      expect(tree.linux_only_commands).toEqual(linuxOnly)
     })
   })
 

--- a/__tests__/tools/rpk-docs/plugin-stubs.test.js
+++ b/__tests__/tools/rpk-docs/plugin-stubs.test.js
@@ -1,0 +1,133 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+
+const {
+  readPartialTitles,
+  inferIncludePrefix,
+  renderStub,
+  reconcileStubs
+} = require('../../../tools/rpk-docs/generate-plugin-stubs.js')
+
+describe('plugin stub reconciler', () => {
+  let dir, partialsDir, stubDir, navFile
+
+  const writePartial = (file, title) => {
+    fs.writeFileSync(path.join(partialsDir, file), `= ${title}\n:description: x\n\n// tag::single-source[]\nBody.\n// end::single-source[]\n`)
+  }
+
+  const writeStub = (file, title, partialFile) => {
+    fs.writeFileSync(path.join(stubDir, file), renderStub({
+      title,
+      file: partialFile || file,
+      includePrefix: 'streaming:reference:partial$rpk-ai/',
+      attributes: [':page-preview: true']
+    }))
+  }
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stub-recon-'))
+    partialsDir = path.join(dir, 'partials')
+    stubDir = path.join(dir, 'stubs')
+    navFile = path.join(dir, 'nav.adoc')
+    fs.mkdirSync(partialsDir)
+    fs.mkdirSync(stubDir)
+    fs.writeFileSync(navFile, [
+      '** xref:reference:rpk/index.adoc[rpk Command Reference]',
+      '*** xref:reference:rpk/rpk-ai/rpk-ai.adoc[rpk ai]',
+      '**** xref:reference:rpk/rpk-ai/rpk-ai-old.adoc[]',
+      '*** xref:reference:rpk-install.adoc[Install rpk]',
+      ''
+    ].join('\n'))
+  })
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+  const run = (overrides = {}) => reconcileStubs({
+    partials: readPartialTitles(partialsDir),
+    stubDir,
+    navFile,
+    plugin: 'ai',
+    includePrefix: 'streaming:reference:partial$rpk-ai/',
+    ...overrides
+  })
+
+  test('creates stubs for new partials and deletes orphaned managed stubs', () => {
+    writePartial('rpk-ai.adoc', 'rpk ai')
+    writePartial('rpk-ai-auth.adoc', 'rpk ai auth')
+    writePartial('rpk-ai-auth-login.adoc', 'rpk ai auth login')
+    writeStub('rpk-ai-old.adoc', 'rpk ai old') // partial gone
+
+    const result = run()
+
+    expect(result.created.sort()).toEqual(['rpk-ai-auth-login.adoc', 'rpk-ai-auth.adoc', 'rpk-ai.adoc'])
+    expect(result.deleted).toEqual(['rpk-ai-old.adoc'])
+    const stub = fs.readFileSync(path.join(stubDir, 'rpk-ai-auth-login.adoc'), 'utf8')
+    expect(stub).toContain('= rpk ai auth login')
+    expect(stub).toContain(':page-preview: true')
+    expect(stub).toContain('include::streaming:reference:partial$rpk-ai/rpk-ai-auth-login.adoc[tag=single-source]')
+  })
+
+  test('rebuilds the nav block hierarchically and preserves surrounding nav', () => {
+    writePartial('rpk-ai.adoc', 'rpk ai')
+    writePartial('rpk-ai-auth.adoc', 'rpk ai auth')
+    writePartial('rpk-ai-auth-login.adoc', 'rpk ai auth login')
+
+    const result = run()
+
+    expect(result.navUpdated).toBe(true)
+    const nav = fs.readFileSync(navFile, 'utf8').split('\n')
+    expect(nav[1]).toBe('*** xref:reference:rpk/rpk-ai/rpk-ai.adoc[rpk ai]')
+    expect(nav[2]).toBe('**** xref:reference:rpk/rpk-ai/rpk-ai-auth.adoc[]')
+    expect(nav[3]).toBe('***** xref:reference:rpk/rpk-ai/rpk-ai-auth-login.adoc[]')
+    expect(nav[4]).toBe('*** xref:reference:rpk-install.adoc[Install rpk]')
+    expect(nav.join('\n')).not.toContain('rpk-ai-old.adoc')
+  })
+
+  test('never deletes pages that are not managed stubs', () => {
+    writePartial('rpk-ai.adoc', 'rpk ai')
+    fs.writeFileSync(path.join(stubDir, 'hand-written.adoc'), '= Concepts\n\nReal prose, no include.\n')
+
+    const result = run()
+
+    expect(result.keptNonStub).toEqual(['hand-written.adoc'])
+    expect(fs.existsSync(path.join(stubDir, 'hand-written.adoc'))).toBe(true)
+  })
+
+  test('flags likely renames for reviewer alias decisions', () => {
+    writePartial('rpk-ai.adoc', 'rpk ai')
+    writePartial('rpk-ai-llm-provider.adoc', 'rpk ai llm-provider')
+    writeStub('rpk-ai-llm.adoc', 'rpk ai llm')
+
+    const result = run()
+
+    expect(result.renameCandidates).toEqual([
+      { deleted: 'rpk-ai-llm.adoc', created: 'rpk-ai-llm-provider.adoc' }
+    ])
+  })
+
+  test('is idempotent', () => {
+    writePartial('rpk-ai.adoc', 'rpk ai')
+    writePartial('rpk-ai-run.adoc', 'rpk ai run')
+    run()
+    const second = run()
+    expect(second.created).toEqual([])
+    expect(second.deleted).toEqual([])
+    expect(second.navUpdated).toBe(false)
+  })
+
+  test('infers the include prefix from an existing stub', () => {
+    writeStub('rpk-ai-run.adoc', 'rpk ai run')
+    expect(inferIncludePrefix(stubDir, 'ai')).toBe('streaming:reference:partial$rpk-ai/')
+    expect(inferIncludePrefix(path.join(dir, 'missing'), 'ai')).toBe(null)
+  })
+
+  test('dry run reports without writing', () => {
+    writePartial('rpk-ai.adoc', 'rpk ai')
+    const result = run({ dryRun: true })
+    expect(result.created).toEqual(['rpk-ai.adoc'])
+    expect(fs.existsSync(path.join(stubDir, 'rpk-ai.adoc'))).toBe(false)
+  })
+})

--- a/__tests__/tools/rpk-docs/plugin-stubs.test.js
+++ b/__tests__/tools/rpk-docs/plugin-stubs.test.js
@@ -124,6 +124,29 @@ describe('plugin stub reconciler', () => {
     expect(inferIncludePrefix(path.join(dir, 'missing'), 'ai')).toBe(null)
   })
 
+  test('supports page-family includes (rp-connect-docs pattern)', () => {
+    writePartial('rpk-connect-run.adoc', 'rpk connect run')
+    const result = reconcileStubs({
+      partials: readPartialTitles(partialsDir),
+      stubDir,
+      navFile: null,
+      plugin: 'connect',
+      includePrefix: 'streaming:reference:page$rpk/rpk-connect/'
+    })
+    expect(result.created).toEqual(['rpk-connect-run.adoc'])
+    const stub = fs.readFileSync(path.join(stubDir, 'rpk-connect-run.adoc'), 'utf8')
+    expect(stub).toContain('include::streaming:reference:page$rpk/rpk-connect/rpk-connect-run.adoc[tag=single-source]')
+    // A second run recognizes the page-family stub as managed
+    const second = reconcileStubs({
+      partials: [],
+      stubDir,
+      navFile: null,
+      plugin: 'connect',
+      includePrefix: 'streaming:reference:page$rpk/rpk-connect/'
+    })
+    expect(second.deleted).toEqual(['rpk-connect-run.adoc'])
+  })
+
   test('dry run reports without writing', () => {
     writePartial('rpk-ai.adoc', 'rpk ai')
     const result = run({ dryRun: true })

--- a/__tests__/tools/rpk-docs/plugin-stubs.test.js
+++ b/__tests__/tools/rpk-docs/plugin-stubs.test.js
@@ -154,3 +154,37 @@ describe('plugin stub reconciler', () => {
     expect(fs.existsSync(path.join(stubDir, 'rpk-ai.adoc'))).toBe(false)
   })
 })
+
+describe('alias-collision guard', () => {
+  const fs2 = require('fs')
+  const path2 = require('path')
+  const os2 = require('os')
+  const { reconcileStubs: recon, readPartialTitles: readTitles, renderStub: render } = require('../../../tools/rpk-docs/generate-plugin-stubs.js')
+
+  test('never creates a stub whose name is claimed as a page alias', () => {
+    const dir = fs2.mkdtempSync(path2.join(os2.tmpdir(), 'alias-guard-'))
+    const partialsDir = path2.join(dir, 'partials'); fs2.mkdirSync(partialsDir)
+    const stubDir = path2.join(dir, 'stubs'); fs2.mkdirSync(stubDir)
+
+    // Upstream still has the old-name partial; this repo's renamed page claims it as alias
+    fs2.writeFileSync(path2.join(partialsDir, 'rpk-ai-llm.adoc'), '= rpk ai llm\n')
+    fs2.writeFileSync(path2.join(partialsDir, 'rpk-ai-llm-provider.adoc'), '= rpk ai llm-provider\n')
+    fs2.writeFileSync(path2.join(stubDir, 'rpk-ai-llm-provider.adoc'),
+      '= rpk ai llm-provider\n:page-aliases: reference:rpk/rpk-ai/rpk-ai-llm.adoc\n\ninclude::streaming:reference:partial$rpk-ai/rpk-ai-llm-provider.adoc[tag=single-source]\n')
+
+    const result = recon({
+      partials: readTitles(partialsDir),
+      stubDir,
+      navFile: null,
+      plugin: 'ai',
+      includePrefix: 'streaming:reference:partial$rpk-ai/'
+    })
+
+    expect(result.skippedAliasTargets).toEqual([
+      { file: 'rpk-ai-llm.adoc', claimedBy: 'rpk-ai-llm-provider.adoc' }
+    ])
+    expect(result.created).toEqual([])
+    expect(fs2.existsSync(path2.join(stubDir, 'rpk-ai-llm.adoc'))).toBe(false)
+    fs2.rmSync(dir, { recursive: true, force: true })
+  })
+})

--- a/__tests__/tools/rpk-docs/pr-summary.test.js
+++ b/__tests__/tools/rpk-docs/pr-summary.test.js
@@ -119,3 +119,33 @@ describe('generatePRSummary change reporting', () => {
     expect(summary).toContain('_(hidden from help output)_')
   })
 })
+
+describe('computeDescriptionCoverage', () => {
+  const { computeDescriptionCoverage } = require('../../../tools/rpk-docs/rpk-docs-handler.js')
+
+  const tree = {
+    name: 'rpk',
+    commands: [
+      { name: 'group', description: 'x'.repeat(2000), commands: [] },
+      { name: 'version', description: 'Prints the version.', commands: [] }
+    ]
+  }
+
+  test('flags overrides that hide substantially longer source help', () => {
+    const overrides = { commands: {
+      'rpk group': { description: 'Manage groups.' },
+      'rpk version': { description: 'Print version info.' }
+    } }
+    const result = computeDescriptionCoverage(tree, overrides)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ commandPath: 'rpk group', sourceChars: 2000 })
+  })
+
+  test('ignores overrides without descriptions and unknown commands', () => {
+    const overrides = { commands: {
+      'rpk group': { flags: {} },
+      'rpk nonexistent': { description: 'x' }
+    } }
+    expect(computeDescriptionCoverage(tree, overrides)).toEqual([])
+  })
+})

--- a/__tests__/tools/rpk-docs/pr-summary.test.js
+++ b/__tests__/tools/rpk-docs/pr-summary.test.js
@@ -1,0 +1,121 @@
+'use strict'
+
+const { generatePRSummary } = require('../../../tools/rpk-docs/rpk-docs-handler.js')
+
+describe('generatePRSummary change reporting', () => {
+  const baseOptions = {
+    rpkVersion: 'v2.0.0',
+    commandCount: 100,
+    filesGenerated: 100,
+    outputDir: 'modules/reference/pages/rpk'
+  }
+
+  const diffWith = (summary, details) => ({
+    comparison: { oldVersion: 'v1.0.0', newVersion: 'v2.0.0' },
+    summary: {
+      newCommands: 0,
+      removedCommands: 0,
+      newFlags: 0,
+      removedFlags: 0,
+      changedDefaults: 0,
+      changedFlagTypes: 0,
+      changedFlagRequirements: 0,
+      changedFlagDescriptions: 0,
+      descriptionChanges: 0,
+      ...summary
+    },
+    details: {
+      newCommands: [],
+      removedCommands: [],
+      newFlags: [],
+      removedFlags: [],
+      changedDefaults: [],
+      changedFlagTypes: [],
+      changedFlagRequirements: [],
+      changedFlagDescriptions: [],
+      descriptionChanges: [],
+      ...details
+    }
+  })
+
+  test('renders changed flag defaults with values', () => {
+    const summary = generatePRSummary({
+      ...baseOptions,
+      diffData: diffWith(
+        { changedDefaults: 1 },
+        { changedDefaults: [{ commandPath: 'rpk topic create', flagName: 'timeout', oldDefault: '5s', newDefault: '30s' }] }
+      )
+    })
+    expect(summary).toContain('| Changed flag defaults | 1 |')
+    expect(summary).toContain('`--timeout` default `5s` → `30s`')
+  })
+
+  test('renders array defaults as JSON', () => {
+    const summary = generatePRSummary({
+      ...baseOptions,
+      diffData: diffWith(
+        { changedDefaults: 1 },
+        { changedDefaults: [{ commandPath: 'rpk x', flagName: 'brokers', oldDefault: ['a'], newDefault: ['b'] }] }
+      )
+    })
+    expect(summary).toContain('["b"]')
+    expect(summary).not.toContain('[object Object]')
+  })
+
+  test('renders command description changes using the correct field name', () => {
+    const summary = generatePRSummary({
+      ...baseOptions,
+      diffData: diffWith(
+        { descriptionChanges: 2 },
+        { descriptionChanges: [{ path: 'rpk topic' }, { path: 'rpk cluster' }] }
+      )
+    })
+    expect(summary).toContain('| Changed command descriptions | 2 |')
+    expect(summary).toContain('`rpk topic`')
+  })
+
+  test('defaults-only changes do not report "no changes"', () => {
+    const summary = generatePRSummary({
+      ...baseOptions,
+      diffData: diffWith(
+        { changedDefaults: 1 },
+        { changedDefaults: [{ commandPath: 'rpk x', flagName: 'y', oldDefault: 1, newDefault: 2 }] }
+      )
+    })
+    expect(summary).not.toContain('No command, flag, or default changes detected.')
+  })
+
+  test('reports no changes when the diff is empty', () => {
+    const summary = generatePRSummary({ ...baseOptions, diffData: diffWith({}, {}) })
+    expect(summary).toContain('No command, flag, or default changes detected.')
+  })
+
+  test('lists removed flags and flag type changes', () => {
+    const summary = generatePRSummary({
+      ...baseOptions,
+      diffData: diffWith(
+        { removedFlags: 1, changedFlagTypes: 1 },
+        {
+          removedFlags: [{ commandPath: 'rpk topic create', flagName: 'legacy' }],
+          changedFlagTypes: [{ commandPath: 'rpk topic create', flagName: 'partitions', oldType: 'int', newType: 'int32' }]
+        }
+      )
+    })
+    expect(summary).toContain('Removed Flags')
+    expect(summary).toContain('`--legacy`')
+    expect(summary).toContain('type `int` → `int32`')
+  })
+
+  test('renders deprecated commands when present', () => {
+    const summary = generatePRSummary({
+      ...baseOptions,
+      diffData: diffWith(
+        { newlyDeprecatedCommands: 1 },
+        { newlyDeprecatedCommands: [{ path: 'rpk redpanda admin', message: 'use rpk cluster instead', hidden: true }] }
+      )
+    })
+    expect(summary).toContain('| Deprecated commands | 1 |')
+    expect(summary).toContain('use rpk cluster instead')
+    expect(summary).toContain('_(hidden from help output)_')
+  })
+})

--- a/__tests__/tools/rpk-docs/report-delta.test.js
+++ b/__tests__/tools/rpk-docs/report-delta.test.js
@@ -509,3 +509,23 @@ describe('rpk Docs Diff Generation', () => {
     })
   })
 })
+
+describe('firstSentence', () => {
+  const { firstSentence } = require('../../../tools/rpk-docs/report-delta.js')
+
+  test('cuts an unterminated summary at the paragraph break', () => {
+    // cobra descriptions often open with a periodless summary line
+    expect(firstSentence('Install Redpanda Check\n\nThis command installs the latest version by default.'))
+      .toBe('Install Redpanda Check')
+  })
+
+  test('joins hard-wrapped lines within the first paragraph', () => {
+    expect(firstSentence('Collects environment data that can help debug\nissues with a cluster. It then bundles the data.'))
+      .toBe('Collects environment data that can help debug issues with a cluster.')
+  })
+
+  test('keeps decimal numbers intact', () => {
+    expect(firstSentence('Installs version 4.32.0 of the plugin. More text.'))
+      .toBe('Installs version 4.32.0 of the plugin.')
+  })
+})

--- a/__tests__/tools/rpk-docs/report-delta.test.js
+++ b/__tests__/tools/rpk-docs/report-delta.test.js
@@ -197,6 +197,96 @@ describe('rpk Docs Diff Generation', () => {
       expect(diff.comparison.newVersion).toBe('v2.0.0')
       expect(diff.comparison.timestamp).toBeDefined()
     })
+
+    test('detects flag type changes', () => {
+      const diff = generateRpkDiff(oldTree, newTree, { oldVersion: 'v1', newVersion: 'v2' })
+      expect(diff.summary.changedFlagTypes).toBe(1)
+      expect(diff.details.changedFlagTypes[0]).toMatchObject({
+        commandPath: 'rpk topic create',
+        flagName: 'partitions',
+        oldType: 'int',
+        newType: 'int32'
+      })
+    })
+
+    test('detects flag default, requirement, and description changes', () => {
+      const before = {
+        name: 'rpk',
+        commands: [{
+          name: 'topic',
+          flags: [
+            { name: 'timeout', type: 'duration', default: '5s', description: 'Wait time', required: false }
+          ],
+          commands: []
+        }]
+      }
+      const after = {
+        name: 'rpk',
+        commands: [{
+          name: 'topic',
+          flags: [
+            { name: 'timeout', type: 'duration', default: '30s', description: 'Maximum wait time', required: true }
+          ],
+          commands: []
+        }]
+      }
+      const diff = generateRpkDiff(before, after)
+      expect(diff.summary.changedDefaults).toBe(1)
+      expect(diff.details.changedDefaults[0]).toMatchObject({ oldDefault: '5s', newDefault: '30s' })
+      expect(diff.summary.changedFlagRequirements).toBe(1)
+      expect(diff.details.changedFlagRequirements[0]).toMatchObject({ oldRequired: false, newRequired: true })
+      expect(diff.summary.changedFlagDescriptions).toBe(1)
+    })
+  })
+
+  describe('generateWhatsNewSection change coverage', () => {
+    const { generateWhatsNewSection } = require('../../../tools/rpk-docs/report-delta.js')
+
+    const baseDiff = (details) => ({
+      comparison: { oldVersion: 'v1', newVersion: 'v2' },
+      summary: {},
+      details: {
+        newCommands: [],
+        removedCommands: [],
+        newFlags: [],
+        removedFlags: [],
+        changedDefaults: [],
+        changedFlagTypes: [],
+        descriptionChanges: [],
+        ...details
+      }
+    })
+
+    test('renders removed commands and flags', () => {
+      const section = generateWhatsNewSection(baseDiff({
+        removedCommands: [{ path: 'rpk old command' }],
+        removedFlags: [{ commandPath: 'rpk topic create', flagName: 'legacy' }]
+      }))
+      expect(section).toContain('=== Removed commands')
+      expect(section).toContain('`rpk old command`')
+      expect(section).toContain('=== Removed flags')
+      expect(section).toContain('`--legacy`')
+    })
+
+    test('renders changed flag types', () => {
+      const section = generateWhatsNewSection(baseDiff({
+        changedFlagTypes: [{ commandPath: 'rpk topic create', flagName: 'partitions', oldType: 'int', newType: 'int32' }]
+      }))
+      expect(section).toContain('=== Changed flag types')
+      expect(section).toContain('`int32`')
+    })
+
+    test('renders array defaults as JSON, not [object Object]', () => {
+      const section = generateWhatsNewSection(baseDiff({
+        changedDefaults: [{ commandPath: 'rpk topic create', flagName: 'brokers', oldDefault: ['a'], newDefault: ['a', 'b'] }]
+      }))
+      expect(section).toContain('["a","b"]')
+      expect(section).not.toContain('[object Object]')
+    })
+
+    test('returns empty string when nothing changed', () => {
+      expect(generateWhatsNewSection(baseDiff({}))).toBe('')
+    })
   })
 
   describe('generateMarkdownSummary', () => {

--- a/__tests__/tools/rpk-docs/report-delta.test.js
+++ b/__tests__/tools/rpk-docs/report-delta.test.js
@@ -529,3 +529,62 @@ describe('firstSentence', () => {
       .toBe('Installs version 4.32.0 of the plugin.')
   })
 })
+
+describe('flag data backfill guard', () => {
+  const { generateRpkDiff } = require('../../../tools/rpk-docs/report-delta.js')
+
+  const tree = (cmds) => ({ name: 'rpk', commands: cmds })
+
+  test('does not report backfilled plugin flags as new', () => {
+    // v26.1.12-style baseline: plugin command exists but no flags captured
+    const oldTree = tree([{ name: 'connect', commands: [{ name: 'streams', flags: [] }] }])
+    const newTree = tree([{
+      name: 'connect',
+      commands: [{
+        name: 'streams',
+        flags: [{ name: 'observability', type: 'string' }, { name: 'chilled', type: 'bool' }]
+      }]
+    }])
+
+    const diff = generateRpkDiff(oldTree, newTree, { oldVersion: 'v1', newVersion: 'v2' })
+    expect(diff.summary.newFlags).toBe(0)
+    expect(diff.summary.flagDataBackfilled).toBe(1)
+    expect(diff.details.flagDataBackfilled).toEqual([
+      { commandPath: 'rpk connect streams', flagCount: 2 }
+    ])
+  })
+
+  test('still detects description changes on backfilled commands', () => {
+    const oldTree = tree([{ name: 'connect', commands: [{ name: 'streams', flags: [], description: 'old' }] }])
+    const newTree = tree([{ name: 'connect', commands: [{ name: 'streams', flags: [{ name: 'x' }], description: 'new' }] }])
+
+    const diff = generateRpkDiff(oldTree, newTree)
+    expect(diff.summary.descriptionChanges).toBe(1)
+  })
+
+  test('reports genuinely new flags when the baseline has flag data', () => {
+    const oldTree = tree([{ name: 'cluster', commands: [{ name: 'info', flags: [{ name: 'brokers', type: 'string' }] }] }])
+    const newTree = tree([{
+      name: 'cluster',
+      commands: [{ name: 'info', flags: [{ name: 'brokers', type: 'string' }, { name: 'detailed', type: 'bool' }] }]
+    }])
+
+    const diff = generateRpkDiff(oldTree, newTree, { newVersion: 'v26.2.1' })
+    expect(diff.summary.flagDataBackfilled).toBe(0)
+    expect(diff.summary.newFlags).toBe(1)
+    expect(diff.details.newFlags[0]).toMatchObject({
+      commandPath: 'rpk cluster info',
+      flagName: 'detailed',
+      introducedInVersion: 'v26.2.1'
+    })
+  })
+
+  test('new commands are unaffected by the guard', () => {
+    const oldTree = tree([])
+    const newTree = tree([{ name: 'policy', flags: [{ name: 'format' }], commands: [] }])
+
+    const diff = generateRpkDiff(oldTree, newTree, { newVersion: 'v26.2.1' })
+    expect(diff.summary.newCommands).toBe(1)
+    expect(diff.summary.flagDataBackfilled).toBe(0)
+  })
+})

--- a/__tests__/tools/rpk-docs/report-delta.test.js
+++ b/__tests__/tools/rpk-docs/report-delta.test.js
@@ -351,6 +351,30 @@ describe('rpk Docs Diff Generation', () => {
       expect(generateWhatsNewSection(baseDiff({}))).toBe('')
     })
 
+    test('routes command-group roots into their directory', () => {
+      const section = generateWhatsNewSection(baseDiff({
+        newCommands: [
+          { path: 'rpk check', description: 'Production readiness checks.' },
+          { path: 'rpk check run', description: 'Run the checks.' },
+          { path: 'rpk version', description: 'Prints the version.' }
+        ]
+      }), { hasSubcommands: (p) => p === 'rpk check' })
+      expect(section).toContain('xref:reference:rpk/rpk-check/rpk-check.adoc[`rpk check`]')
+      expect(section).toContain('xref:reference:rpk/rpk-check/rpk-check-run.adoc[`rpk check run`]')
+      expect(section).toContain('xref:reference:rpk/rpk-version.adoc[`rpk version`]')
+    })
+
+    test('caps bullet descriptions at a sentence boundary', () => {
+      const section = generateWhatsNewSection(baseDiff({
+        newCommands: [{
+          path: 'rpk ai llm-provider diff',
+          description: 'Dry-run of apply for LLM providers. Prints, per manifest, whether apply would\ncreate, update, or leave the resource unchanged.'
+        }]
+      }))
+      expect(section).toContain(' - Dry-run of apply for LLM providers.')
+      expect(section).not.toContain('whether apply would')
+    })
+
     test('renders deprecated commands with replacement and affected subcommands', () => {
       const section = generateWhatsNewSection(baseDiff({
         newlyDeprecatedCommands: [{

--- a/__tests__/tools/rpk-docs/report-delta.test.js
+++ b/__tests__/tools/rpk-docs/report-delta.test.js
@@ -239,6 +239,69 @@ describe('rpk Docs Diff Generation', () => {
     })
   })
 
+  describe('deprecation detection', () => {
+    const oldTreeDep = {
+      name: 'rpk',
+      commands: [
+        { name: 'redpanda', commands: [{ name: 'admin', commands: [{ name: 'brokers', commands: [{ name: 'list', commands: [] }] }] }] },
+        { name: 'gone', commands: [] }
+      ]
+    }
+    const newTreeDep = {
+      name: 'rpk',
+      commands: [
+        { name: 'redpanda', commands: [] }
+      ]
+    }
+    const newDeprecated = {
+      'rpk redpanda admin': {
+        deprecated: true,
+        _note: 'Hidden: true, found by scanning Go source',
+        deprecatedMessage: 'use `rpk cluster` subcommands',
+        replacement: 'Use xref:reference:rpk/rpk-cluster/rpk-cluster.adoc[`rpk cluster`] instead.'
+      }
+    }
+
+    test('reports newly deprecated commands with metadata', () => {
+      const diff = generateRpkDiff(oldTreeDep, newTreeDep, {
+        newVersion: 'v2',
+        oldDeprecatedCommands: {},
+        newDeprecatedCommands: newDeprecated
+      })
+      expect(diff.summary.newlyDeprecatedCommands).toBe(1)
+      const dep = diff.details.newlyDeprecatedCommands[0]
+      expect(dep.path).toBe('rpk redpanda admin')
+      expect(dep.hidden).toBe(true)
+      expect(dep.message).toContain('rpk cluster')
+      expect(dep.replacement).toContain('xref:')
+    })
+
+    test('reclassifies hidden-deprecated subtree removals as deprecations', () => {
+      const diff = generateRpkDiff(oldTreeDep, newTreeDep, {
+        newVersion: 'v2',
+        oldDeprecatedCommands: {},
+        newDeprecatedCommands: newDeprecated
+      })
+      // rpk gone is a genuine removal; the admin family is not
+      expect(diff.details.removedCommands.map(c => c.path)).toEqual(['rpk gone'])
+      const dep = diff.details.newlyDeprecatedCommands[0]
+      expect(dep.affectedSubcommands).toEqual(
+        expect.arrayContaining(['rpk redpanda admin brokers', 'rpk redpanda admin brokers list'])
+      )
+    })
+
+    test('already-deprecated commands do not re-report', () => {
+      const diff = generateRpkDiff(oldTreeDep, newTreeDep, {
+        newVersion: 'v2',
+        oldDeprecatedCommands: newDeprecated,
+        newDeprecatedCommands: newDeprecated
+      })
+      expect(diff.summary.newlyDeprecatedCommands).toBe(0)
+      // Without a NEW deprecation, the subtree disappearance counts as removal
+      expect(diff.summary.removedCommands).toBe(4)
+    })
+  })
+
   describe('generateWhatsNewSection change coverage', () => {
     const { generateWhatsNewSection } = require('../../../tools/rpk-docs/report-delta.js')
 
@@ -286,6 +349,21 @@ describe('rpk Docs Diff Generation', () => {
 
     test('returns empty string when nothing changed', () => {
       expect(generateWhatsNewSection(baseDiff({}))).toBe('')
+    })
+
+    test('renders deprecated commands with replacement and affected subcommands', () => {
+      const section = generateWhatsNewSection(baseDiff({
+        newlyDeprecatedCommands: [{
+          path: 'rpk redpanda admin',
+          message: 'use `rpk cluster` subcommands',
+          replacement: 'Use xref:reference:rpk/rpk-cluster/rpk-cluster.adoc[`rpk cluster`] instead.',
+          hidden: true,
+          affectedSubcommands: ['rpk redpanda admin brokers']
+        }]
+      }))
+      expect(section).toContain('=== Deprecated commands')
+      expect(section).toContain('xref:reference:rpk/rpk-cluster/rpk-cluster.adoc')
+      expect(section).toContain('rpk redpanda admin brokers')
     })
   })
 

--- a/__tests__/tools/rpk-docs/report-delta.test.js
+++ b/__tests__/tools/rpk-docs/report-delta.test.js
@@ -588,3 +588,59 @@ describe('flag data backfill guard', () => {
     expect(diff.summary.flagDataBackfilled).toBe(0)
   })
 })
+
+describe('flag data backfill guard: group-level baseline detection', () => {
+  const { generateRpkDiff } = require('../../../tools/rpk-docs/report-delta.js')
+  const tree = (cmds) => ({ name: 'rpk', commands: cmds })
+
+  test('a zero-flag core command in a group with baseline data gets genuine new flags', () => {
+    // rpk cluster config status gained --format; the cluster group has
+    // baseline flag data elsewhere, so this is not backfill
+    const oldTree = tree([{
+      name: 'cluster',
+      commands: [
+        { name: 'health', flags: [{ name: 'watch', type: 'bool' }] },
+        { name: 'config', commands: [{ name: 'status', flags: [] }] }
+      ]
+    }])
+    const newTree = tree([{
+      name: 'cluster',
+      commands: [
+        { name: 'health', flags: [{ name: 'watch', type: 'bool' }] },
+        { name: 'config', commands: [{ name: 'status', flags: [{ name: 'format', type: 'string' }] }] }
+      ]
+    }])
+
+    const diff = generateRpkDiff(oldTree, newTree, { newVersion: 'v26.2.1' })
+    expect(diff.summary.flagDataBackfilled).toBe(0)
+    expect(diff.details.newFlags).toEqual([expect.objectContaining({
+      commandPath: 'rpk cluster config status',
+      flagName: 'format'
+    })])
+  })
+
+  test('shim flags do not count as plugin baseline data', () => {
+    // Old connect subtree only has the rpk-native install shim flag; the
+    // plugin commands themselves recorded no flags, so it is backfill
+    const oldTree = tree([{
+      name: 'connect',
+      commands: [
+        { name: 'install', flags: [{ name: 'connect-version', type: 'string' }] },
+        { name: 'streams', flags: [] }
+      ]
+    }])
+    const newTree = tree([{
+      name: 'connect',
+      commands: [
+        { name: 'install', flags: [{ name: 'connect-version', type: 'string' }] },
+        { name: 'streams', flags: [{ name: 'observability', type: 'string' }] }
+      ]
+    }])
+
+    const diff = generateRpkDiff(oldTree, newTree)
+    expect(diff.summary.newFlags).toBe(0)
+    expect(diff.details.flagDataBackfilled).toEqual([
+      { commandPath: 'rpk connect streams', flagCount: 1 }
+    ])
+  })
+})

--- a/__tests__/tools/rpk-docs/rpk-docs-handler.test.js
+++ b/__tests__/tools/rpk-docs/rpk-docs-handler.test.js
@@ -76,6 +76,33 @@ describe('rpk Docs Handler', () => {
         const result = JSON.parse(fs.readFileSync(overridesPath, 'utf8'))
         expect(result.commands['rpk topic existing'].introducedInVersion).toBe('v26.1.0')
       })
+
+      test('stamps plugin commands with the plugin version, core commands with the rpk version', () => {
+        fs.writeFileSync(overridesPath, JSON.stringify({ commands: {} }))
+
+        const diffData = {
+          summary: { newCommands: 2 },
+          details: {
+            newCommands: [
+              { path: 'rpk connect new-subcommand' },
+              { path: 'rpk cluster new-command' }
+            ],
+            newFlags: [
+              { commandPath: 'rpk connect run', flagName: 'new-flag' }
+            ],
+            removedCommands: [],
+            removedFlags: [],
+            changedDefaults: []
+          }
+        }
+
+        updateOverridesWithIntroducedVersions(diffData, overridesPath, 'v26.2.0', { connect: '4.103.0' })
+
+        const result = JSON.parse(fs.readFileSync(overridesPath, 'utf8'))
+        expect(result.commands['rpk connect new-subcommand'].introducedInVersion).toBe('4.103.0')
+        expect(result.commands['rpk cluster new-command'].introducedInVersion).toBe('v26.2.0')
+        expect(result.commands['rpk connect run'].flags['new-flag'].introducedInVersion).toBe('4.103.0')
+      })
     })
 
     describe('flag version tracking', () => {

--- a/__tests__/tools/rpk-docs/table-conversion.test.js
+++ b/__tests__/tools/rpk-docs/table-conversion.test.js
@@ -419,3 +419,79 @@ Without \`--node-id\`, the request is sent to any broker.`
     })
   })
 })
+
+describe('unindented shell examples and colon-introduced code', () => {
+  const {
+    convertIndentedCodeBlocksToAsciiDoc,
+    parseDescriptionSections
+  } = require('../../../tools/rpk-docs/generate-rpk-docs.js')
+
+  test('captures a column-0 $ invocation and its output as blocks', () => {
+    const store = []
+    const input = [
+      'Progress is reported as follows.',
+      '',
+      '$ rpk cluster brokers decommission-status 4',
+      'DECOMMISSION PROGRESS',
+      '=====================',
+      'kafka/test/0   3   9   1699470920',
+      '',
+      'Using --detailed prints granular reports.'
+    ].join('\n')
+
+    const out = convertIndentedCodeBlocksToAsciiDoc(input, store)
+    expect(store).toHaveLength(1)
+    expect(store[0]).toContain('[,bash]\n----\nrpk cluster brokers decommission-status 4\n----')
+    expect(store[0]).toContain('[.no-copy]\n----\nDECOMMISSION PROGRESS\n=====================\nkafka/test/0   3   9   1699470920\n----')
+    expect(out).toContain('__EARLY_CODE_BLOCK_0__')
+    expect(out).toContain('Using --detailed prints granular reports.')
+  })
+
+  test('all-caps output title after a $ invocation is not a section header', () => {
+    const desc = [
+      'Reports progress.',
+      '',
+      '$ rpk thing status 4',
+      'DECOMMISSION PROGRESS',
+      '=====================',
+      'row 1',
+      '',
+      'Trailing prose.'
+    ].join('\n')
+
+    const { mainDescription, sections } = parseDescriptionSections(desc)
+    expect(Object.keys(sections)).toEqual([])
+    expect(mainDescription).toContain('DECOMMISSION PROGRESS')
+  })
+
+  test('captures a colon-introduced indented code sample verbatim', () => {
+    const store = []
+    const input = [
+      'Scope the resource to your MCP server, e.g.:',
+      '',
+      '  permit(principal, action == Action::"tools_call",',
+      '         resource == McpServer::"servicenow");',
+      '',
+      'Data shaping is NOT configured here.'
+    ].join('\n')
+
+    const out = convertIndentedCodeBlocksToAsciiDoc(input, store)
+    expect(store).toHaveLength(1)
+    expect(store[0]).toContain('permit(principal, action == Action::"tools_call",\n       resource == McpServer::"servicenow");')
+    expect(out).toContain('Data shaping is NOT configured here.')
+  })
+
+  test('colon-introduced indented lists are not captured as code', () => {
+    const store = []
+    const input = [
+      'The following conditions are met:',
+      '',
+      '  - All partitions have leaders',
+      '  - No brokers are down',
+      ''
+    ].join('\n')
+
+    convertIndentedCodeBlocksToAsciiDoc(input, store)
+    expect(store).toHaveLength(0)
+  })
+})

--- a/__tests__/tools/rpk-docs/text-transformations.test.js
+++ b/__tests__/tools/rpk-docs/text-transformations.test.js
@@ -145,3 +145,27 @@ describe('applyToCode rules in early code blocks', () => {
     expect(out).not.toContain('NOTE: output follows')
   })
 })
+
+describe('applyTextTransformationsToExamples', () => {
+  const { applyTextTransformationsToExamples } = require('../../../tools/rpk-docs/generate-rpk-docs.js')
+
+  const transforms = {
+    replacements: [
+      { pattern: '"([a-z]{1,20})"', replacement: '`$1`', flags: 'g' },
+      { pattern: '\\brpai\\b', replacement: 'rpk ai', flags: 'g', applyToCode: true }
+    ]
+  }
+
+  test('caption rules never rewrite quoted strings inside command lines', () => {
+    const input = 'Import client "quotas" from a string:\n  rpk cluster quotas import --from \'{"quotas":...}\''
+    const out = applyTextTransformationsToExamples(input, transforms)
+    expect(out).toContain('`quotas` from a string')
+    expect(out).toContain(String.raw`'{"quotas":...}'`)
+  })
+
+  test('code-safe rules still apply to command lines', () => {
+    const input = 'Send a task:\n  rpai agent a2a send hello'
+    const out = applyTextTransformationsToExamples(input, transforms)
+    expect(out).toContain('  rpk ai agent a2a send hello')
+  })
+})

--- a/__tests__/tools/rpk-docs/text-transformations.test.js
+++ b/__tests__/tools/rpk-docs/text-transformations.test.js
@@ -125,3 +125,23 @@ describe('Text Transformations', () => {
     }, 30000)
   })
 })
+
+describe('applyToCode rules in early code blocks', () => {
+  const { formatDescription } = require('../../../tools/rpk-docs/generate-rpk-docs.js')
+
+  const transforms = {
+    replacements: [
+      { pattern: '\\brpai\\b', replacement: 'rpk ai', flags: 'g', applyToCode: true },
+      { pattern: '(^|\\n\\s*)Note:\\s', replacement: '$1NOTE: ', flags: 'g' }
+    ]
+  }
+
+  test('applies only code-safe rules inside captured code blocks', () => {
+    const input = 'Run the agent, e.g.:\n\n  rpai run claude -L anthropic\n  Note: output follows\n\nDone.'
+    const out = formatDescription(input, transforms)
+    expect(out).toContain('rpk ai run claude -L anthropic')
+    // The admonition rule must NOT rewrite text inside the code block
+    expect(out).toContain('Note: output follows')
+    expect(out).not.toContain('NOTE: output follows')
+  })
+})

--- a/__tests__/tools/rpk-docs/whats-new-merge.test.js
+++ b/__tests__/tools/rpk-docs/whats-new-merge.test.js
@@ -149,3 +149,14 @@ describe('updateWhatsNewFile merge semantics', () => {
     expect(content).toContain('rpk-cluster.adoc')
   })
 })
+
+describe('linkable predicate coverage', () => {
+  const { makeLinkablePredicate } = require('../../../tools/rpk-docs/rpk-docs-handler.js')
+
+  test('cloud and security-secret commands are never linkable', () => {
+    const linkable = makeLinkablePredicate(null)
+    expect(linkable('rpk cloud auth list')).toBe(false)
+    expect(linkable('rpk security secret create')).toBe(false)
+    expect(linkable('rpk topic create')).toBe(true)
+  })
+})

--- a/__tests__/tools/rpk-docs/whats-new-merge.test.js
+++ b/__tests__/tools/rpk-docs/whats-new-merge.test.js
@@ -1,0 +1,129 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+
+const { updateWhatsNewFile } = require('../../../tools/rpk-docs/rpk-docs-handler.js')
+
+describe('updateWhatsNewFile merge semantics', () => {
+  let tempDir
+  let whatsNewPath
+
+  const diffWith = (details) => ({
+    comparison: { oldVersion: 'v1', newVersion: 'v2' },
+    summary: {},
+    details: {
+      newCommands: [],
+      newlyDeprecatedCommands: [],
+      removedCommands: [],
+      newFlags: [],
+      removedFlags: [],
+      changedDefaults: [],
+      changedFlagTypes: [],
+      descriptionChanges: [],
+      ...details
+    }
+  })
+
+  const rcDiff = (cmdPath) => diffWith({
+    newCommands: [{ path: cmdPath, description: 'Does things' }]
+  })
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'whats-new-test-'))
+    whatsNewPath = path.join(tempDir, 'redpanda.adoc')
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  test('creates a marked Redpanda CLI section when none exists', () => {
+    fs.writeFileSync(whatsNewPath, '= What\'s New\n\n== Bug fixes\n\nStuff.\n')
+    updateWhatsNewFile(rcDiff('rpk topic new'), whatsNewPath, 'v2.0.1-rc1')
+
+    const content = fs.readFileSync(whatsNewPath, 'utf8')
+    expect(content).toContain('== Redpanda CLI')
+    expect(content).toContain('// AUTOGEN-RPK-CHANGES v2.0.1-rc1 START')
+    expect(content).toContain('`rpk topic new`')
+    // Inserted before Bug fixes
+    expect(content.indexOf('== Redpanda CLI')).toBeLessThan(content.indexOf('== Bug fixes'))
+  })
+
+  test('appends a second version block into the existing section', () => {
+    fs.writeFileSync(whatsNewPath, '= What\'s New\n\n== Bug fixes\n\nStuff.\n')
+    updateWhatsNewFile(rcDiff('rpk topic new'), whatsNewPath, 'v2.0.1-rc1')
+    updateWhatsNewFile(rcDiff('rpk cluster newer'), whatsNewPath, 'v2.0.1-rc2')
+
+    const content = fs.readFileSync(whatsNewPath, 'utf8')
+    expect(content.match(/== Redpanda CLI/g)).toHaveLength(1)
+    expect(content).toContain('AUTOGEN-RPK-CHANGES v2.0.1-rc1 START')
+    expect(content).toContain('AUTOGEN-RPK-CHANGES v2.0.1-rc2 START')
+    expect(content).toContain('`rpk topic new`')
+    expect(content).toContain('`rpk cluster newer`')
+    // Both blocks stay inside the CLI section, before Bug fixes
+    expect(content.indexOf('rc2 START')).toBeLessThan(content.indexOf('== Bug fixes'))
+  })
+
+  test('re-running the same version replaces its block instead of duplicating', () => {
+    fs.writeFileSync(whatsNewPath, '= What\'s New\n')
+    updateWhatsNewFile(rcDiff('rpk topic old-name'), whatsNewPath, 'v2.0.1-rc1')
+    updateWhatsNewFile(rcDiff('rpk topic renamed'), whatsNewPath, 'v2.0.1-rc1')
+
+    const content = fs.readFileSync(whatsNewPath, 'utf8')
+    expect(content.match(/AUTOGEN-RPK-CHANGES v2\.0\.1-rc1 START/g)).toHaveLength(1)
+    expect(content).toContain('`rpk topic renamed`')
+    expect(content).not.toContain('`rpk topic old-name`')
+  })
+
+  test('preserves a hand-written CLI section and appends after it', () => {
+    fs.writeFileSync(whatsNewPath, [
+      '= What\'s New',
+      '',
+      '== Redpanda CLI (rpk)',
+      '',
+      '* *Hand-curated entry*: writers wrote this.',
+      '',
+      '== Bug fixes',
+      '',
+      'Stuff.',
+      ''
+    ].join('\n'))
+
+    updateWhatsNewFile(rcDiff('rpk topic new'), whatsNewPath, 'v2.0.1-rc3')
+
+    const content = fs.readFileSync(whatsNewPath, 'utf8')
+    expect(content).toContain('* *Hand-curated entry*: writers wrote this.')
+    expect(content).toContain('AUTOGEN-RPK-CHANGES v2.0.1-rc3 START')
+    // Appended inside the CLI section (before Bug fixes), after manual prose
+    expect(content.indexOf('Hand-curated entry')).toBeLessThan(content.indexOf('AUTOGEN-RPK-CHANGES'))
+    expect(content.indexOf('AUTOGEN-RPK-CHANGES v2.0.1-rc3 END')).toBeLessThan(content.indexOf('== Bug fixes'))
+  })
+
+  test('plugin runs write plugin-labeled blocks without xrefs', () => {
+    fs.writeFileSync(whatsNewPath, '= What\'s New\n')
+    updateWhatsNewFile(rcDiff('rpk ai gateway'), whatsNewPath, 'ai plugin 0.3.0', { xrefs: false })
+
+    const content = fs.readFileSync(whatsNewPath, 'utf8')
+    expect(content).toContain('AUTOGEN-RPK-CHANGES ai plugin 0.3.0 START')
+    expect(content).toContain('`rpk ai gateway`')
+    expect(content).not.toContain('xref:')
+  })
+
+  test('writes deprecations from the diff', () => {
+    fs.writeFileSync(whatsNewPath, '= What\'s New\n')
+    updateWhatsNewFile(diffWith({
+      newlyDeprecatedCommands: [{
+        path: 'rpk redpanda admin',
+        message: 'use `rpk cluster` subcommands',
+        replacement: 'Use xref:reference:rpk/rpk-cluster/rpk-cluster.adoc[`rpk cluster`] instead.',
+        hidden: true
+      }]
+    }), whatsNewPath, 'v2.0.0')
+
+    const content = fs.readFileSync(whatsNewPath, 'utf8')
+    expect(content).toContain('=== Deprecated commands')
+    expect(content).toContain('rpk-cluster.adoc')
+  })
+})

--- a/__tests__/tools/rpk-docs/whats-new-merge.test.js
+++ b/__tests__/tools/rpk-docs/whats-new-merge.test.js
@@ -101,14 +101,36 @@ describe('updateWhatsNewFile merge semantics', () => {
     expect(content.indexOf('AUTOGEN-RPK-CHANGES v2.0.1-rc3 END')).toBeLessThan(content.indexOf('== Bug fixes'))
   })
 
-  test('plugin runs write plugin-labeled blocks without xrefs', () => {
-    fs.writeFileSync(whatsNewPath, '= What\'s New\n')
-    updateWhatsNewFile(rcDiff('rpk ai gateway'), whatsNewPath, 'ai plugin 0.3.0', { xrefs: false })
+  test('plugin runs write to a separate rpk plugins section without xrefs', () => {
+    fs.writeFileSync(whatsNewPath, '= What\'s New\n\n== Redpanda CLI\n\n* Core entry.\n')
+    updateWhatsNewFile(rcDiff('rpk ai gateway'), whatsNewPath, 'ai plugin 0.3.0', {
+      xrefs: false,
+      sectionHeading: '== rpk plugins'
+    })
 
     const content = fs.readFileSync(whatsNewPath, 'utf8')
+    expect(content).toContain('== rpk plugins')
     expect(content).toContain('AUTOGEN-RPK-CHANGES ai plugin 0.3.0 START')
+    expect(content).toContain('=== ai plugin 0.3.0')
     expect(content).toContain('`rpk ai gateway`')
     expect(content).not.toContain('xref:')
+    // Core section untouched
+    expect(content).toContain('* Core entry.')
+    const cliIdx = content.indexOf('== Redpanda CLI')
+    expect(content.indexOf('AUTOGEN-RPK-CHANGES')).toBeGreaterThan(cliIdx)
+  })
+
+  test('block headings carry the version so accumulated blocks never collide', () => {
+    fs.writeFileSync(whatsNewPath, '= What\'s New\n')
+    updateWhatsNewFile(rcDiff('rpk topic a'), whatsNewPath, 'v2.0.1-rc1')
+    updateWhatsNewFile(rcDiff('rpk topic b'), whatsNewPath, 'v2.0.1-rc2')
+
+    const content = fs.readFileSync(whatsNewPath, 'utf8')
+    expect(content).toContain('=== v2.0.1-rc1')
+    expect(content).toContain('=== v2.0.1-rc2')
+    // Category headings nest under the version heading
+    expect(content).toContain('==== New commands')
+    expect(content).not.toMatch(/^=== New commands$/m)
   })
 
   test('writes deprecations from the diff', () => {
@@ -123,7 +145,7 @@ describe('updateWhatsNewFile merge semantics', () => {
     }), whatsNewPath, 'v2.0.0')
 
     const content = fs.readFileSync(whatsNewPath, 'utf8')
-    expect(content).toContain('=== Deprecated commands')
+    expect(content).toContain('==== Deprecated commands')
     expect(content).toContain('rpk-cluster.adoc')
   })
 })

--- a/bin/doc-tools.js
+++ b/bin/doc-tools.js
@@ -1201,6 +1201,119 @@ automation
   })
 
 /**
+ * generate rpk-plugin-stubs
+ *
+ * @description
+ * Reconciles a consumer repo's single-source stub pages and nav section
+ * against the rpk plugin partials generated in the docs repo. Run from the
+ * consumer repo root (for example, adp-docs for rpk ai). Creates stubs for
+ * new partials, deletes managed stubs whose partial is gone, rebuilds the
+ * plugin's nav block, and proposes page aliases for likely renames.
+ * Full reconcile, so it is idempotent and heals pre-existing drift.
+ */
+automation
+  .command('rpk-plugin-stubs')
+  .description('Reconcile single-source stub pages and nav against the docs repo\'s rpk plugin partials. Run from the consumer repo root.')
+  .option('--plugin <name>', 'rpk plugin command name', 'ai')
+  .option('--docs-repo <owner/repo>', 'Docs repo that owns the partials', 'redpanda-data/docs')
+  .option('--docs-ref <ref>', 'Branch or tag to read partials from', 'main')
+  .option('--partials-dir <path>', 'Local partials directory (skips cloning the docs repo)')
+  .option('--stub-dir <path>', 'Stub pages directory in the consumer repo (default: modules/reference/pages/rpk/rpk-<plugin>)')
+  .option('--nav-file <path>', 'Nav file whose plugin block is rebuilt', 'modules/ROOT/nav.adoc')
+  .option('--include-prefix <prefix>', 'Antora resource prefix for stub includes. Default: inferred from an existing stub.')
+  .option('--attribute <line>', 'Page attribute line added to new stubs (repeatable)', (value, acc) => { acc.push(value); return acc }, [])
+  .option('--summary-file <path>', 'Write a markdown summary (for PR bodies)')
+  .option('--dry-run', 'Report what would change without writing')
+  .action(async (options) => {
+    try {
+      const {
+        readPartialTitles, fetchPartialsDir, inferIncludePrefix, reconcileStubs
+      } = require('../tools/rpk-docs/generate-plugin-stubs.js')
+
+      const plugin = options.plugin
+      const stubDir = options.stubDir || `modules/reference/pages/rpk/rpk-${plugin}`
+      const partialsDir = options.partialsDir || fetchPartialsDir({
+        docsRepo: options.docsRepo,
+        docsRef: options.docsRef,
+        plugin
+      })
+
+      const includePrefix = options.includePrefix || inferIncludePrefix(stubDir, plugin)
+      if (!includePrefix) {
+        console.error('Error: could not infer the include prefix (no existing stubs). Pass --include-prefix, for example: streaming:reference:partial$rpk-ai/')
+        process.exit(1)
+      }
+
+      const partials = readPartialTitles(partialsDir)
+      console.log(`Reconciling ${partials.length} partial(s) against ${stubDir}`)
+
+      const result = reconcileStubs({
+        partials,
+        stubDir,
+        navFile: options.navFile,
+        plugin,
+        includePrefix,
+        ...(options.attribute.length > 0 ? { attributes: options.attribute } : {}),
+        dryRun: options.dryRun
+      })
+
+      console.log(`  Created: ${result.created.length}, deleted: ${result.deleted.length}, nav updated: ${result.navUpdated}`)
+      for (const f of result.created) console.log(`  + ${f}`)
+      for (const f of result.deleted) console.log(`  - ${f}`)
+      for (const f of result.keptNonStub) console.log(`  ! kept (not a managed stub): ${f}`)
+
+      const lines = []
+      lines.push(`## rpk ${plugin} stub reconciliation`)
+      lines.push('')
+      lines.push(`Reconciled against \`${options.partialsDir ? partialsDir : `${options.docsRepo}@${options.docsRef}`}\`.`)
+      lines.push('')
+      if (result.created.length + result.deleted.length === 0 && !result.navUpdated) {
+        lines.push('No changes: stubs and nav already match the partials.')
+      }
+      if (result.created.length > 0) {
+        lines.push(`### New stubs (${result.created.length})`)
+        lines.push('')
+        result.created.forEach(f => lines.push(`- \`${f}\``))
+        lines.push('')
+      }
+      if (result.deleted.length > 0) {
+        lines.push(`### Deleted stubs (${result.deleted.length})`)
+        lines.push('')
+        result.deleted.forEach(f => lines.push(`- \`${f}\``))
+        lines.push('')
+      }
+      if (result.renameCandidates.length > 0) {
+        lines.push('### Possible renames — reviewer decision needed')
+        lines.push('')
+        lines.push('These deleted/created pairs look like renames. If so, add `:page-aliases:` for the old page name to the new stub so published URLs keep working:')
+        lines.push('')
+        for (const rc of result.renameCandidates) {
+          lines.push(`- \`${rc.deleted}\` → \`${rc.created}\`: add \`:page-aliases: reference:rpk/rpk-${plugin}/${rc.deleted}\` to the new stub`)
+        }
+        lines.push('')
+      }
+      if (result.keptNonStub.length > 0) {
+        lines.push('### Kept (not managed stubs)')
+        lines.push('')
+        lines.push('These pages do not match the managed stub shape, so they were not touched:')
+        lines.push('')
+        result.keptNonStub.forEach(f => lines.push(`- \`${f}\``))
+        lines.push('')
+      }
+      const summary = lines.join('\n')
+      if (options.summaryFile) {
+        fs.writeFileSync(options.summaryFile, summary, 'utf8')
+        console.log(`Summary written to: ${options.summaryFile}`)
+      }
+
+      process.exit(0)
+    } catch (err) {
+      console.error(`Error: ${err.message}`)
+      process.exit(1)
+    }
+  })
+
+/**
  * validate rpk-overrides
  *
  * @description

--- a/bin/doc-tools.js
+++ b/bin/doc-tools.js
@@ -1111,6 +1111,14 @@ automation
   .option('--from-json <path>', 'Regenerate docs from an existing versioned JSON file (skips building)')
   .option('--plugin <name>', 'Refresh a single rpk plugin\'s docs (ai, connect, k8s, check). Requires --from-json. Installs the plugin, splices its fresh subtree into the snapshot, and re-renders.')
   .option('--plugin-version <version>', 'Plugin version to install and record (for example, 4.102.0). Defaults to the latest published version.')
+  .option('--plugin-pin <name=version>', 'Pin a plugin version for the installs during full generation (repeatable, for example --plugin-pin k8s=26.3.1-beta.1). Required for pre-GA plugins with no promoted latest version.', (value, pins) => {
+    const eq = value.indexOf('=')
+    if (eq < 1 || eq === value.length - 1) {
+      throw new Error(`Invalid --plugin-pin '${value}': expected <name>=<version>`)
+    }
+    pins[value.slice(0, eq)] = value.slice(eq + 1)
+    return pins
+  }, {})
   .option('--rpk-bin <path>', 'Path to an existing rpk binary for the plugin refresh (skips download/build)')
   .option('--overrides <path>', 'Path to overrides JSON file', 'docs-data/rpk-overrides.json')
   .option('--diff <oldVersion>', 'Generate diff against previous version')
@@ -1148,6 +1156,7 @@ automation
         fromJson: options.fromJson,
         plugin: options.plugin,
         pluginVersion: options.pluginVersion,
+        pluginPins: options.pluginPin,
         rpkBin: options.rpkBin,
         overrides: options.overrides,
         diff: options.diff,

--- a/bin/doc-tools.js
+++ b/bin/doc-tools.js
@@ -1218,6 +1218,7 @@ automation
   .option('--docs-repo <owner/repo>', 'Docs repo that owns the partials', 'redpanda-data/docs')
   .option('--docs-ref <ref>', 'Branch or tag to read partials from', 'main')
   .option('--partials-dir <path>', 'Local partials directory (skips cloning the docs repo)')
+  .option('--source-path <path>', 'Path in the docs repo to read from (default: modules/reference/partials/rpk-<plugin>; use modules/reference/pages/rpk/rpk-connect for page-family content)')
   .option('--stub-dir <path>', 'Stub pages directory in the consumer repo (default: modules/reference/pages/rpk/rpk-<plugin>)')
   .option('--nav-file <path>', 'Nav file whose plugin block is rebuilt', 'modules/ROOT/nav.adoc')
   .option('--include-prefix <prefix>', 'Antora resource prefix for stub includes. Default: inferred from an existing stub.')
@@ -1235,7 +1236,8 @@ automation
       const partialsDir = options.partialsDir || fetchPartialsDir({
         docsRepo: options.docsRepo,
         docsRef: options.docsRef,
-        plugin
+        plugin,
+        sourcePath: options.sourcePath
       })
 
       const includePrefix = options.includePrefix || inferIncludePrefix(stubDir, plugin)

--- a/bin/doc-tools.js
+++ b/bin/doc-tools.js
@@ -1284,6 +1284,25 @@ automation
         result.deleted.forEach(f => lines.push(`- \`${f}\``))
         lines.push('')
       }
+      if ((result.skippedAliasTargets || []).length > 0) {
+        lines.push('### Skipped: names claimed as page aliases')
+        lines.push('')
+        lines.push('These partials exist upstream, but a page here already claims the name as a `:page-aliases:` target — creating the stub would make the Antora build fatal. Usually this means a rename alias exists while the upstream partial for the old name has not been cleaned up yet:')
+        lines.push('')
+        for (const t of result.skippedAliasTargets) {
+          lines.push(`- \`${t.file}\` (claimed by \`${t.claimedBy}\`)`)
+        }
+        lines.push('')
+      }
+      const straightDeletions = result.deleted.filter(d => !result.renameCandidates.some(rc => rc.deleted === d))
+      if (straightDeletions.length > 0) {
+        lines.push('### Deletions with no rename partner')
+        lines.push('')
+        lines.push('These pages were removed with no successor detected. Their published URLs will 404 — consider adding a redirect or an alias on a related page:')
+        lines.push('')
+        straightDeletions.forEach(f => lines.push(`- \`${f}\``))
+        lines.push('')
+      }
       if (result.renameCandidates.length > 0) {
         lines.push('### Possible renames — reviewer decision needed')
         lines.push('')

--- a/bin/doc-tools.js
+++ b/bin/doc-tools.js
@@ -1109,6 +1109,9 @@ automation
   .option('-r, --ref <ref>', 'Git branch or tag to document (e.g., dev, v26.2.0). Clones from GitHub.')
   .option('--from-source <path>', 'Path to local rpk source (src/go/rpk directory)')
   .option('--from-json <path>', 'Regenerate docs from an existing versioned JSON file (skips building)')
+  .option('--plugin <name>', 'Refresh a single rpk plugin\'s docs (ai, connect, k8s, check). Requires --from-json. Installs the plugin, splices its fresh subtree into the snapshot, and re-renders.')
+  .option('--plugin-version <version>', 'Plugin version to install and record (for example, 4.102.0). Defaults to the latest published version.')
+  .option('--rpk-bin <path>', 'Path to an existing rpk binary for the plugin refresh (skips download/build)')
   .option('--overrides <path>', 'Path to overrides JSON file', 'docs-data/rpk-overrides.json')
   .option('--diff <oldVersion>', 'Generate diff against previous version')
   .option('--update-whats-new [path]', 'Update what\'s-new file with rpk changes from diff (default: modules/get-started/pages/release-notes/redpanda.adoc)')
@@ -1124,6 +1127,12 @@ automation
     try {
       const { handleRpkDocsGeneration } = require('../tools/rpk-docs/rpk-docs-handler.js')
 
+      if (options.plugin && !options.fromJson) {
+        console.error('Error: --plugin requires --from-json <snapshot>')
+        console.error('A plugin refresh splices the fresh subtree into an existing committed snapshot.')
+        process.exit(1)
+      }
+
       // Handle --update-whats-new with optional path
       let whatsNewPath = null
       if (options.updateWhatsNew !== undefined) {
@@ -1137,6 +1146,9 @@ automation
         ref: options.ref,
         fromSource: options.fromSource,
         fromJson: options.fromJson,
+        plugin: options.plugin,
+        pluginVersion: options.pluginVersion,
+        rpkBin: options.rpkBin,
         overrides: options.overrides,
         diff: options.diff,
         updateWhatsNew: whatsNewPath,
@@ -1150,6 +1162,10 @@ automation
       })
 
       if (result.success) {
+        if (result.skipped) {
+          console.log(`\n✓ Skipped: ${result.reason}`)
+          process.exit(0)
+        }
         console.log('\n✓ rpk documentation generated successfully')
 
         // Write PR summary to file if requested (useful for GitHub Actions)

--- a/docs-data/rpk-overrides.schema.json
+++ b/docs-data/rpk-overrides.schema.json
@@ -36,6 +36,10 @@
                 "description": "Regular expression flags. Default: 'g' (global). Common: 'gi' (global, case-insensitive)",
                 "default": "g",
                 "pattern": "^[gimsuvy]*$"
+              },
+              "applyToCode": {
+                "type": "boolean",
+                "description": "Also apply this replacement inside code blocks captured from help text (verbatim command examples). Default false: code blocks are protected from prose transformations. Use for binary-name rewrites like rpai to rpk ai."
               }
             },
             "required": ["pattern", "replacement"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.2.5",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.2.5",
+      "version": "5.3.0",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.2.5",
+  "version": "5.3.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/rpk-docs/generate-plugin-stubs.js
+++ b/tools/rpk-docs/generate-plugin-stubs.js
@@ -60,10 +60,12 @@ function readPartialTitles(partialsDir) {
  * @param {string} params.plugin - Plugin command name (e.g. ai)
  * @returns {string} Local path to the partials directory
  */
-function fetchPartialsDir({ docsRepo, docsRef, plugin }) {
+function fetchPartialsDir({ docsRepo, docsRef, plugin, sourcePath }) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-stubs-'))
   const repoDir = path.join(tmpDir, 'docs')
-  const sparsePath = `modules/reference/partials/rpk-${plugin}`
+  // ai and cloud content renders as partials; connect renders as pages —
+  // both carry the single-source tag, so either family can be stubbed
+  const sparsePath = sourcePath || `modules/reference/partials/rpk-${plugin}`
 
   console.log(`Fetching ${sparsePath} from ${docsRepo}@${docsRef}...`)
   const cloneResult = spawnSync('git', [
@@ -101,7 +103,7 @@ function inferIncludePrefix(stubDir, plugin) {
   for (const file of fs.readdirSync(stubDir)) {
     if (!file.endsWith('.adoc')) continue
     const content = fs.readFileSync(path.join(stubDir, file), 'utf8')
-    const match = content.match(new RegExp(`include::([^\\[]*partial\\$rpk-${plugin}/)`))
+    const match = content.match(new RegExp(`include::([^\\[]*(?:partial|page)\\$[^\\[]*rpk-${plugin}/)`))
     if (match) return match[1]
   }
   return null
@@ -147,7 +149,7 @@ function reconcileStubs({
   attributes = [':page-preview: true'],
   dryRun = false
 }) {
-  const managedStubRe = new RegExp(`include::[^\\[]*partial\\$rpk-${plugin}/([\\w.-]+\\.adoc)\\[`)
+  const managedStubRe = new RegExp(`include::[^\\[]*(?:partial|page)\\$[^\\[]*rpk-${plugin}/([\\w.-]+\\.adoc)\\[`)
   const partialByFile = new Map(partials.map(p => [p.file, p]))
 
   fs.mkdirSync(stubDir, { recursive: true })

--- a/tools/rpk-docs/generate-plugin-stubs.js
+++ b/tools/rpk-docs/generate-plugin-stubs.js
@@ -158,6 +158,23 @@ function reconcileStubs({
   const created = []
   const deleted = []
   const keptNonStub = []
+  const skippedAliasTargets = []
+
+  // Page names already claimed as aliases by other pages in this directory.
+  // Creating a page whose resource ID is an alias target makes the Antora
+  // build fatal ("Page alias cannot reference an existing page"), which
+  // happens when a rename alias exists here while the upstream partial for
+  // the old name still lingers. Skip those creations and surface them.
+  const aliasClaims = new Map()
+  for (const file of existingStubs) {
+    const content = fs.readFileSync(path.join(stubDir, file), 'utf8')
+    const aliasLine = content.match(/^:page-aliases:\s*(.+)$/m)
+    if (!aliasLine) continue
+    for (const target of aliasLine[1].split(',')) {
+      const base = target.trim().split('/').pop()
+      if (base) aliasClaims.set(base, file)
+    }
+  }
 
   // Delete managed stubs whose partial no longer exists. Pages that do not
   // match the managed-stub shape are never deleted: they may be hand-written.
@@ -184,6 +201,10 @@ function reconcileStubs({
   )
   for (const partial of partials) {
     if (remainingStubs.has(partial.file)) continue
+    if (aliasClaims.has(partial.file)) {
+      skippedAliasTargets.push({ file: partial.file, claimedBy: aliasClaims.get(partial.file) })
+      continue
+    }
     if (!dryRun) {
       fs.writeFileSync(
         path.join(stubDir, partial.file),
@@ -235,8 +256,10 @@ function reconcileStubs({
         end++
       }
 
+      const skippedFiles = new Set(skippedAliasTargets.map(t => t.file))
       const entries = []
       for (const partial of partials) {
+        if (skippedFiles.has(partial.file)) continue
         const words = partial.title.split(' ').length
         if (words <= 2) continue // the parent line represents the root command
         const stars = '*'.repeat(parentStars + (words - 2))
@@ -256,7 +279,7 @@ function reconcileStubs({
     }
   }
 
-  return { created, deleted, keptNonStub, navUpdated, renameCandidates }
+  return { created, deleted, keptNonStub, navUpdated, renameCandidates, skippedAliasTargets }
 }
 
 module.exports = {

--- a/tools/rpk-docs/generate-plugin-stubs.js
+++ b/tools/rpk-docs/generate-plugin-stubs.js
@@ -1,0 +1,266 @@
+'use strict'
+
+/**
+ * Stub reconciler for consumer repos that publish rpk plugin docs through
+ * single-source stubs (adp-docs for rpk ai).
+ *
+ * The docs repo owns the generated partials; consumer repos own one static
+ * stub page per command plus a nav entry. When a plugin release adds or
+ * removes commands, the stubs drift: a new partial has no stub (command
+ * invisible on the consumer site) and a deleted partial leaves a stub with an
+ * unresolved include (broken page). This module reconciles the stub set
+ * against the current partials rather than applying a diff, so it also heals
+ * pre-existing drift and is idempotent.
+ */
+
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+const { spawnSync } = require('child_process')
+
+/**
+ * Read command titles from generated partials. The title line is
+ * authoritative: dashified filenames cannot be reversed unambiguously
+ * (rpk-ai-llm-provider could be `llm provider` or `llm-provider`).
+ * @param {string} partialsDir - Directory of generated .adoc partials
+ * @returns {Array<{file: string, title: string}>} Sorted by command path
+ */
+function readPartialTitles(partialsDir) {
+  const partials = []
+  for (const file of fs.readdirSync(partialsDir)) {
+    if (!file.endsWith('.adoc')) continue
+    const content = fs.readFileSync(path.join(partialsDir, file), 'utf8')
+    const match = content.match(/^= (.+)$/m)
+    if (!match) {
+      console.warn(`Warning: no title line in ${file}; skipping`)
+      continue
+    }
+    partials.push({ file, title: match[1].trim() })
+  }
+  // Hierarchical order: sort by command words so parents precede children
+  partials.sort((a, b) => {
+    const aw = a.title.split(' ')
+    const bw = b.title.split(' ')
+    for (let i = 0; i < Math.max(aw.length, bw.length); i++) {
+      if (aw[i] === bw[i]) continue
+      if (aw[i] === undefined) return -1
+      if (bw[i] === undefined) return 1
+      return aw[i] < bw[i] ? -1 : 1
+    }
+    return 0
+  })
+  return partials
+}
+
+/**
+ * Sparse-clone the docs repo and return the path to a plugin's partials dir.
+ * @param {Object} params
+ * @param {string} params.docsRepo - owner/repo (e.g. redpanda-data/docs)
+ * @param {string} params.docsRef - Branch or tag to read (e.g. main)
+ * @param {string} params.plugin - Plugin command name (e.g. ai)
+ * @returns {string} Local path to the partials directory
+ */
+function fetchPartialsDir({ docsRepo, docsRef, plugin }) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-stubs-'))
+  const repoDir = path.join(tmpDir, 'docs')
+  const sparsePath = `modules/reference/partials/rpk-${plugin}`
+
+  console.log(`Fetching ${sparsePath} from ${docsRepo}@${docsRef}...`)
+  const cloneResult = spawnSync('git', [
+    'clone', '--depth', '1', '--filter=blob:none', '--sparse',
+    '--branch', docsRef,
+    `https://github.com/${docsRepo}.git`, repoDir
+  ], { encoding: 'utf8', timeout: 180000 })
+  if (cloneResult.status !== 0) {
+    throw new Error(`Failed to clone ${docsRepo}@${docsRef}: ${cloneResult.stderr}`)
+  }
+
+  const sparseResult = spawnSync('git', ['sparse-checkout', 'set', sparsePath], {
+    cwd: repoDir, encoding: 'utf8', timeout: 60000
+  })
+  if (sparseResult.status !== 0) {
+    throw new Error(`Failed sparse checkout of ${sparsePath}: ${sparseResult.stderr}`)
+  }
+
+  const partialsDir = path.join(repoDir, sparsePath)
+  if (!fs.existsSync(partialsDir)) {
+    throw new Error(`Partials directory not found in ${docsRepo}@${docsRef}: ${sparsePath}`)
+  }
+  return partialsDir
+}
+
+/**
+ * Infer the include prefix from an existing managed stub, so the reconciler
+ * follows whatever component/module coordinates the consumer repo uses.
+ * @param {string} stubDir - Consumer repo stub directory
+ * @param {string} plugin - Plugin command name
+ * @returns {string|null} e.g. "streaming:reference:partial$rpk-ai/"
+ */
+function inferIncludePrefix(stubDir, plugin) {
+  if (!fs.existsSync(stubDir)) return null
+  for (const file of fs.readdirSync(stubDir)) {
+    if (!file.endsWith('.adoc')) continue
+    const content = fs.readFileSync(path.join(stubDir, file), 'utf8')
+    const match = content.match(new RegExp(`include::([^\\[]*partial\\$rpk-${plugin}/)`))
+    if (match) return match[1]
+  }
+  return null
+}
+
+/**
+ * Render a stub page.
+ * @param {Object} params
+ * @param {string} params.title - Command path (e.g. "rpk ai auth login")
+ * @param {string} params.file - Partial filename
+ * @param {string} params.includePrefix - Antora resource prefix
+ * @param {Array<string>} params.attributes - Page attribute lines
+ * @returns {string}
+ */
+function renderStub({ title, file, includePrefix, attributes }) {
+  const lines = [`= ${title}`]
+  for (const attr of attributes) lines.push(attr)
+  lines.push('')
+  lines.push(`include::${includePrefix}${file}[tag=single-source]`)
+  lines.push('')
+  return lines.join('\n')
+}
+
+/**
+ * Reconcile a consumer repo's stub pages and nav section against the
+ * current set of generated partials.
+ * @param {Object} params
+ * @param {Array<{file: string, title: string}>} params.partials
+ * @param {string} params.stubDir - Consumer stub directory (created if missing)
+ * @param {string} params.navFile - Consumer nav.adoc path
+ * @param {string} params.plugin - Plugin command name (e.g. ai)
+ * @param {string} params.includePrefix - Antora resource prefix for includes
+ * @param {Array<string>} [params.attributes] - Page attributes for new stubs
+ * @param {boolean} [params.dryRun]
+ * @returns {Object} { created, deleted, keptNonStub, navUpdated, renameCandidates }
+ */
+function reconcileStubs({
+  partials,
+  stubDir,
+  navFile,
+  plugin,
+  includePrefix,
+  attributes = [':page-preview: true'],
+  dryRun = false
+}) {
+  const managedStubRe = new RegExp(`include::[^\\[]*partial\\$rpk-${plugin}/([\\w.-]+\\.adoc)\\[`)
+  const partialByFile = new Map(partials.map(p => [p.file, p]))
+
+  fs.mkdirSync(stubDir, { recursive: true })
+  const existingStubs = fs.readdirSync(stubDir).filter(f => f.endsWith('.adoc'))
+
+  const created = []
+  const deleted = []
+  const keptNonStub = []
+
+  // Delete managed stubs whose partial no longer exists. Pages that do not
+  // match the managed-stub shape are never deleted: they may be hand-written.
+  const deletedTitles = new Map()
+  for (const file of existingStubs) {
+    const stubPath = path.join(stubDir, file)
+    const content = fs.readFileSync(stubPath, 'utf8')
+    const match = content.match(managedStubRe)
+    if (!match) {
+      if (!partialByFile.has(file)) keptNonStub.push(file)
+      continue
+    }
+    if (!partialByFile.has(match[1])) {
+      const titleMatch = content.match(/^= (.+)$/m)
+      deletedTitles.set(file, titleMatch ? titleMatch[1].trim() : '')
+      if (!dryRun) fs.unlinkSync(stubPath)
+      deleted.push(file)
+    }
+  }
+
+  // Create stubs for partials that have none
+  const remainingStubs = new Set(
+    fs.existsSync(stubDir) ? fs.readdirSync(stubDir).filter(f => f.endsWith('.adoc')) : []
+  )
+  for (const partial of partials) {
+    if (remainingStubs.has(partial.file)) continue
+    if (!dryRun) {
+      fs.writeFileSync(
+        path.join(stubDir, partial.file),
+        renderStub({ ...partial, includePrefix, attributes }),
+        'utf8'
+      )
+    }
+    created.push(partial.file)
+  }
+
+  // Rename candidates: same parent command, same depth, related last words
+  // (llm -> llm-provider). Proposed for the reviewer, who decides whether
+  // the new stub gets a page alias.
+  const renameCandidates = []
+  for (const [dFile, dTitle] of deletedTitles) {
+    if (!dTitle) continue
+    const dWords = dTitle.split(' ')
+    for (const cFile of created) {
+      const cTitle = (partialByFile.get(cFile) || {}).title || ''
+      const cWords = cTitle.split(' ')
+      if (cWords.length !== dWords.length) continue
+      if (cWords.slice(0, -1).join(' ') !== dWords.slice(0, -1).join(' ')) continue
+      const dLast = dWords[dWords.length - 1]
+      const cLast = cWords[cWords.length - 1]
+      if (cLast.startsWith(dLast) || dLast.startsWith(cLast)) {
+        renameCandidates.push({ deleted: dFile, created: cFile })
+      }
+    }
+  }
+
+  // Rebuild the plugin's nav block: keep the labeled parent line, regenerate
+  // child entries from titles at star depth = parent depth + (words - 2)
+  let navUpdated = false
+  if (navFile && fs.existsSync(navFile)) {
+    const navLines = fs.readFileSync(navFile, 'utf8').split('\n')
+    const parentRe = new RegExp(`^(\\*+) xref:[^\\[]*rpk-${plugin}/rpk-${plugin}\\.adoc\\[`)
+    const parentIdx = navLines.findIndex(l => parentRe.test(l))
+    if (parentIdx === -1) {
+      console.warn(`Warning: no rpk-${plugin} parent entry found in ${navFile}; nav not updated`)
+    } else {
+      const parentStars = navLines[parentIdx].match(parentRe)[1].length
+      const navPathPrefix = navLines[parentIdx].match(/xref:([^\[]*rpk-\w+\/)/)[1]
+
+      // The block ends at the first line that is not a deeper entry
+      let end = parentIdx + 1
+      while (end < navLines.length) {
+        const starMatch = navLines[end].match(/^(\*+) /)
+        if (!starMatch || starMatch[1].length <= parentStars) break
+        end++
+      }
+
+      const entries = []
+      for (const partial of partials) {
+        const words = partial.title.split(' ').length
+        if (words <= 2) continue // the parent line represents the root command
+        const stars = '*'.repeat(parentStars + (words - 2))
+        entries.push(`${stars} xref:${navPathPrefix}${partial.file}[]`)
+      }
+
+      const rebuilt = [
+        ...navLines.slice(0, parentIdx + 1),
+        ...entries,
+        ...navLines.slice(end)
+      ].join('\n')
+
+      if (rebuilt !== navLines.join('\n')) {
+        if (!dryRun) fs.writeFileSync(navFile, rebuilt, 'utf8')
+        navUpdated = true
+      }
+    }
+  }
+
+  return { created, deleted, keptNonStub, navUpdated, renameCandidates }
+}
+
+module.exports = {
+  readPartialTitles,
+  fetchPartialsDir,
+  inferIncludePrefix,
+  renderStub,
+  reconcileStubs
+}

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -805,11 +805,21 @@ function convertIndentedCodeBlocksToAsciiDoc(text, codeBlockStore = []) {
 
     // Colon-introduced code sample: prose ending with ":" followed by an
     // indented block that is not a list (Cedar policies, config snippets).
+    // Deeply indented (4+ space) blocks are literals by help-text convention
+    // even without a colon introducer (path templates like
+    // "    kafka/{topic}/{partition}_{revision}/" would otherwise render as
+    // prose whose braces Asciidoctor eats as attribute references).
     // Captured verbatim (dedented) so inline-code transforms never touch it.
     const prevNonBlank = [...result].reverse().find(l => l.trim() !== '')
+    // Only a chunk that starts after a blank line is a standalone literal;
+    // a deeply indented line mid-chunk is a wrapped continuation of a table
+    // row or list item and belongs to the converters below.
+    const atChunkStart = result.length === 0 || result[result.length - 1].trim() === ''
     if (
-      prevNonBlank && /:\s*$/.test(prevNonBlank) &&
-      /^[ ]{2,}\S/.test(line) &&
+      (
+        (prevNonBlank && /:\s*$/.test(prevNonBlank) && /^[ ]{2,}\S/.test(line)) ||
+        (atChunkStart && /^[ ]{4,}\S/.test(line))
+      ) &&
       !/^[ ]{2,}(-|\*|\d+[.)])\s/.test(line) &&
       !/^[ ]{2,}(--|rpk\s|\$\s)/.test(line)
     ) {
@@ -1682,6 +1692,16 @@ function formatDescription(desc, customTransformations = null, options = {}) {
   // Pattern: #NNNN (4+ digits) when not inside backticks or code
   // e.g., "(see #2904)" → "(see https://github.com/redpanda-data/redpanda/issues/2904[#2904])"
   result = result.replace(/(?<![`\w])#(\d{4,})(?![`\w])/g, 'https://github.com/redpanda-data/redpanda/issues/$1[#$1]')
+
+  // Escape template placeholders like {name} in prose: Asciidoctor would
+  // consume them as attribute references and drop them from the output.
+  // Backtick spans can hold raw code at this stage, so only prose segments
+  // between spans are touched. {vbar} stays: it is a real attribute used to
+  // escape pipes in table cells.
+  result = result.split(/(`[^`]*`)/).map((segment, idx) =>
+    idx % 2 === 1 ? segment : segment.replace(/(?<![\\`\w{]){([a-z][\w-]{0,30})}/g, (match, token) =>
+      token === 'vbar' ? match : `\\{${token}}`)
+  ).join('')
 
   // Restore early code blocks FIRST (from indented command/YAML detection)
   // This must happen before inline code restoration so that placeholders

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -2166,7 +2166,7 @@ const STATIC_RPK_NAV_ENTRIES = [
  * @param {Set} topLevelWithSubcommands - Set of top-level command names with subcommands
  * @returns {Object} { navUpdated, navEntriesGenerated }
  */
-function updateNavFile(navFile, commands, resolvedOverrides, topLevelWithSubcommands) {
+function updateNavFile(navFile, commands, resolvedOverrides, topLevelWithSubcommands, protectedPlugins = []) {
   if (!fs.existsSync(navFile)) {
     console.warn(`Warning: nav file not found, skipping nav update: ${navFile}`)
     return { navUpdated: false }
@@ -2212,11 +2212,28 @@ function updateNavFile(navFile, commands, resolvedOverrides, topLevelWithSubcomm
     newEntries.push(`${stars} xref:${xrefPath}[]`)
   }
 
-  // Rebuild: header + static entries + generated entries
+  // Preserve existing entries for protected plugins (their commands are
+  // absent from this run's tree, so they would otherwise be dropped).
+  const preservedEntries = []
+  if (protectedPlugins.length > 0) {
+    const patterns = protectedPlugins.map(pl => `reference:rpk/rpk-${pl}/`)
+    const regenerated = new Set(newEntries.map(e => e.replace(/^\*+ /, '')))
+    for (const line of lines.slice(sectionStart + 1, sectionEnd)) {
+      if (patterns.some(pat => line.includes(pat)) && !regenerated.has(line.replace(/^\*+ /, ''))) {
+        preservedEntries.push(line)
+      }
+    }
+    if (preservedEntries.length > 0) {
+      console.log(`  Preserving ${preservedEntries.length} nav entries for plugins: ${protectedPlugins.join(', ')}`)
+    }
+  }
+
+  // Rebuild: header + static entries + generated entries + preserved plugin entries
   const newSection = [
     lines[sectionStart],
     ...STATIC_RPK_NAV_ENTRIES,
     ...newEntries,
+    ...preservedEntries,
   ]
 
   const newLines = [
@@ -2244,7 +2261,12 @@ async function generateRpkDocs(options = {}) {
     pluginVersions = {},
     draftMissing = false,
     flatOutput = false, // If true, output all files flat (legacy behavior)
-    navFile // Optional: path to nav.adoc for automatic nav updates
+    navFile, // Optional: path to nav.adoc for automatic nav updates
+    // Plugins that exist but could not be installed for this run (for example,
+    // rpk k8s before its GA plugin publishes). Their pages and nav entries are
+    // preserved instead of treated as stale, because their absence from the
+    // command tree reflects the generation environment, not the product.
+    protectedPlugins = []
   } = options
 
   // Register partials
@@ -2681,9 +2703,35 @@ async function generateRpkDocs(options = {}) {
       .map(entry => path.join(baseDir, entry.name))
   }
 
+  // Auto-detect plugins whose commands are missing from this run's tree.
+  // rpk core ships only a shim (install/uninstall/upgrade) for managed
+  // plugins; the real commands appear only when the plugin binary is
+  // installed in the generation environment. If a known plugin's subtree is
+  // absent or shim-only, its existing pages reflect the plugin, not stale
+  // commands, so preserve them. Pre-GA windows hit this every time: the
+  // plugin publisher only promotes stable X.Y.Z releases, so `rpk <plugin>
+  // install` finds nothing until GA (see redpanda-data/docs#1831).
+  const PLUGIN_SHIM_COMMANDS = new Set(['install', 'uninstall', 'upgrade'])
+  const KNOWN_PLUGIN_NAMES = ['ai', 'check', 'connect', 'k8s', 'oxla']
+  const autoProtected = KNOWN_PLUGIN_NAMES.filter(pl => {
+    const subNames = commands
+      .filter(c => c.path.startsWith(`rpk ${pl} `))
+      .map(c => c.path.split(' ')[2])
+    const hasTopLevel = commands.some(c => c.path === `rpk ${pl}`)
+    if (!hasTopLevel) return true
+    return subNames.length === 0 || subNames.every(n => PLUGIN_SHIM_COMMANDS.has(n))
+  })
+  const effectiveProtectedPlugins = [...new Set([...protectedPlugins, ...autoProtected])]
+  const protectedDirNames = new Set(effectiveProtectedPlugins.map(pl => `rpk-${pl}`))
   const scanDirs = new Set()
   for (const dir of rpkSubdirs(outputDir)) scanDirs.add(dir)
   for (const dir of rpkSubdirs(cloudSecretDir)) scanDirs.add(dir)
+  for (const dir of [...scanDirs]) {
+    if (protectedDirNames.has(path.basename(dir))) {
+      console.log(`  Preserving ${path.basename(dir)}/ (plugin commands absent from this run's tree)`)
+      scanDirs.delete(dir)
+    }
+  }
 
   for (const dir of scanDirs) {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -2711,7 +2759,7 @@ async function generateRpkDocs(options = {}) {
   // Update nav.adoc if a path was provided
   let navResult = { navUpdated: false }
   if (navFile) {
-    navResult = updateNavFile(navFile, commands, resolvedOverrides, topLevelWithSubcommands)
+    navResult = updateNavFile(navFile, commands, resolvedOverrides, topLevelWithSubcommands, effectiveProtectedPlugins)
   }
 
   return {

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -1807,11 +1807,27 @@ function parseDescriptionSections(desc) {
   let currentContent = []
   const mainLines = []
 
-  for (const line of lines) {
+  let skipNext = false
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (skipNext) {
+      skipNext = false
+      continue
+    }
     // Check for ALL CAPS header (at least 2 chars, possibly with spaces, hyphens, slashes, or ampersands)
     // Examples: "FIELDS", "BALANCER STATUS", "PRODUCER ID & EPOCH"
-    const headerMatch = line.match(/^([A-Z][A-Z\s\-\/&]{0,}[A-Z])$/)
+    // A line with runs of multiple spaces is a column-header row of aligned
+    // sample output (for example "PARTITION      REASON"), not a section
+    // header, so leave it in the content.
+    const headerMatch = /  /.test(line) ? null : line.match(/^([A-Z][A-Z\s\-\/&]{0,}[A-Z])$/)
     if (headerMatch) {
+      // Help text often underlines section titles with a run of = or -
+      // characters. Consume the underline: left in the content, a line of
+      // 4+ = or - is an AsciiDoc block delimiter and breaks the page
+      // (unterminated example block).
+      if (i + 1 < lines.length && /^\s*(={3,}|-{3,})\s*$/.test(lines[i + 1])) {
+        skipNext = true
+      }
       // Save previous section
       if (currentSection) {
         // Preserve indentation: only remove leading/trailing blank lines, not spaces
@@ -1830,6 +1846,13 @@ function parseDescriptionSections(desc) {
   if (currentSection) {
     // Preserve indentation: only remove leading/trailing blank lines, not spaces
     sections[currentSection] = trimBlankLines(currentContent.join('\n'))
+  }
+
+  const delimiterRun = /^\s*(={4,}|-{4,})\s*$/
+  for (const [name, body] of Object.entries(sections)) {
+    if (body.split('\n').some(l => delimiterRun.test(l))) {
+      console.warn(`Warning: section "${name}" contains a bare =/- delimiter run; it may break AsciiDoc rendering`)
+    }
   }
 
   return {

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -2235,6 +2235,10 @@ function detectProtectedPlugins(commands, explicitProtected = []) {
  * landing page (the section header), so it is skipped during generation.
  */
 const STATIC_RPK_NAV_ENTRIES = [
+  // The root rpk command page is generated but skipped by the entry loop
+  // (its path has no group segment), so it is listed here to keep it in
+  // the nav ahead of the hand-written pages.
+  '*** xref:reference:rpk/rpk.adoc[]',
   '*** xref:reference:rpk/rpk-commands.adoc[]',
   '*** xref:reference:rpk/rpk-x-options.adoc[rpk -X]',
 ]

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -2168,6 +2168,61 @@ function findTopLevelWithSubcommands(tree) {
 }
 
 /**
+ * Known rpk plugins that are managed separately from rpk core (they have
+ * install/uninstall/upgrade shim commands, and their real command tree only
+ * appears when the plugin binary is installed in the generation environment).
+ * Shared with rpk-docs-handler.js, which iterates this list to install each
+ * plugin before running --print-tree.
+ */
+const KNOWN_PLUGINS = ['ai', 'check', 'connect', 'k8s', 'oxla']
+
+/**
+ * Subcommands that rpk core ships as a built-in shim for managed plugins,
+ * present even when the plugin binary itself is not installed.
+ */
+const PLUGIN_SHIM_COMMANDS = new Set(['install', 'uninstall', 'upgrade'])
+
+/**
+ * Check whether a command path belongs to a protected plugin's subtree
+ * (including the plugin's own top-level command).
+ * @param {string} commandPath - Full command path, e.g. 'rpk k8s multicluster'
+ * @param {Array<string>} protectedPlugins - Plugin names, e.g. ['k8s']
+ * @returns {boolean}
+ */
+function isProtectedCommandPath(commandPath, protectedPlugins) {
+  return protectedPlugins.some(pl => commandPath === `rpk ${pl}` || commandPath.startsWith(`rpk ${pl} `))
+}
+
+/**
+ * Determine which managed plugins must be protected for this run.
+ *
+ * Auto-detects plugins whose commands are missing from this run's tree:
+ * rpk core ships only a shim (install/uninstall/upgrade) for managed
+ * plugins; the real commands appear only when the plugin binary is
+ * installed in the generation environment. If a known plugin's subtree is
+ * absent or shim-only, its existing pages reflect the plugin, not stale
+ * commands, so they must be preserved. Pre-GA windows hit this every time:
+ * the plugin publisher only promotes stable X.Y.Z releases, so `rpk <plugin>
+ * install` finds nothing until GA (see redpanda-data/docs#1831).
+ *
+ * @param {Array} commands - Flat command list from flattenCommands()
+ * @param {Array<string>} explicitProtected - Plugins the caller already knows
+ *   failed to install this run (merged with auto-detection)
+ * @returns {Array<string>} Deduplicated protected plugin names
+ */
+function detectProtectedPlugins(commands, explicitProtected = []) {
+  const autoProtected = KNOWN_PLUGINS.filter(pl => {
+    const subNames = commands
+      .filter(c => c.path.startsWith(`rpk ${pl} `))
+      .map(c => c.path.split(' ')[2])
+    const hasTopLevel = commands.some(c => c.path === `rpk ${pl}`)
+    if (!hasTopLevel) return true
+    return subNames.length === 0 || subNames.every(n => PLUGIN_SHIM_COMMANDS.has(n))
+  })
+  return [...new Set([...explicitProtected, ...autoProtected])]
+}
+
+/**
  * Static entries that always appear at the top of the rpk nav section,
  * before the auto-generated command entries. These are hand-written pages
  * that are not part of the CLI command tree. The root `rpk` command is not
@@ -2220,6 +2275,10 @@ function updateNavFile(navFile, commands, resolvedOverrides, topLevelWithSubcomm
   const newEntries = []
   for (const { path: commandPath } of commands) {
     if (commandPath === 'rpk') continue
+    // Protected plugins get no generated entries: this run's tree has at
+    // most the shim (install/uninstall/upgrade) for them, so their previous
+    // nav block is preserved in place instead (below).
+    if (isProtectedCommandPath(commandPath, protectedPlugins)) continue
     if (shouldExcludeCommand(resolvedOverrides, commandPath)) continue
     if (shouldUsePartialDir(resolvedOverrides, commandPath)) continue
     if (commandPath.startsWith('rpk cloud')) continue
@@ -2235,29 +2294,65 @@ function updateNavFile(navFile, commands, resolvedOverrides, topLevelWithSubcomm
     newEntries.push(`${stars} xref:${xrefPath}[]`)
   }
 
-  // Preserve existing entries for protected plugins (their commands are
-  // absent from this run's tree, so they would otherwise be dropped).
-  const preservedEntries = []
+  // Preserve existing entries for protected plugins. Their commands are
+  // absent (or shim-only) in this run's tree, so nothing was generated for
+  // them above. Each plugin's previous nav block (parent entry plus nested
+  // children) is kept together and spliced back in at its original position,
+  // anchored to the nearest preceding entry that survives regeneration —
+  // never appended at the end, where the children would render under the
+  // wrong parent.
+  const stripStars = (line) => line.replace(/^\*+ /, '')
+  const emittedTargets = new Set([...STATIC_RPK_NAV_ENTRIES, ...newEntries].map(stripStars))
+  // Map of anchor target (or null for "before all surviving entries") to the
+  // preserved lines that follow that anchor, in original order.
+  const preservedBlocks = new Map()
+  let preservedCount = 0
+  const preservedPlugins = new Set()
   if (protectedPlugins.length > 0) {
-    const patterns = protectedPlugins.map(pl => `reference:rpk/rpk-${pl}/`)
-    const regenerated = new Set(newEntries.map(e => e.replace(/^\*+ /, '')))
+    const patternsFor = (pl) => [`reference:rpk/rpk-${pl}/`, `reference:rpk/rpk-${pl}.adoc`]
+    const pluginFor = (line) => protectedPlugins.find(pl => patternsFor(pl).some(pat => line.includes(pat)))
+    let lastAnchor = null
     for (const line of lines.slice(sectionStart + 1, sectionEnd)) {
-      if (patterns.some(pat => line.includes(pat)) && !regenerated.has(line.replace(/^\*+ /, ''))) {
-        preservedEntries.push(line)
+      const plugin = pluginFor(line)
+      if (plugin) {
+        // Never duplicate an entry that regeneration already emits.
+        if (emittedTargets.has(stripStars(line))) continue
+        if (!preservedBlocks.has(lastAnchor)) preservedBlocks.set(lastAnchor, [])
+        preservedBlocks.get(lastAnchor).push(line)
+        preservedCount++
+        preservedPlugins.add(plugin)
+      } else if (emittedTargets.has(stripStars(line))) {
+        lastAnchor = stripStars(line)
       }
     }
-    if (preservedEntries.length > 0) {
-      console.log(`  Preserving ${preservedEntries.length} nav entries for plugins: ${protectedPlugins.join(', ')}`)
+    if (preservedCount > 0) {
+      console.log(`  Preserving ${preservedCount} nav entries for plugins: ${[...preservedPlugins].join(', ')}`)
     }
   }
 
-  // Rebuild: header + static entries + generated entries + preserved plugin entries
-  const newSection = [
-    lines[sectionStart],
-    ...STATIC_RPK_NAV_ENTRIES,
-    ...newEntries,
-    ...preservedEntries,
-  ]
+  // Rebuild: header + static entries + generated entries, splicing each
+  // preserved block back in directly after its anchor entry.
+  const newSection = [lines[sectionStart]]
+  const pushEntry = (line) => {
+    newSection.push(line)
+    const target = stripStars(line)
+    if (preservedBlocks.has(target)) {
+      newSection.push(...preservedBlocks.get(target))
+      preservedBlocks.delete(target)
+    }
+  }
+  // Blocks that preceded every surviving entry in the old nav go right after
+  // the section header, before the static entries.
+  if (preservedBlocks.has(null)) {
+    newSection.push(...preservedBlocks.get(null))
+    preservedBlocks.delete(null)
+  }
+  for (const line of STATIC_RPK_NAV_ENTRIES) pushEntry(line)
+  for (const line of newEntries) pushEntry(line)
+  // Safety net: if an anchor vanished between collection and rebuild (it
+  // cannot with the logic above, but never silently drop preserved entries),
+  // append any remaining blocks at the end.
+  for (const block of preservedBlocks.values()) newSection.push(...block)
 
   const newLines = [
     ...lines.slice(0, sectionStart),
@@ -2327,6 +2422,16 @@ async function generateRpkDocs(options = {}) {
   // Flatten command tree
   const commands = flattenCommands(tree)
 
+  // Determine which managed plugins are protected this run: explicitly
+  // passed by the caller (failed installs) merged with auto-detection of
+  // absent or shim-only plugin subtrees. Protection covers the whole
+  // pipeline — page writes, the stale-file sweep, and nav updates — so a
+  // run without the plugin binary leaves the plugin's docs fully untouched.
+  const effectiveProtectedPlugins = detectProtectedPlugins(commands, protectedPlugins)
+  if (effectiveProtectedPlugins.length > 0) {
+    console.log(`  Protected plugins this run (pages and nav preserved, not regenerated): ${effectiveProtectedPlugins.join(', ')}`)
+  }
+
   // Find top-level commands with subcommands (for directory structure)
   const topLevelWithSubcommands = findTopLevelWithSubcommands(tree)
 
@@ -2344,6 +2449,18 @@ async function generateRpkDocs(options = {}) {
     // index.adoc landing page, which generation must not overwrite. The nav
     // builder skips it for the same reason (see updateNavFile).
     if (commandPath === 'rpk') {
+      filesSkipped++
+      continue
+    }
+
+    // Protected plugins: skip generating the whole subtree, parent page
+    // included. This run's tree has at most the shim
+    // (install/uninstall/upgrade) for these plugins, so regenerating would
+    // overwrite full-plugin pages from an earlier successful run — for
+    // example, rewriting rpk-k8s.adoc with a Subcommands table reduced to
+    // the shim and orphaning the preserved child pages. Existing pages stay
+    // untouched, exactly as in the fully-absent-plugin case.
+    if (isProtectedCommandPath(commandPath, effectiveProtectedPlugins)) {
       filesSkipped++
       continue
     }
@@ -2726,25 +2843,9 @@ async function generateRpkDocs(options = {}) {
       .map(entry => path.join(baseDir, entry.name))
   }
 
-  // Auto-detect plugins whose commands are missing from this run's tree.
-  // rpk core ships only a shim (install/uninstall/upgrade) for managed
-  // plugins; the real commands appear only when the plugin binary is
-  // installed in the generation environment. If a known plugin's subtree is
-  // absent or shim-only, its existing pages reflect the plugin, not stale
-  // commands, so preserve them. Pre-GA windows hit this every time: the
-  // plugin publisher only promotes stable X.Y.Z releases, so `rpk <plugin>
-  // install` finds nothing until GA (see redpanda-data/docs#1831).
-  const PLUGIN_SHIM_COMMANDS = new Set(['install', 'uninstall', 'upgrade'])
-  const KNOWN_PLUGIN_NAMES = ['ai', 'check', 'connect', 'k8s', 'oxla']
-  const autoProtected = KNOWN_PLUGIN_NAMES.filter(pl => {
-    const subNames = commands
-      .filter(c => c.path.startsWith(`rpk ${pl} `))
-      .map(c => c.path.split(' ')[2])
-    const hasTopLevel = commands.some(c => c.path === `rpk ${pl}`)
-    if (!hasTopLevel) return true
-    return subNames.length === 0 || subNames.every(n => PLUGIN_SHIM_COMMANDS.has(n))
-  })
-  const effectiveProtectedPlugins = [...new Set([...protectedPlugins, ...autoProtected])]
+  // Protected plugins (computed before the write loop, see
+  // detectProtectedPlugins): their existing pages reflect the plugin, not
+  // stale commands, so their directories are excluded from the sweep.
   const protectedDirNames = new Set(effectiveProtectedPlugins.map(pl => `rpk-${pl}`))
   const scanDirs = new Set()
   for (const dir of rpkSubdirs(outputDir)) scanDirs.add(dir)
@@ -2819,6 +2920,8 @@ module.exports = {
   shouldExcludeCommand,
   shouldUsePartialDir,
   updateNavFile,
+  KNOWN_PLUGINS,
+  detectProtectedPlugins,
   getCommandMetadata,
   processContentArray,
   // Exported for testing

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -2657,7 +2657,24 @@ async function generateRpkDocs(options = {}) {
           return `${parentPath} ${alias}`
         }),
       aliasNotes: commandOverride.aliasNotes,
-      flags: (mergedCommand.flags || []).map(flag => ({
+      // A curated override section titled "Flags" wins over the extracted
+      // flag table: rendering both produced duplicate == Flags headings and
+      // conflicting content (rpk connect run). Curation is authoritative;
+      // the warning tells maintainers the override can be dropped to adopt
+      // the extracted table.
+      flags: (() => {
+        const hasCuratedFlagsSection = Object.values(processedContent.sections || {})
+          .some(items => (items || []).some(item => /^flags$/i.test(item.title || '')))
+        if (hasCuratedFlagsSection && (mergedCommand.flags || []).length > 0) {
+          console.warn(
+            `Warning: ${commandPath} has a curated "Flags" override section; ` +
+            `skipping the extracted flag table (${mergedCommand.flags.length} flags). ` +
+            'Remove the override section to adopt the extracted table.'
+          )
+          return []
+        }
+        return mergedCommand.flags || []
+      })().map(flag => ({
         ...flag,
         name: flag.shorthand ? `-${flag.shorthand}, --${flag.name}` : `--${flag.name}`,
         type: flag.type || '-',

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -1966,8 +1966,8 @@ function dashify(commandPath) {
  */
 /**
  * Collapse runs of three or more newlines to a single blank line, except
- * inside AsciiDoc delimited blocks (----, ====, ...., |===), where blank
- * lines are content.
+ * inside AsciiDoc delimited blocks (----, ====, ...., |===, and -- open
+ * blocks), where blank lines are content.
  * @param {string} text - Rendered page content
  * @returns {string}
  */
@@ -1980,7 +1980,7 @@ function collapseBlankLines(text) {
 
   for (const line of lines) {
     const trimmed = line.trimEnd()
-    const isDelim = /^(-{4,}|={4,}|\.{4,}|\|===)$/.test(trimmed)
+    const isDelim = /^(-{4,}|={4,}|\.{4,}|\|===|--)$/.test(trimmed)
     if (isDelim) {
       if (!inBlock) {
         inBlock = true

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -1470,6 +1470,11 @@ function formatDescription(desc, customTransformations = null, options = {}) {
     // Also handles '--flag/-f', '--flag help', and similar patterns
     .replace(/'(--[a-z][-a-z0-9]*(?:\/-[a-z])?(?:\s+\w+)?)'/gi, '$1')
     .replace(/'(-[a-z])'/gi, '$1')
+    // Drop a dangling example lead-in with nothing after it (upstream help
+    // strings sometimes end mid-example, which would render as "for example,.")
+    .replace(/[,;]?\s*\be\.g\.[\s,]*$/i, '')
+    // Stray space before a closing parenthesis (upstream help typo)
+    .replace(/ +\)/g, ')')
     // === STYLE GUIDE COMPLIANCE ===
     .replace(/\be\.g\.\s*/gi, 'for example, ')
     .replace(/\bi\.e\.\s*/gi, 'that is, ')
@@ -2790,6 +2795,21 @@ async function generateRpkDocs(options = {}) {
     // the separators between skipped blocks stack up). Blank lines inside
     // delimited blocks are preserved: they are content there.
     const content = collapseBlankLines(template(context))
+
+    // Duplicate top-level headings almost always mean an override adds a
+    // section the page already renders (or embeds its own heading in raw
+    // content). The page still builds, but anchors collide and readers see
+    // the same section twice.
+    const h2Counts = new Map()
+    for (const line of content.split('\n')) {
+      const h2 = line.match(/^== (\S.*)$/)
+      if (h2) h2Counts.set(h2[1], (h2Counts.get(h2[1]) || 0) + 1)
+    }
+    for (const [heading, count] of h2Counts) {
+      if (count > 1) {
+        console.warn(`⚠️  ${commandPath}: heading "== ${heading}" appears ${count} times. Check the override content for this command.`)
+      }
+    }
 
     // Determine output path
     // Check if this command should go to cloudSecretDir

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -1941,6 +1941,45 @@ function dashify(commandPath) {
  * @param {string} desc - Full description
  * @returns {string} Short description
  */
+/**
+ * Collapse runs of three or more newlines to a single blank line, except
+ * inside AsciiDoc delimited blocks (----, ====, ...., |===), where blank
+ * lines are content.
+ * @param {string} text - Rendered page content
+ * @returns {string}
+ */
+function collapseBlankLines(text) {
+  const lines = text.split('\n')
+  const out = []
+  let inBlock = false
+  let blockDelim = null
+  let blankRun = 0
+
+  for (const line of lines) {
+    const trimmed = line.trimEnd()
+    const isDelim = /^(-{4,}|={4,}|\.{4,}|\|===)$/.test(trimmed)
+    if (isDelim) {
+      if (!inBlock) {
+        inBlock = true
+        blockDelim = trimmed
+      } else if (trimmed === blockDelim || (blockDelim === '|===' && trimmed === '|===')) {
+        inBlock = false
+        blockDelim = null
+      }
+    }
+
+    if (!inBlock && trimmed === '') {
+      blankRun++
+      if (blankRun > 1) continue
+    } else {
+      blankRun = 0
+    }
+    out.push(line)
+  }
+
+  return out.join('\n')
+}
+
 function capToTwoSentences(desc) {
   if (!desc) return ''
   if (typeof desc !== 'string') return String(desc)
@@ -1982,11 +2021,26 @@ function capToTwoSentences(desc) {
     })
   }
 
+  // Protect decimal points in version-like numbers (OAuth 2.0, HTTP 1.1) so
+  // they neither split a sentence nor cause the leading fragment to be
+  // dropped by the sentence matcher
+  normalized = normalized.replace(/(\d)\.(\d)/g, '$1__DECIMAL__$2')
+
   // Match sentences
-  const sentences = normalized.match(/[^.!?]+[.!?]+(?:\s|$)/g)
+  let sentences = normalized.match(/[^.!?]+[.!?]+(?:\s|$)/g)
+
+  // Never drop a leading fragment: if the first matched sentence does not
+  // start at the beginning of the text (an unterminated prefix was skipped),
+  // glue the prefix back onto it
+  if (sentences && sentences.length > 0) {
+    const firstIdx = normalized.indexOf(sentences[0])
+    if (firstIdx > 0) {
+      sentences = [normalized.slice(0, firstIdx) + sentences[0], ...sentences.slice(1)]
+    }
+  }
   if (!sentences || sentences.length === 0) {
     // Restore and return
-    let result = normalized
+    let result = normalized.replace(/__DECIMAL__/g, '.')
     placeholders.forEach(({ ph, original }) => {
       result = result.replace(ph, original)
     })
@@ -1997,6 +2051,9 @@ function capToTwoSentences(desc) {
   }
 
   let result = sentences.slice(0, 2).join('')
+
+  // Restore decimal points
+  result = result.replace(/__DECIMAL__/g, '.')
 
   // Restore abbreviations
   placeholders.forEach(({ ph, original }) => {
@@ -2542,8 +2599,11 @@ async function generateRpkDocs(options = {}) {
       hasUnknownSections: unknownSections.length > 0
     }
 
-    // Render template
-    const content = template(context)
+    // Render template, then collapse runs of blank lines left behind by
+    // absent optional sections (plugin commands have no aliases or flags, so
+    // the separators between skipped blocks stack up). Blank lines inside
+    // delimited blocks are preserved: they are content there.
+    const content = collapseBlankLines(template(context))
 
     // Determine output path
     // Check if this command should go to cloudSecretDir

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -1318,6 +1318,24 @@ function applyTextTransformations(text, customTransformations, options = {}) {
 }
 
 /**
+ * Apply text transformations to examples content line by line. Indented
+ * lines are verbatim commands: only rules flagged applyToCode may touch
+ * them (a caption rule once rewrote '{"quotas":...}' inside a command to
+ * '{`quotas`:...}'). Caption lines get the full rule set.
+ * @param {string} text
+ * @param {Object|null} customTransformations
+ * @returns {string}
+ */
+function applyTextTransformationsToExamples(text, customTransformations) {
+  if (!text || !customTransformations?.replacements) return text
+  return text.split('\n').map(line =>
+    /^[ ]{2,}\S/.test(line)
+      ? applyTextTransformations(line, customTransformations, { code: true })
+      : applyTextTransformations(line, customTransformations)
+  ).join('\n')
+}
+
+/**
  * Format description by adding backticks around flags and code
  * @param {string} desc - Description text
  * @param {Object} [customTransformations] - Optional custom text transformations from overrides
@@ -2593,8 +2611,9 @@ async function generateRpkDocs(options = {}) {
         if (mergedCommand.excludeExamples && mergedCommand.excludeExamples.length > 0) {
           examplesContent = filterExamples(sectionContent, mergedCommand.excludeExamples)
         }
-        // Apply text transformations (e.g. rpai → rpk ai) then format
-        examplesContent = applyTextTransformations(examplesContent, textTransformations)
+        // Apply text transformations (e.g. rpai → rpk ai) then format.
+        // Command lines only get code-safe rules.
+        examplesContent = applyTextTransformationsToExamples(examplesContent, textTransformations)
         sections[sectionName] = formatExamples(examplesContent)
       } else {
         sections[sectionName] = formatDescription(sectionContent, textTransformations)
@@ -2611,8 +2630,9 @@ async function generateRpkDocs(options = {}) {
       if (mergedCommand.excludeExamples && mergedCommand.excludeExamples.length > 0) {
         examplesContent = filterExamples(examplesContent, mergedCommand.excludeExamples)
       }
-      // Apply text transformations (e.g. rpai → rpk ai) then format
-      examplesContent = applyTextTransformations(examplesContent, textTransformations)
+      // Apply text transformations (e.g. rpai → rpk ai) then format.
+      // Command lines only get code-safe rules.
+      examplesContent = applyTextTransformationsToExamples(examplesContent, textTransformations)
       sections.EXAMPLES = formatExamples(examplesContent)
     }
 
@@ -3059,5 +3079,6 @@ module.exports = {
   processContentArray,
   // Exported for testing
   filterExamples,
-  formatExamples
+  formatExamples,
+  applyTextTransformationsToExamples
 }

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -2422,9 +2422,16 @@ async function generateRpkDocs(options = {}) {
     // Build subcommands with correct xref paths
     // Filter out excluded and asPartial subcommands — excluded have no file,
     // asPartial ones live in the partials directory with no linkable xref.
+    // rpk cloud and rpk security secret are hardcoded-routed to partials
+    // (single-sourced into cloud docs), so they have no linkable pages
+    // either: rpk-security.adoc linking rpk-security-secret.adoc was a
+    // broken xref in the published site.
     const subcommands = (command.commands || [])
       .filter(sub => {
         const subPath = `${commandPath} ${sub.name}`
+        if (subPath.startsWith('rpk cloud') || subPath.startsWith('rpk security secret')) {
+          return false
+        }
         return !shouldExcludeCommand(resolvedOverrides, subPath) && !shouldUsePartialDir(resolvedOverrides, subPath)
       })
       .map(sub => {

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -778,6 +778,66 @@ function convertIndentedCodeBlocksToAsciiDoc(text, codeBlockStore = []) {
   while (i < lines.length) {
     const line = lines[i]
 
+    // Unindented shell example: "$ rpk ..." at column 0 followed by its
+    // sample output on the contiguous lines below. Rendered as a command
+    // block plus a no-copy output block so the output's =-underlined titles
+    // and aligned columns are never parsed as prose or headings.
+    if (/^\$\s/.test(line)) {
+      const command = line.replace(/^\$\s+/, '')
+      let j = i + 1
+      const outputLines = []
+      while (j < lines.length && lines[j].trim() !== '' && !/^\$\s/.test(lines[j])) {
+        outputLines.push(lines[j])
+        j++
+      }
+      let block = `\n[,bash]\n----\n${command}\n----\n`
+      if (outputLines.length > 0) {
+        block += `\n[.no-copy]\n----\n${outputLines.join('\n')}\n----\n`
+      }
+      const placeholder = `__EARLY_CODE_BLOCK_${codeBlockStore.length}__`
+      codeBlockStore.push(block)
+      result.push('')
+      result.push(placeholder)
+      result.push('')
+      i = j
+      continue
+    }
+
+    // Colon-introduced code sample: prose ending with ":" followed by an
+    // indented block that is not a list (Cedar policies, config snippets).
+    // Captured verbatim (dedented) so inline-code transforms never touch it.
+    const prevNonBlank = [...result].reverse().find(l => l.trim() !== '')
+    if (
+      prevNonBlank && /:\s*$/.test(prevNonBlank) &&
+      /^[ ]{2,}\S/.test(line) &&
+      !/^[ ]{2,}(-|\*|\d+[.)])\s/.test(line) &&
+      !/^[ ]{2,}(--|rpk\s|\$\s)/.test(line)
+    ) {
+      const blockLines = []
+      let j = i
+      while (j < lines.length && (/^[ ]{2,}\S/.test(lines[j]) || lines[j].trim() === '')) {
+        if (lines[j].trim() === '' && (j + 1 >= lines.length || !/^[ ]{2,}\S/.test(lines[j + 1]))) break
+        blockLines.push(lines[j])
+        j++
+      }
+      // Column-aligned layouts (two or more lines with a run of spaces
+      // separating columns) are definition tables, not code: leave them for
+      // the indented-table/YAML converters below.
+      const alignedLines = blockLines.filter(l => /\S\s{2,}\S/.test(l.trim())).length
+      if (alignedLines < 2) {
+        const indent = Math.min(...blockLines.filter(l => l.trim() !== '').map(l => l.search(/\S/)))
+        const dedented = blockLines.map(l => l.slice(indent)).join('\n')
+        const codeBlock = `\n[,text]\n----\n${dedented}\n----\n`
+        const placeholder = `__EARLY_CODE_BLOCK_${codeBlockStore.length}__`
+        codeBlockStore.push(codeBlock)
+        result.push('')
+        result.push(placeholder)
+        result.push('')
+        i = j
+        continue
+      }
+    }
+
     // Check for indented command example: 2+ spaces then --, rpk, or $ (shell prompt)
     // e.g. "  --job-name test --labels ..."
     // e.g. "  rpk cluster info"
@@ -1240,10 +1300,13 @@ function convertIndentedTablesToAsciiDoc(text, options = {}) {
  * @param {Object|null} customTransformations
  * @returns {string}
  */
-function applyTextTransformations(text, customTransformations) {
+function applyTextTransformations(text, customTransformations, options = {}) {
   if (!text || !customTransformations?.replacements) return text
   let result = text
   for (const rule of customTransformations.replacements) {
+    // Code blocks are verbatim: only rules explicitly marked applyToCode
+    // (like the rpai -> rpk ai binary-name rewrite) may touch them.
+    if (options.code && !rule.applyToCode) continue
     try {
       const flags = rule.flags || 'g'
       result = result.replace(new RegExp(rule.pattern, flags), rule.replacement)
@@ -1476,8 +1539,13 @@ function formatDescription(desc, customTransformations = null, options = {}) {
     // Stray space before a closing parenthesis (upstream help typo)
     .replace(/ +\)/g, ')')
     // === STYLE GUIDE COMPLIANCE ===
-    .replace(/\be\.g\.\s*/gi, 'for example, ')
-    .replace(/\bi\.e\.\s*/gi, 'that is, ')
+    // "e.g.:" introduces a block; keep the colon instead of rendering ", :".
+    // Horizontal whitespace only: crossing a newline would glue the next
+    // line (often a code-block placeholder) onto this sentence.
+    .replace(/,?[^\S\n]*\be\.g\.:[^\S\n]*/gi, ', for example: ')
+    .replace(/, for example: $/gm, ', for example:')
+    .replace(/\be\.g\.[^\S\n]*/gi, 'for example, ')
+    .replace(/\bi\.e\.[^\S\n]*/gi, 'that is, ')
     // === TYPO CORRECTIONS ===
     // Fix "an" before consonant sounds (common source typos)
     .replace(/\ban\s+(prod|dev|test|local|remote|new|cluster|config|file)\b/gi, 'a $1')
@@ -1602,7 +1670,8 @@ function formatDescription(desc, customTransformations = null, options = {}) {
   // inside the early code blocks (like __INLINE_CODE_X__) get resolved
   // Use function replacements to prevent $ special-pattern interpretation (e.g. `$` → before-match)
   earlyCodeBlocks.forEach((block, i) => {
-    result = result.replace(`__EARLY_CODE_BLOCK_${i}__`, () => block)
+    const transformed = applyTextTransformations(block, customTransformations, { code: true })
+    result = result.replace(`__EARLY_CODE_BLOCK_${i}__`, () => transformed)
   })
 
   // Restore inline code
@@ -1824,7 +1893,17 @@ function parseDescriptionSections(desc) {
     // A line with runs of multiple spaces is a column-header row of aligned
     // sample output (for example "PARTITION      REASON"), not a section
     // header, so leave it in the content.
-    const headerMatch = /  /.test(line) ? null : line.match(/^([A-Z][A-Z\s\-\/&]{0,}[A-Z])$/)
+    let headerMatch = /  /.test(line) ? null : line.match(/^([A-Z][A-Z\s\-\/&]{0,}[A-Z])$/)
+    // An all-caps line directly after a "$ command" invocation is the title
+    // of that command's sample output (for example "DECOMMISSION PROGRESS"),
+    // not a section header. Splitting there would strand the invocation in
+    // one section and its output table in another.
+    if (headerMatch) {
+      for (let p = i - 1; p >= 0; p--) {
+        if (lines[p].trim() === '') break
+        if (/^\$\s/.test(lines[p])) { headerMatch = null; break }
+      }
+    }
     if (headerMatch) {
       // Help text often underlines section titles with a run of = or -
       // characters. Consume the underline: left in the content, a line of
@@ -2015,6 +2094,19 @@ function capToTwoSentences(desc) {
   // Remove section headers and content after them (for overrides that include full content)
   // Pattern: matches == Section Header and everything after it
   let cleaned = desc.replace(/\s*==\s+.+$/s, '')
+
+  // Delimited code/output blocks never belong in a summary. Indented help
+  // examples are converted to [,text]/[,bash]/[.no-copy] blocks before this
+  // runs. A block introduced by a colon ends the summary there (the prose
+  // after it would read as a non sequitur without the sample); otherwise
+  // drop the block and keep the surrounding prose.
+  const blockRe = /\n?\[[^\]\n]*\]\n----\n[\s\S]*?\n----|\n----\n[\s\S]*?\n----/
+  const firstBlock = cleaned.match(blockRe)
+  if (firstBlock && /:\s*$/.test(cleaned.slice(0, firstBlock.index))) {
+    cleaned = cleaned.slice(0, firstBlock.index)
+  } else {
+    cleaned = cleaned.replace(new RegExp(blockRe.source, 'g'), '')
+  }
 
   // Remove indented content (tables, lists, etc.) after colons before sentence detection
   // Pattern: text ending with colon, optionally followed by blank line, then indented content

--- a/tools/rpk-docs/helpers/index.js
+++ b/tools/rpk-docs/helpers/index.js
@@ -52,16 +52,26 @@ function shortDescription(str) {
     })
   }
 
-  const sentences = normalized.match(/[^.!?]+[.!?]+(?:\s|$)/g)
+  // Protect decimal points (OAuth 2.0) so version numbers neither split a
+  // sentence nor cause the leading fragment to be dropped
+  normalized = normalized.replace(/(\d)\.(\d)/g, '$1__DECIMAL__$2')
+
+  let sentences = normalized.match(/[^.!?]+[.!?]+(?:\s|$)/g)
   if (!sentences || sentences.length === 0) {
-    let result = normalized
+    let result = normalized.replace(/__DECIMAL__/g, '.')
     placeholders.forEach(({ ph, original }) => {
       result = result.replace(ph, original)
     })
     return result.trim()
   }
 
-  let result = sentences.slice(0, 2).join('')
+  // Never drop an unterminated leading fragment
+  const firstIdx = normalized.indexOf(sentences[0])
+  if (firstIdx > 0) {
+    sentences = [normalized.slice(0, firstIdx) + sentences[0], ...sentences.slice(1)]
+  }
+
+  let result = sentences.slice(0, 2).join('').replace(/__DECIMAL__/g, '.')
   placeholders.forEach(({ ph, original }) => {
     result = result.replace(ph, original)
   })

--- a/tools/rpk-docs/report-delta.js
+++ b/tools/rpk-docs/report-delta.js
@@ -231,6 +231,7 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
   const changedFlagRequirements = []
   const changedFlagDescriptions = []
   const descriptionChanges = []
+  const flagDataBackfilled = []
 
   for (const path of newPaths) {
     if (!oldPaths.has(path)) continue // Skip new commands
@@ -241,8 +242,19 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
     const oldFlags = getFlagsMap(oldCmd)
     const newFlagsMap = getFlagsMap(newCmd)
 
-    // Find new flags
-    for (const [flagName, flag] of newFlagsMap) {
+    // Baseline gap guard: when a pre-existing command had NO flags recorded
+    // in the old snapshot, its flags in the new snapshot are newly captured
+    // documentation (plugin flag extraction backfilling data), not newly
+    // introduced flags. Stamping them "New in <version>" would mislabel
+    // long-standing flags, so report them separately and skip the flag diff
+    // (description changes below are still detected).
+    const isFlagBackfill = oldFlags.size === 0 && newFlagsMap.size > 0
+    if (isFlagBackfill) {
+      flagDataBackfilled.push({ commandPath: path, flagCount: newFlagsMap.size })
+    }
+
+    // Find new flags (skipped entirely for backfilled commands)
+    for (const [flagName, flag] of isFlagBackfill ? [] : newFlagsMap) {
       if (!oldFlags.has(flagName)) {
         newFlags.push({
           commandPath: path,
@@ -338,7 +350,8 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
       changedFlagTypes: changedFlagTypes.length,
       changedFlagRequirements: changedFlagRequirements.length,
       changedFlagDescriptions: changedFlagDescriptions.length,
-      descriptionChanges: descriptionChanges.length
+      descriptionChanges: descriptionChanges.length,
+      flagDataBackfilled: flagDataBackfilled.length
     },
     details: {
       newCommands: newCommandsDetails,
@@ -350,7 +363,8 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
       changedFlagTypes,
       changedFlagRequirements,
       changedFlagDescriptions,
-      descriptionChanges
+      descriptionChanges,
+      flagDataBackfilled
     }
   }
 }
@@ -369,6 +383,9 @@ function printDiffReport(diff) {
   console.log(`  Deprecated commands: ${diff.summary.newlyDeprecatedCommands || 0}`)
   console.log(`  Removed commands: ${diff.summary.removedCommands}`)
   console.log(`  New flags: ${diff.summary.newFlags}`)
+  if (diff.summary.flagDataBackfilled) {
+    console.log(`  Flag documentation backfilled: ${diff.summary.flagDataBackfilled} command(s) (baseline had no flag data; not reported as new flags)`)
+  }
   console.log(`  Removed flags: ${diff.summary.removedFlags}`)
   console.log(`  Changed defaults: ${diff.summary.changedDefaults}`)
   console.log(`  Changed flag types: ${diff.summary.changedFlagTypes || 0}`)
@@ -466,6 +483,9 @@ function generateMarkdownSummary(diff) {
   lines.push(`| New flags | ${diff.summary.newFlags} |`)
   lines.push(`| Removed flags | ${diff.summary.removedFlags} |`)
   lines.push(`| Changed defaults | ${diff.summary.changedDefaults} |`)
+  if (diff.summary.flagDataBackfilled) {
+    lines.push(`| Flag docs backfilled (baseline had no flag data) | ${diff.summary.flagDataBackfilled} commands |`)
+  }
   lines.push(``)
 
   if (diff.details.newCommands.length > 0) {

--- a/tools/rpk-docs/report-delta.js
+++ b/tools/rpk-docs/report-delta.js
@@ -690,7 +690,12 @@ function generateWhatsNewSection(diff, options = {}) {
  */
 function firstSentence(str) {
   if (!str) return ''
-  const singleLine = String(str).replace(/\s*\n+\s*/g, ' ').trim()
+  // A blank line separates the summary from the long text even when the
+  // summary has no terminal period ("Install Redpanda Check\n\nThis
+  // command..."), so cut at the paragraph break before joining the
+  // hard-wrapped lines within it.
+  const firstParagraph = String(str).split(/\n\s*\n/, 1)[0]
+  const singleLine = firstParagraph.replace(/\s*\n+\s*/g, ' ').trim()
   const protectedText = singleLine.replace(/(\d)\.(\d)/g, '$1__DECIMAL__$2')
   const match = protectedText.match(/^.*?[.!?](?=\s|$)/)
   const sentence = match ? match[0] : protectedText
@@ -717,5 +722,7 @@ module.exports = {
   generateWhatsNewSection,
   flattenToMap,
   getFlagsMap,
-  compareFlags
+  compareFlags,
+  // Exported for testing
+  firstSentence
 }

--- a/tools/rpk-docs/report-delta.js
+++ b/tools/rpk-docs/report-delta.js
@@ -168,6 +168,9 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
   const newFlags = []
   const removedFlags = []
   const changedDefaults = []
+  const changedFlagTypes = []
+  const changedFlagRequirements = []
+  const changedFlagDescriptions = []
   const descriptionChanges = []
 
   for (const path of newPaths) {
@@ -222,6 +225,30 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
             newDefault: changes.default.new
           })
         }
+        if (changes.type) {
+          changedFlagTypes.push({
+            commandPath: path,
+            flagName,
+            oldType: changes.type.old,
+            newType: changes.type.new
+          })
+        }
+        if (changes.required) {
+          changedFlagRequirements.push({
+            commandPath: path,
+            flagName,
+            oldRequired: changes.required.old,
+            newRequired: changes.required.new
+          })
+        }
+        if (changes.description) {
+          changedFlagDescriptions.push({
+            commandPath: path,
+            flagName,
+            oldDescription: changes.description.old,
+            newDescription: changes.description.new
+          })
+        }
       }
     }
 
@@ -248,6 +275,9 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
       newFlags: newFlags.length,
       removedFlags: removedFlags.length,
       changedDefaults: changedDefaults.length,
+      changedFlagTypes: changedFlagTypes.length,
+      changedFlagRequirements: changedFlagRequirements.length,
+      changedFlagDescriptions: changedFlagDescriptions.length,
       descriptionChanges: descriptionChanges.length
     },
     details: {
@@ -256,6 +286,9 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
       newFlags,
       removedFlags,
       changedDefaults,
+      changedFlagTypes,
+      changedFlagRequirements,
+      changedFlagDescriptions,
       descriptionChanges
     }
   }
@@ -272,11 +305,14 @@ function printDiffReport(diff) {
 
   console.log('Summary:')
   console.log(`  New commands: ${diff.summary.newCommands}`)
-  console.log(`  Deprecated commands: ${diff.summary.removedCommands}`)
+  console.log(`  Removed commands: ${diff.summary.removedCommands}`)
   console.log(`  New flags: ${diff.summary.newFlags}`)
-  console.log(`  Deprecated flags: ${diff.summary.removedFlags}`)
+  console.log(`  Removed flags: ${diff.summary.removedFlags}`)
   console.log(`  Changed defaults: ${diff.summary.changedDefaults}`)
-  console.log(`  Description changes: ${diff.summary.descriptionChanges}`)
+  console.log(`  Changed flag types: ${diff.summary.changedFlagTypes || 0}`)
+  console.log(`  Changed flag requirements: ${diff.summary.changedFlagRequirements || 0}`)
+  console.log(`  Changed flag descriptions: ${diff.summary.changedFlagDescriptions || 0}`)
+  console.log(`  Command description changes: ${diff.summary.descriptionChanges}`)
 
   if (diff.details.newCommands.length > 0) {
     console.log('\nNew Commands:')
@@ -290,7 +326,7 @@ function printDiffReport(diff) {
   }
 
   if (diff.details.removedCommands.length > 0) {
-    console.log('\nDeprecated Commands (no longer in command tree):')
+    console.log('\nRemoved Commands (no longer in command tree):')
     for (const cmd of diff.details.removedCommands) {
       console.log(`  ⚠ ${cmd.path}`)
     }
@@ -304,7 +340,7 @@ function printDiffReport(diff) {
   }
 
   if (diff.details.removedFlags.length > 0) {
-    console.log('\nDeprecated Flags (no longer in command tree):')
+    console.log('\nRemoved Flags (no longer in command tree):')
     for (const flag of diff.details.removedFlags) {
       console.log(`  ⚠ ${flag.commandPath} --${flag.flagName}`)
     }
@@ -315,6 +351,20 @@ function printDiffReport(diff) {
     for (const change of diff.details.changedDefaults) {
       console.log(`  ~ ${change.commandPath} --${change.flagName}`)
       console.log(`      ${JSON.stringify(change.oldDefault)} → ${JSON.stringify(change.newDefault)}`)
+    }
+  }
+
+  if ((diff.details.changedFlagTypes || []).length > 0) {
+    console.log('\nChanged Flag Types:')
+    for (const change of diff.details.changedFlagTypes) {
+      console.log(`  ~ ${change.commandPath} --${change.flagName}: ${change.oldType} → ${change.newType}`)
+    }
+  }
+
+  if ((diff.details.changedFlagRequirements || []).length > 0) {
+    console.log('\nChanged Flag Requirements:')
+    for (const change of diff.details.changedFlagRequirements) {
+      console.log(`  ~ ${change.commandPath} --${change.flagName}: required ${change.oldRequired} → ${change.newRequired}`)
     }
   }
 
@@ -339,9 +389,9 @@ function generateMarkdownSummary(diff) {
   lines.push(`| Category | Count |`)
   lines.push(`|----------|-------|`)
   lines.push(`| New commands | ${diff.summary.newCommands} |`)
-  lines.push(`| Deprecated commands | ${diff.summary.removedCommands} |`)
+  lines.push(`| Removed commands | ${diff.summary.removedCommands} |`)
   lines.push(`| New flags | ${diff.summary.newFlags} |`)
-  lines.push(`| Deprecated flags | ${diff.summary.removedFlags} |`)
+  lines.push(`| Removed flags | ${diff.summary.removedFlags} |`)
   lines.push(`| Changed defaults | ${diff.summary.changedDefaults} |`)
   lines.push(``)
 
@@ -355,9 +405,9 @@ function generateMarkdownSummary(diff) {
   }
 
   if (diff.details.removedCommands.length > 0) {
-    lines.push(`### Deprecated Commands`)
+    lines.push(`### Removed Commands`)
     lines.push(``)
-    lines.push(`> Commands no longer in the active command tree. These may still work but are deprecated.`)
+    lines.push(`> Commands no longer in the active command tree.`)
     lines.push(``)
     for (const cmd of diff.details.removedCommands) {
       lines.push(`- ~~\`${cmd.path}\`~~`)
@@ -414,10 +464,14 @@ function generateWhatsNewSection(diff, options = {}) {
 
   // Check if there are any changes worth documenting
   const hasNewCommands = diff.details.newCommands.length > 0
+  const hasRemovedCommands = diff.details.removedCommands.length > 0
   const hasNewFlags = diff.details.newFlags.length > 0
+  const hasRemovedFlags = diff.details.removedFlags.length > 0
   const hasChangedDefaults = diff.details.changedDefaults.length > 0
+  const hasChangedFlagTypes = (diff.details.changedFlagTypes || []).length > 0
 
-  if (!hasNewCommands && !hasNewFlags && !hasChangedDefaults) {
+  if (!hasNewCommands && !hasRemovedCommands && !hasNewFlags &&
+      !hasRemovedFlags && !hasChangedDefaults && !hasChangedFlagTypes) {
     return '' // No changes to document
   }
 
@@ -460,12 +514,64 @@ function generateWhatsNewSection(diff, options = {}) {
     lines.push(``)
     for (const change of diff.details.changedDefaults) {
       const xrefPath = commandPathToXref(change.commandPath)
-      lines.push(`* xref:reference:rpk/${xrefPath}[\`${change.commandPath}\`]: \`--${change.flagName}\` default changed from \`${change.oldDefault}\` to \`${change.newDefault}\``)
+      const oldVal = formatFlagValue(change.oldDefault)
+      const newVal = formatFlagValue(change.newDefault)
+      lines.push(`* xref:reference:rpk/${xrefPath}[\`${change.commandPath}\`]: \`--${change.flagName}\` default changed from \`${oldVal}\` to \`${newVal}\``)
+    }
+    lines.push(``)
+  }
+
+  if (hasChangedFlagTypes) {
+    lines.push(`=== Changed flag types`)
+    lines.push(``)
+    for (const change of diff.details.changedFlagTypes) {
+      const xrefPath = commandPathToXref(change.commandPath)
+      lines.push(`* xref:reference:rpk/${xrefPath}[\`${change.commandPath}\`]: \`--${change.flagName}\` type changed from \`${change.oldType}\` to \`${change.newType}\``)
+    }
+    lines.push(``)
+  }
+
+  if (hasRemovedCommands) {
+    lines.push(`=== Removed commands`)
+    lines.push(``)
+    for (const cmd of diff.details.removedCommands) {
+      lines.push(`* \`${cmd.path}\``)
+    }
+    lines.push(``)
+  }
+
+  if (hasRemovedFlags) {
+    lines.push(`=== Removed flags`)
+    lines.push(``)
+    const removedByCommand = {}
+    for (const flag of diff.details.removedFlags) {
+      if (!removedByCommand[flag.commandPath]) {
+        removedByCommand[flag.commandPath] = []
+      }
+      removedByCommand[flag.commandPath].push(flag)
+    }
+    for (const [cmdPath, flags] of Object.entries(removedByCommand)) {
+      const xrefPath = commandPathToXref(cmdPath)
+      const flagList = flags.map(f => `\`--${f.flagName}\``).join(', ')
+      lines.push(`* xref:reference:rpk/${xrefPath}[\`${cmdPath}\`]: Removed ${flagList}`)
     }
     lines.push(``)
   }
 
   return lines.join('\n')
+}
+
+/**
+ * Render a flag value for display. Objects and arrays are JSON-encoded so
+ * they never render as [object Object].
+ * @param {*} value - Flag default value
+ * @returns {string}
+ */
+function formatFlagValue(value) {
+  if (value === undefined) return 'unset'
+  if (value === null) return 'null'
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
 }
 
 module.exports = {

--- a/tools/rpk-docs/report-delta.js
+++ b/tools/rpk-docs/report-delta.js
@@ -132,7 +132,14 @@ function compareFlags(oldFlag, newFlag) {
  * @returns {Object} Diff report
  */
 function generateRpkDiff(oldTree, newTree, options = {}) {
-  const { oldVersion = 'old', newVersion = 'new' } = options
+  const {
+    oldVersion = 'old',
+    newVersion = 'new',
+    // deprecated_commands maps from the snapshots (path -> metadata), as
+    // produced by scan-deprecated-commands.js
+    oldDeprecatedCommands = {},
+    newDeprecatedCommands = {}
+  } = options
 
   const oldCommands = flattenToMap(oldTree)
   const newCommands = flattenToMap(newTree)
@@ -152,17 +159,47 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
     }
   })
 
-  // Find removed commands
+  // Newly deprecated commands: in the new snapshot's deprecation map but not
+  // the old one. Detected by source scanning, because deprecated commands
+  // that are also hidden never appear in --print-tree output.
+  const newlyDeprecatedDetails = Object.entries(newDeprecatedCommands)
+    .filter(([path]) => !oldDeprecatedCommands[path])
+    .map(([path, info]) => ({
+      path,
+      message: info.deprecatedMessage || '',
+      replacement: info.replacement || '',
+      hidden: info.hidden === true || /Hidden:\s*true/.test(info._note || ''),
+      deprecatedInVersion: newVersion
+    }))
+
+  // Find removed commands, then separate genuine removals from commands that
+  // disappeared from the tree because they (or an ancestor) were deprecated
+  // and hidden — those still work as aliases and should be reported as
+  // deprecations, not removals.
+  const deprecatedRoots = newlyDeprecatedDetails.map(d => d.path)
+  const isUnderNewlyDeprecated = (p) =>
+    deprecatedRoots.some(root => p === root || p.startsWith(root + ' '))
+
   const removedCommandPaths = [...oldPaths].filter(p => !newPaths.has(p))
-  const removedCommandsDetails = removedCommandPaths.map(path => {
+  const removedCommandsDetails = []
+  for (const path of removedCommandPaths) {
+    if (isUnderNewlyDeprecated(path)) {
+      const root = deprecatedRoots.find(r => path === r || path.startsWith(r + ' '))
+      const entry = newlyDeprecatedDetails.find(d => d.path === root)
+      if (path !== root) {
+        entry.affectedSubcommands = entry.affectedSubcommands || []
+        entry.affectedSubcommands.push(path)
+      }
+      continue
+    }
     const cmd = oldCommands.get(path)
-    return {
+    removedCommandsDetails.push({
       path,
       name: cmd.name,
       description: cmd.description || '',
       removedInVersion: newVersion
-    }
-  })
+    })
+  }
 
   // Find flag changes in existing commands
   const newFlags = []
@@ -271,6 +308,7 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
     },
     summary: {
       newCommands: newCommandsDetails.length,
+      newlyDeprecatedCommands: newlyDeprecatedDetails.length,
       removedCommands: removedCommandsDetails.length,
       newFlags: newFlags.length,
       removedFlags: removedFlags.length,
@@ -282,6 +320,7 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
     },
     details: {
       newCommands: newCommandsDetails,
+      newlyDeprecatedCommands: newlyDeprecatedDetails,
       removedCommands: removedCommandsDetails,
       newFlags,
       removedFlags,
@@ -305,6 +344,7 @@ function printDiffReport(diff) {
 
   console.log('Summary:')
   console.log(`  New commands: ${diff.summary.newCommands}`)
+  console.log(`  Deprecated commands: ${diff.summary.newlyDeprecatedCommands || 0}`)
   console.log(`  Removed commands: ${diff.summary.removedCommands}`)
   console.log(`  New flags: ${diff.summary.newFlags}`)
   console.log(`  Removed flags: ${diff.summary.removedFlags}`)
@@ -321,6 +361,17 @@ function printDiffReport(diff) {
       if (cmd.description) {
         const shortDesc = cmd.description.split('\n')[0].substring(0, 60)
         console.log(`      ${shortDesc}${cmd.description.length > 60 ? '...' : ''}`)
+      }
+    }
+  }
+
+  if ((diff.details.newlyDeprecatedCommands || []).length > 0) {
+    console.log('\nDeprecated Commands (still work, hidden or discouraged):')
+    for (const cmd of diff.details.newlyDeprecatedCommands) {
+      console.log(`  ⚠ ${cmd.path}${cmd.hidden ? ' (hidden)' : ''}`)
+      if (cmd.message) console.log(`      ${cmd.message}`)
+      if ((cmd.affectedSubcommands || []).length > 0) {
+        console.log(`      affects ${cmd.affectedSubcommands.length} subcommand(s)`)
       }
     }
   }
@@ -464,14 +515,15 @@ function generateWhatsNewSection(diff, options = {}) {
 
   // Check if there are any changes worth documenting
   const hasNewCommands = diff.details.newCommands.length > 0
+  const hasDeprecatedCommands = (diff.details.newlyDeprecatedCommands || []).length > 0
   const hasRemovedCommands = diff.details.removedCommands.length > 0
   const hasNewFlags = diff.details.newFlags.length > 0
   const hasRemovedFlags = diff.details.removedFlags.length > 0
   const hasChangedDefaults = diff.details.changedDefaults.length > 0
   const hasChangedFlagTypes = (diff.details.changedFlagTypes || []).length > 0
 
-  if (!hasNewCommands && !hasRemovedCommands && !hasNewFlags &&
-      !hasRemovedFlags && !hasChangedDefaults && !hasChangedFlagTypes) {
+  if (!hasNewCommands && !hasDeprecatedCommands && !hasRemovedCommands &&
+      !hasNewFlags && !hasRemovedFlags && !hasChangedDefaults && !hasChangedFlagTypes) {
     return '' // No changes to document
   }
 
@@ -527,6 +579,25 @@ function generateWhatsNewSection(diff, options = {}) {
     for (const change of diff.details.changedFlagTypes) {
       const xrefPath = commandPathToXref(change.commandPath)
       lines.push(`* xref:reference:rpk/${xrefPath}[\`${change.commandPath}\`]: \`--${change.flagName}\` type changed from \`${change.oldType}\` to \`${change.newType}\``)
+    }
+    lines.push(``)
+  }
+
+  if (hasDeprecatedCommands) {
+    lines.push(`=== Deprecated commands`)
+    lines.push(``)
+    for (const cmd of diff.details.newlyDeprecatedCommands) {
+      let entry = `* \`${cmd.path}\``
+      if (cmd.replacement) {
+        entry += `: ${cmd.replacement}`
+      } else if (cmd.message) {
+        entry += `: ${cmd.message}`
+      }
+      lines.push(entry)
+      if ((cmd.affectedSubcommands || []).length > 0) {
+        lines.push(`+`)
+        lines.push(`Includes its subcommands: ${cmd.affectedSubcommands.map(s => `\`${s}\``).join(', ')}.`)
+      }
     }
     lines.push(``)
   }

--- a/tools/rpk-docs/report-delta.js
+++ b/tools/rpk-docs/report-delta.js
@@ -233,6 +233,22 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
   const descriptionChanges = []
   const flagDataBackfilled = []
 
+  // Baseline gap detection: plugin subtrees captured before flag extraction
+  // existed record no flags on any of their own commands (the install/
+  // uninstall/upgrade shims are rpk-native and do carry flags). Flag
+  // "additions" inside such a group are newly captured documentation, not
+  // newly introduced flags, and stamping them "New in <version>" would
+  // mislabel long-standing flags. Core groups have baseline flag data, so a
+  // zero-flag command there that gains a flag is a genuine addition.
+  const groupsWithBaselineFlagData = new Set()
+  for (const [path, cmd] of oldCommands) {
+    const parts = path.split(' ')
+    if (parts.length < 2) continue
+    // "rpk <plugin> install|uninstall|upgrade" shims are rpk-native
+    if (parts.length === 3 && /^(install|uninstall|upgrade)$/.test(parts[2])) continue
+    if ((cmd.flags || []).length > 0) groupsWithBaselineFlagData.add(parts[1])
+  }
+
   for (const path of newPaths) {
     if (!oldPaths.has(path)) continue // Skip new commands
 
@@ -242,13 +258,10 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
     const oldFlags = getFlagsMap(oldCmd)
     const newFlagsMap = getFlagsMap(newCmd)
 
-    // Baseline gap guard: when a pre-existing command had NO flags recorded
-    // in the old snapshot, its flags in the new snapshot are newly captured
-    // documentation (plugin flag extraction backfilling data), not newly
-    // introduced flags. Stamping them "New in <version>" would mislabel
-    // long-standing flags, so report them separately and skip the flag diff
-    // (description changes below are still detected).
-    const isFlagBackfill = oldFlags.size === 0 && newFlagsMap.size > 0
+    const topLevel = path.split(' ')[1]
+    const isFlagBackfill = topLevel !== undefined &&
+      !groupsWithBaselineFlagData.has(topLevel) &&
+      oldFlags.size === 0 && newFlagsMap.size > 0
     if (isFlagBackfill) {
       flagDataBackfilled.push({ commandPath: path, flagCount: newFlagsMap.size })
     }

--- a/tools/rpk-docs/report-delta.js
+++ b/tools/rpk-docs/report-delta.js
@@ -546,9 +546,19 @@ function generateWhatsNewSection(diff, options = {}) {
   const sectionHeading = options.sectionHeading || '== Redpanda CLI'
   const blockLabel = options.blockLabel || null
   const h = blockLabel ? '====' : '==='
+  // Command groups (two-part commands with subcommands) render into their own
+  // directory: rpk check -> rpk-check/rpk-check.adoc, not rpk-check.adoc
+  const hasSubcommands = typeof options.hasSubcommands === 'function'
+    ? options.hasSubcommands
+    : () => false
   const cmdRef = (commandPath) => {
     if (!useXrefs || !linkable(commandPath)) return `\`${commandPath}\``
-    return `xref:reference:rpk/${commandPathToXref(commandPath)}[\`${commandPath}\`]`
+    let xrefPath = commandPathToXref(commandPath)
+    if (commandPath.split(' ').length === 2 && hasSubcommands(commandPath)) {
+      const dashified = commandPath.replace(/ /g, '-')
+      xrefPath = `${dashified}/${dashified}.adoc`
+    }
+    return `xref:reference:rpk/${xrefPath}[\`${commandPath}\`]`
   }
 
   // Check if there are any changes worth documenting
@@ -576,8 +586,7 @@ function generateWhatsNewSection(diff, options = {}) {
     lines.push(`${h} New commands`)
     lines.push(``)
     for (const cmd of diff.details.newCommands) {
-      // First line only: multi-line help text would break the bullet list
-      const shortDesc = (cmd.description || '').split('\n')[0].trim()
+      const shortDesc = firstSentence(cmd.description || '')
       const desc = shortDesc ? ` - ${shortDesc}` : ''
       lines.push(`* ${cmdRef(cmd.path)}${desc}`)
     }
@@ -669,6 +678,23 @@ function generateWhatsNewSection(diff, options = {}) {
   }
 
   return lines.join('\n')
+}
+
+/**
+ * Extract the first sentence of a description for a one-line bullet.
+ * Newlines are collapsed first (cobra help wraps mid-sentence), and decimal
+ * points in version numbers do not end a sentence. Falls back to the whole
+ * collapsed text when no sentence boundary exists.
+ * @param {string} str - Command description
+ * @returns {string}
+ */
+function firstSentence(str) {
+  if (!str) return ''
+  const singleLine = String(str).replace(/\s*\n+\s*/g, ' ').trim()
+  const protectedText = singleLine.replace(/(\d)\.(\d)/g, '$1__DECIMAL__$2')
+  const match = protectedText.match(/^.*?[.!?](?=\s|$)/)
+  const sentence = match ? match[0] : protectedText
+  return sentence.replace(/__DECIMAL__/g, '.').trim()
 }
 
 /**

--- a/tools/rpk-docs/report-delta.js
+++ b/tools/rpk-docs/report-delta.js
@@ -162,7 +162,7 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
   // Newly deprecated commands: in the new snapshot's deprecation map but not
   // the old one. Detected by source scanning, because deprecated commands
   // that are also hidden never appear in --print-tree output.
-  const newlyDeprecatedDetails = Object.entries(newDeprecatedCommands)
+  const newlyDeprecatedRaw = Object.entries(newDeprecatedCommands)
     .filter(([path]) => !oldDeprecatedCommands[path])
     .map(([path, info]) => ({
       path,
@@ -171,6 +171,22 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
       hidden: info.hidden === true || /Hidden:\s*true/.test(info._note || ''),
       deprecatedInVersion: newVersion
     }))
+
+  // Roll deprecated subcommands up into their nearest deprecated ancestor:
+  // one entry for `rpk redpanda admin` with its subcommands listed reads
+  // better than a dozen sibling entries
+  const newlyDeprecatedDetails = newlyDeprecatedRaw.filter(d =>
+    !newlyDeprecatedRaw.some(other => other !== d && d.path.startsWith(other.path + ' ')))
+  for (const child of newlyDeprecatedRaw) {
+    if (newlyDeprecatedDetails.includes(child)) continue
+    const root = newlyDeprecatedDetails.find(r => child.path.startsWith(r.path + ' '))
+    if (root) {
+      root.affectedSubcommands = root.affectedSubcommands || []
+      if (!root.affectedSubcommands.includes(child.path)) {
+        root.affectedSubcommands.push(child.path)
+      }
+    }
+  }
 
   // Find removed commands, then separate genuine removals from commands that
   // disappeared from the tree because they (or an ancestor) were deprecated
@@ -188,7 +204,9 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
       const entry = newlyDeprecatedDetails.find(d => d.path === root)
       if (path !== root) {
         entry.affectedSubcommands = entry.affectedSubcommands || []
-        entry.affectedSubcommands.push(path)
+        if (!entry.affectedSubcommands.includes(path)) {
+          entry.affectedSubcommands.push(path)
+        }
       }
       continue
     }
@@ -199,6 +217,10 @@ function generateRpkDiff(oldTree, newTree, options = {}) {
       description: cmd.description || '',
       removedInVersion: newVersion
     })
+  }
+
+  for (const dep of newlyDeprecatedDetails) {
+    if (dep.affectedSubcommands) dep.affectedSubcommands.sort()
   }
 
   // Find flag changes in existing commands
@@ -512,6 +534,15 @@ function commandPathToXref(commandPath) {
 function generateWhatsNewSection(diff, options = {}) {
   const lines = []
   const version = options.version || diff.comparison.newVersion
+  // Plugin subtrees may render as partials with no linkable pages, so plugin
+  // runs disable xrefs and render plain command names instead.
+  const useXrefs = options.xrefs !== false
+  // Commands that render as partials or are excluded have no linkable page
+  const linkable = typeof options.linkable === 'function' ? options.linkable : () => true
+  const cmdRef = (commandPath) => {
+    if (!useXrefs || !linkable(commandPath)) return `\`${commandPath}\``
+    return `xref:reference:rpk/${commandPathToXref(commandPath)}[\`${commandPath}\`]`
+  }
 
   // Check if there are any changes worth documenting
   const hasNewCommands = diff.details.newCommands.length > 0
@@ -534,9 +565,10 @@ function generateWhatsNewSection(diff, options = {}) {
     lines.push(`=== New commands`)
     lines.push(``)
     for (const cmd of diff.details.newCommands) {
-      const xrefPath = commandPathToXref(cmd.path)
-      const desc = cmd.description ? ` - ${cmd.description}` : ''
-      lines.push(`* xref:reference:rpk/${xrefPath}[\`${cmd.path}\`]${desc}`)
+      // First line only: multi-line help text would break the bullet list
+      const shortDesc = (cmd.description || '').split('\n')[0].trim()
+      const desc = shortDesc ? ` - ${shortDesc}` : ''
+      lines.push(`* ${cmdRef(cmd.path)}${desc}`)
     }
     lines.push(``)
   }
@@ -554,9 +586,8 @@ function generateWhatsNewSection(diff, options = {}) {
     }
 
     for (const [cmdPath, flags] of Object.entries(flagsByCommand)) {
-      const xrefPath = commandPathToXref(cmdPath)
       const flagList = flags.map(f => `\`--${f.flagName}\``).join(', ')
-      lines.push(`* xref:reference:rpk/${xrefPath}[\`${cmdPath}\`]: Added ${flagList}`)
+      lines.push(`* ${cmdRef(cmdPath)}: Added ${flagList}`)
     }
     lines.push(``)
   }
@@ -565,10 +596,9 @@ function generateWhatsNewSection(diff, options = {}) {
     lines.push(`=== Changed defaults`)
     lines.push(``)
     for (const change of diff.details.changedDefaults) {
-      const xrefPath = commandPathToXref(change.commandPath)
       const oldVal = formatFlagValue(change.oldDefault)
       const newVal = formatFlagValue(change.newDefault)
-      lines.push(`* xref:reference:rpk/${xrefPath}[\`${change.commandPath}\`]: \`--${change.flagName}\` default changed from \`${oldVal}\` to \`${newVal}\``)
+      lines.push(`* ${cmdRef(change.commandPath)}: \`--${change.flagName}\` default changed from \`${oldVal}\` to \`${newVal}\``)
     }
     lines.push(``)
   }
@@ -577,8 +607,7 @@ function generateWhatsNewSection(diff, options = {}) {
     lines.push(`=== Changed flag types`)
     lines.push(``)
     for (const change of diff.details.changedFlagTypes) {
-      const xrefPath = commandPathToXref(change.commandPath)
-      lines.push(`* xref:reference:rpk/${xrefPath}[\`${change.commandPath}\`]: \`--${change.flagName}\` type changed from \`${change.oldType}\` to \`${change.newType}\``)
+      lines.push(`* ${cmdRef(change.commandPath)}: \`--${change.flagName}\` type changed from \`${change.oldType}\` to \`${change.newType}\``)
     }
     lines.push(``)
   }
@@ -622,9 +651,8 @@ function generateWhatsNewSection(diff, options = {}) {
       removedByCommand[flag.commandPath].push(flag)
     }
     for (const [cmdPath, flags] of Object.entries(removedByCommand)) {
-      const xrefPath = commandPathToXref(cmdPath)
       const flagList = flags.map(f => `\`--${f.flagName}\``).join(', ')
-      lines.push(`* xref:reference:rpk/${xrefPath}[\`${cmdPath}\`]: Removed ${flagList}`)
+      lines.push(`* ${cmdRef(cmdPath)}: Removed ${flagList}`)
     }
     lines.push(``)
   }

--- a/tools/rpk-docs/report-delta.js
+++ b/tools/rpk-docs/report-delta.js
@@ -539,6 +539,13 @@ function generateWhatsNewSection(diff, options = {}) {
   const useXrefs = options.xrefs !== false
   // Commands that render as partials or are excluded have no linkable page
   const linkable = typeof options.linkable === 'function' ? options.linkable : () => true
+  // Section heading for the page ("== Redpanda CLI" for core rpk changes,
+  // "== rpk plugins" for plugin releases). When blockLabel is set, the block
+  // opens with a "=== <label>" heading and category headings nest one level
+  // deeper, so accumulated blocks never produce colliding section ids.
+  const sectionHeading = options.sectionHeading || '== Redpanda CLI'
+  const blockLabel = options.blockLabel || null
+  const h = blockLabel ? '====' : '==='
   const cmdRef = (commandPath) => {
     if (!useXrefs || !linkable(commandPath)) return `\`${commandPath}\``
     return `xref:reference:rpk/${commandPathToXref(commandPath)}[\`${commandPath}\`]`
@@ -558,11 +565,15 @@ function generateWhatsNewSection(diff, options = {}) {
     return '' // No changes to document
   }
 
-  lines.push(`== Redpanda CLI`)
+  lines.push(sectionHeading)
   lines.push(``)
+  if (blockLabel) {
+    lines.push(`=== ${blockLabel}`)
+    lines.push(``)
+  }
 
   if (hasNewCommands) {
-    lines.push(`=== New commands`)
+    lines.push(`${h} New commands`)
     lines.push(``)
     for (const cmd of diff.details.newCommands) {
       // First line only: multi-line help text would break the bullet list
@@ -574,7 +585,7 @@ function generateWhatsNewSection(diff, options = {}) {
   }
 
   if (hasNewFlags) {
-    lines.push(`=== New flags`)
+    lines.push(`${h} New flags`)
     lines.push(``)
     // Group flags by command
     const flagsByCommand = {}
@@ -593,7 +604,7 @@ function generateWhatsNewSection(diff, options = {}) {
   }
 
   if (hasChangedDefaults) {
-    lines.push(`=== Changed defaults`)
+    lines.push(`${h} Changed defaults`)
     lines.push(``)
     for (const change of diff.details.changedDefaults) {
       const oldVal = formatFlagValue(change.oldDefault)
@@ -604,7 +615,7 @@ function generateWhatsNewSection(diff, options = {}) {
   }
 
   if (hasChangedFlagTypes) {
-    lines.push(`=== Changed flag types`)
+    lines.push(`${h} Changed flag types`)
     lines.push(``)
     for (const change of diff.details.changedFlagTypes) {
       lines.push(`* ${cmdRef(change.commandPath)}: \`--${change.flagName}\` type changed from \`${change.oldType}\` to \`${change.newType}\``)
@@ -613,7 +624,7 @@ function generateWhatsNewSection(diff, options = {}) {
   }
 
   if (hasDeprecatedCommands) {
-    lines.push(`=== Deprecated commands`)
+    lines.push(`${h} Deprecated commands`)
     lines.push(``)
     for (const cmd of diff.details.newlyDeprecatedCommands) {
       let entry = `* \`${cmd.path}\``
@@ -632,7 +643,7 @@ function generateWhatsNewSection(diff, options = {}) {
   }
 
   if (hasRemovedCommands) {
-    lines.push(`=== Removed commands`)
+    lines.push(`${h} Removed commands`)
     lines.push(``)
     for (const cmd of diff.details.removedCommands) {
       lines.push(`* \`${cmd.path}\``)
@@ -641,7 +652,7 @@ function generateWhatsNewSection(diff, options = {}) {
   }
 
   if (hasRemovedFlags) {
-    lines.push(`=== Removed flags`)
+    lines.push(`${h} Removed flags`)
     lines.push(``)
     const removedByCommand = {}
     for (const flag of diff.details.removedFlags) {

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -1093,7 +1093,14 @@ function makeLinkablePredicate(overridesData) {
 }
 
 function updateWhatsNewFile(diffData, whatsNewPath, version, options = {}) {
-  const whatsNewContent = generateWhatsNewSection(diffData, { version, ...options })
+  // Each block opens with a "=== <version>" heading so accumulated blocks
+  // (successive RCs, multiple plugin releases) never collide on section ids
+  const sectionHeading = options.sectionHeading || '== Redpanda CLI'
+  const whatsNewContent = generateWhatsNewSection(diffData, {
+    version,
+    blockLabel: version,
+    ...options
+  })
 
   if (!whatsNewContent) {
     console.log('No Redpanda CLI changes to add to what\'s new')
@@ -1117,7 +1124,7 @@ function updateWhatsNewFile(diffData, whatsNewPath, version, options = {}) {
   // its own markers for the same version label.
   const startMarker = `// AUTOGEN-RPK-CHANGES ${version} START`
   const endMarker = `// AUTOGEN-RPK-CHANGES ${version} END`
-  const sectionBody = whatsNewContent.replace(/^== Redpanda CLI[^\n]*\n+/, '')
+  const sectionBody = whatsNewContent.replace(/^== [^\n]*\n+/, '')
   const block = `${startMarker}\n${sectionBody.trimEnd()}\n${endMarker}`
   const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
@@ -1130,7 +1137,7 @@ function updateWhatsNewFile(diffData, whatsNewPath, version, options = {}) {
     return
   }
 
-  const headingMatch = existingContent.match(/^== Redpanda CLI[^\n]*$/m)
+  const headingMatch = existingContent.match(new RegExp(`^${escapeRe(sectionHeading)}[^\\n]*$`, 'm'))
   if (headingMatch) {
     // Append this version's block at the end of the existing section, just
     // before the next level-2 heading (or end of file)
@@ -1141,7 +1148,7 @@ function updateWhatsNewFile(diffData, whatsNewPath, version, options = {}) {
     const before = existingContent.slice(0, insertAt).replace(/\s*$/, '\n\n')
     const after = existingContent.slice(insertAt).replace(/^\n*/, '\n')
     fs.writeFileSync(whatsNewPath, `${before}${block}${after}`, 'utf8')
-    console.log(`Appended ${version} block to the Redpanda CLI section in: ${whatsNewPath}`)
+    console.log(`Appended ${version} block to the "${sectionHeading}" section in: ${whatsNewPath}`)
     return
   }
 
@@ -1163,7 +1170,7 @@ function updateWhatsNewFile(diffData, whatsNewPath, version, options = {}) {
     }
   }
 
-  const fullSection = `== Redpanda CLI\n\n${block}\n`
+  const fullSection = `${sectionHeading}\n\n${block}\n`
 
   let updatedContent
   if (insertIndex > 0) {
@@ -1177,7 +1184,7 @@ function updateWhatsNewFile(diffData, whatsNewPath, version, options = {}) {
   }
 
   fs.writeFileSync(whatsNewPath, updatedContent, 'utf8')
-  console.log(`Created Redpanda CLI section in what's-new file: ${whatsNewPath}`)
+  console.log(`Created "${sectionHeading}" section in what's-new file: ${whatsNewPath}`)
 }
 
 /**
@@ -1692,7 +1699,7 @@ async function handleRpkDocsGeneration(options = {}) {
           const label = resolvedVersion
             ? `${plugin} plugin ${resolvedVersion}`
             : `${plugin} plugin`
-          updateWhatsNewFile(pluginDiffData, whatsNewPath, label, { xrefs: false })
+          updateWhatsNewFile(pluginDiffData, whatsNewPath, label, { xrefs: false, sectionHeading: '== rpk plugins' })
         }
       }
 

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -874,7 +874,7 @@ function loadOverrides(overridesPath, commandTree = null, options = {}) {
     )
   }
 
-  return overrides
+  return { overrides, validation }
 }
 
 /**
@@ -1420,7 +1420,37 @@ function acquireRpkBinary(rpkVersion, options = {}) {
 
   const sourceRef = tag === 'vdev' ? 'dev' : tag
   const sourcePath = prepareSourceFromRef(sourceRef, null)
-  return buildRpkBinary(sourcePath, path.join(workDir, 'rpk'))
+  try {
+    return buildRpkBinary(sourcePath, path.join(workDir, 'rpk'))
+  } catch (nativeErr) {
+    // Local Go older than go.mod requires is common on laptops; the --ref
+    // path already tolerates this by building in a container, so do the same
+    // here when Docker is available
+    const dockerCheck = spawnSync('docker', ['info'], { encoding: 'utf8', timeout: 10000 })
+    if (dockerCheck.status !== 0) {
+      throw new Error(
+        `${nativeErr.message}\n` +
+        'Docker is not available for a container build either. ' +
+        'Update Go, start Docker, or pass --rpk-bin <path> to use an existing rpk binary.'
+      )
+    }
+    console.warn(`Native build failed (${nativeErr.message.split('\n')[0]}); building in a container...`)
+    const goVersion = getRequiredGoVersion(sourcePath)
+    const goImage = goVersion ? `golang:${goVersion}` : 'golang:1'
+    const buildResult = spawnSync('docker', [
+      'run', '--rm',
+      '-v', `${path.resolve(sourcePath)}:/rpk-source:ro`,
+      '-v', `${workDir}:/out`,
+      '-w', '/rpk-source',
+      goImage,
+      'go', 'build', '-o', '/out/rpk', './cmd/rpk'
+    ], { encoding: 'utf8', timeout: 600000 })
+    const binPath = path.join(workDir, 'rpk')
+    if (buildResult.status !== 0 || !fs.existsSync(binPath)) {
+      throw new Error(`Container build failed: ${buildResult.stderr || 'no binary produced'}`)
+    }
+    return binPath
+  }
 }
 
 /**
@@ -1513,6 +1543,7 @@ function parseCobraFlags(helpText) {
   if (start === -1) return []
 
   const flags = []
+  let flagIndent = null
   for (let i = start + 1; i < lines.length; i++) {
     const line = lines[i]
     if (/^\S/.test(line)) break // next section (Global Flags:, Use "...", ...)
@@ -1522,6 +1553,7 @@ function parseCobraFlags(helpText) {
     if (m) {
       const [, shorthand, name, valueType, desc] = m
       if (name === 'help') continue
+      flagIndent = line.search(/\S/)
       const flag = {
         name,
         type: valueType || 'bool',
@@ -1534,8 +1566,12 @@ function parseCobraFlags(helpText) {
         flag.description = flag.description.slice(0, def.index).trim()
       }
       flags.push(flag)
-    } else if (flags.length > 0 && /^\s{4,}\S/.test(line) && !line.trim().startsWith('-')) {
-      // Wrapped description continuation
+    } else if (flags.length > 0 && flagIndent !== null && line.search(/\S/) > flagIndent) {
+      // Wrapped description continuation: any line indented deeper than the
+      // flag column that did not parse as a flag. Continuations can begin
+      // with flag-looking tokens ("(alias: --x-ref)" wraps to "--x-ref)"),
+      // so no dash guard — a genuine flag line always matches the regex
+      // above first.
       const last = flags[flags.length - 1]
       last.description = `${last.description} ${line.trim()}`.trim()
       const def = last.description.match(/\s*\(default (.+)\)$/)
@@ -1564,6 +1600,7 @@ function parseUrfaveFlags(helpText) {
   if (start === -1) return []
 
   const flags = []
+  let urfaveIndent = null
   for (let i = start + 1; i < lines.length; i++) {
     const line = lines[i]
     if (/^\S/.test(line)) break // next section (GLOBAL OPTIONS:, ...)
@@ -1576,6 +1613,7 @@ function parseUrfaveFlags(helpText) {
       if (!nameMatch) continue
       const name = nameMatch[1]
       if (name === 'help') continue
+      urfaveIndent = line.search(/\S/)
 
       const flag = { name, description: desc.trim() }
       const shorthandMatch = spec.match(/,\s+-(\w)\b/)
@@ -1591,7 +1629,9 @@ function parseUrfaveFlags(helpText) {
         flag.description = flag.description.slice(0, def.index).trim()
       }
       flags.push(flag)
-    } else if (flags.length > 0 && /^\s{4,}\S/.test(line) && !line.trim().startsWith('-')) {
+    } else if (flags.length > 0 && urfaveIndent !== null && line.search(/\S/) > urfaveIndent) {
+      // Continuation lines may begin with flag-looking tokens; see the
+      // cobra parser above for why there is no dash guard
       const last = flags[flags.length - 1]
       last.description = `${last.description} ${line.trim()}`.trim()
       const def = last.description.match(/\s*\(default:\s*(.+?)\)$/)
@@ -1972,7 +2012,7 @@ async function handleRpkDocsGeneration(options = {}) {
       // Load and validate overrides
       const defaultOverridesPath = path.join(dataDir, 'rpk-overrides.json')
       const effectiveOverridesPath = overridesPath || defaultOverridesPath
-      const overridesData = loadOverrides(effectiveOverridesPath, tree, { strict: false })
+      const { overrides: overridesData, validation: overrideValidation } = loadOverrides(effectiveOverridesPath, tree, { strict: false }) || {}
 
       if (overridesData) {
         console.log(`Loaded overrides from ${effectiveOverridesPath}`)
@@ -2073,6 +2113,7 @@ async function handleRpkDocsGeneration(options = {}) {
         filesSkipped: result.filesSkipped,
         diffData: plugin ? pluginDiffData : diffData,
         validationResult,
+        overrideValidation,
         outputDir: finalOutputDir
       })
 
@@ -2288,7 +2329,7 @@ async function handleRpkDocsGeneration(options = {}) {
     // before the overrides load so the annotations apply to this run.
     mergeVisibleDeprecationsIntoOverrides(deprecatedCommands, tree, effectiveOverridesPath)
 
-    const overridesData = loadOverrides(effectiveOverridesPath, tree, { strict: false })
+    const { overrides: overridesData, validation: overrideValidation } = loadOverrides(effectiveOverridesPath, tree, { strict: false }) || {}
 
     if (overridesData) {
       console.log(`Loaded overrides from ${effectiveOverridesPath}`)
@@ -2392,6 +2433,7 @@ async function handleRpkDocsGeneration(options = {}) {
     // Generate PR summary
     const prSummary = generatePRSummary({
       rpkVersion,
+      overrideValidation,
       commandCount: result.commandCount,
       filesGenerated: result.filesGenerated,
       filesSkipped: result.filesSkipped,
@@ -2445,6 +2487,7 @@ function generatePRSummary(options) {
     filesSkipped = 0,
     diffData,
     validationResult,
+    overrideValidation,
     outputDir
   } = options
 
@@ -2460,8 +2503,11 @@ function generatePRSummary(options) {
     lines.push(`**Base rpk snapshot:** ${rpkVersion}`)
     lines.push('')
     lines.push(
-      `Only the \`rpk ${plugin}\` subtree was refreshed. ` +
-      'All other pages were re-rendered from the committed snapshot and are unchanged.'
+      `The \`rpk ${plugin}\` subtree was refreshed in the snapshot, then the ` +
+      'full rpk reference was re-rendered from it as a converge. Pages outside ' +
+      `\`rpk ${plugin}\` can carry template-level or consistency updates, and ` +
+      'stale generated files are cleaned up, so the change list may be wider ' +
+      'than the plugin itself.'
     )
     lines.push('')
   } else {
@@ -2567,6 +2613,22 @@ function generatePRSummary(options) {
       change => `- \`${change.commandPath}\`: \`--${change.flagName}\` required \`${change.oldRequired}\` → \`${change.newRequired}\``)
     pushDetailsList('Changed Command Descriptions', diffData.details?.descriptionChanges,
       change => `- \`${change.path}\``)
+  }
+
+  // Override validation: entries referencing commands the tree lacks do
+  // nothing silently, so surface them where they become actionable
+  if (overrideValidation && overrideValidation.errors && overrideValidation.errors.length > 0) {
+    lines.push('### Override Validation')
+    lines.push('')
+    lines.push(`⚠ ${overrideValidation.errors.length} override entr${overrideValidation.errors.length === 1 ? 'y' : 'ies'} did not apply (unknown command paths — stale entries in the overrides file):`)
+    lines.push('')
+    for (const err of overrideValidation.errors.slice(0, 10)) {
+      lines.push(`- ${typeof err === 'string' ? err : err.message || JSON.stringify(err)}`)
+    }
+    if (overrideValidation.errors.length > 10) {
+      lines.push(`- ... and ${overrideValidation.errors.length - 10} more`)
+    }
+    lines.push('')
   }
 
   // Validation results

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -8,7 +8,7 @@ const os = require('os')
 const semver = require('semver')
 const { findRepoRoot } = require('../../cli-utils/doc-tools-utils')
 const { generateRpkDocs, applyOverridesToTree, resolveReferences } = require('./generate-rpk-docs')
-const { generateRpkDiff, printDiffReport, generateWhatsNewSection } = require('./report-delta')
+const { generateRpkDiff, printDiffReport, generateWhatsNewSection, flattenToMap } = require('./report-delta')
 const { loadAndValidateOverrides, ValidationResult } = require('./validate-overrides')
 const { validateDirectory, formatResults } = require('./validate-output')
 
@@ -821,6 +821,57 @@ function loadOverrides(overridesPath, commandTree = null, options = {}) {
   }
 
   return overrides
+}
+
+/**
+ * Merge deprecation metadata for commands still present in the tree into the
+ * overrides file, so their pages render deprecation banners without manual
+ * curation. Hidden deprecated commands are excluded: they are absent from
+ * --print-tree, have no pages, and would only produce unknown-path warnings.
+ * Commands whose overrides already carry a `deprecated` value are left alone.
+ * @param {Object} deprecatedCommands - Map from scan-deprecated-commands.js
+ * @param {Object} tree - Current command tree
+ * @param {string} overridesPath - Path to overrides JSON file
+ */
+function mergeVisibleDeprecationsIntoOverrides(deprecatedCommands, tree, overridesPath) {
+  const entries = Object.entries(deprecatedCommands || {})
+  if (entries.length === 0 || !overridesPath || !fs.existsSync(overridesPath)) {
+    return
+  }
+
+  const treePaths = new Set(flattenToMap(tree).keys())
+
+  let overrides
+  try {
+    overrides = JSON.parse(fs.readFileSync(overridesPath, 'utf8'))
+  } catch (err) {
+    console.warn(`Warning: Could not parse overrides file for deprecation merge: ${err.message}`)
+    return
+  }
+  if (!overrides.commands) {
+    overrides.commands = {}
+  }
+
+  let annotated = 0
+  for (const [cmdPath, info] of entries) {
+    if (!treePaths.has(cmdPath)) continue
+    const existing = overrides.commands[cmdPath] || {}
+    if (existing.deprecated !== undefined) continue
+    overrides.commands[cmdPath] = {
+      ...existing,
+      deprecated: true,
+      ...(info.deprecatedMessage && !existing.deprecatedMessage
+        ? { deprecatedMessage: info.deprecatedMessage } : {}),
+      ...(info.replacement && !existing.replacement
+        ? { replacement: info.replacement } : {})
+    }
+    annotated++
+  }
+
+  if (annotated > 0) {
+    fs.writeFileSync(overridesPath, JSON.stringify(overrides, null, 2), 'utf8')
+    console.log(`Annotated ${annotated} visible deprecated command(s) in ${overridesPath}`)
+  }
 }
 
 /**
@@ -1655,7 +1706,9 @@ async function handleRpkDocsGeneration(options = {}) {
           const oldTree = oldData.raw_tree || oldData.tree
           diffData = generateRpkDiff(oldTree, tree, {
             oldVersion: diffVersion,
-            newVersion: rpkVersion
+            newVersion: rpkVersion,
+            oldDeprecatedCommands: oldData.deprecated_commands || {},
+            newDeprecatedCommands: jsonData.deprecated_commands || {}
           })
 
           // Save diff
@@ -1883,6 +1936,12 @@ async function handleRpkDocsGeneration(options = {}) {
     // Load and validate overrides
     const defaultOverridesPath = path.join(dataDir, 'rpk-overrides.json')
     const effectiveOverridesPath = overridesPath || defaultOverridesPath
+
+    // Annotate deprecated commands that are still visible in the tree so
+    // their pages render deprecation banners without manual curation. Runs
+    // before the overrides load so the annotations apply to this run.
+    mergeVisibleDeprecationsIntoOverrides(deprecatedCommands, tree, effectiveOverridesPath)
+
     const overridesData = loadOverrides(effectiveOverridesPath, tree, { strict: false })
 
     if (overridesData) {
@@ -1921,7 +1980,9 @@ async function handleRpkDocsGeneration(options = {}) {
         const oldTree = oldData.raw_tree || oldData.tree
         diffData = generateRpkDiff(oldTree, tree, {
           oldVersion: diffVersion,
-          newVersion: rpkVersion
+          newVersion: rpkVersion,
+          oldDeprecatedCommands: oldData.deprecated_commands || {},
+          newDeprecatedCommands: deprecatedCommands
         })
 
         // Save diff

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -1544,6 +1544,75 @@ function parseCobraFlags(helpText) {
 }
 
 /**
+ * Parse the OPTIONS section of urfave/cli --help output (Redpanda Connect)
+ * into the same flag shape as parseCobraFlags. Entries look like:
+ *   --log.level value                     override the configured log level
+ *   --set value, -s value [ --set value, -s value ]   set a field ...
+ *   --chilled                             continue ... (default: false)
+ * The GLOBAL OPTIONS section is skipped, matching the cobra handling.
+ * @param {string} helpText - Output of `rpk <command> --help`
+ * @returns {Array<Object>} Flags: { name, shorthand?, type, description, default? }
+ */
+function parseUrfaveFlags(helpText) {
+  const lines = (helpText || '').split('\n')
+  const start = lines.findIndex(l => /^OPTIONS:\s*$/.test(l))
+  if (start === -1) return []
+
+  const flags = []
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (/^\S/.test(line)) break // next section (GLOBAL OPTIONS:, ...)
+    if (line.trim() === '') break
+
+    const m = line.match(/^\s{2,}(--\S[^\s]*(?:[^ ]| (?!\s))*)\s{2,}(.*)$/)
+    if (m) {
+      const [, spec, desc] = m
+      const nameMatch = spec.match(/^--([\w.-]+)/)
+      if (!nameMatch) continue
+      const name = nameMatch[1]
+      if (name === 'help') continue
+
+      const flag = { name, description: desc.trim() }
+      const shorthandMatch = spec.match(/,\s+-(\w)\b/)
+      if (shorthandMatch) flag.shorthand = shorthandMatch[1]
+
+      const repeatable = spec.includes('[ --')
+      const hasValue = new RegExp(`^--${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s+\\S`).test(spec)
+      flag.type = repeatable ? 'strings' : (hasValue ? 'string' : 'bool')
+
+      const def = flag.description.match(/\s*\(default:\s*(.+?)\)$/)
+      if (def) {
+        flag.default = def[1]
+        flag.description = flag.description.slice(0, def.index).trim()
+      }
+      flags.push(flag)
+    } else if (flags.length > 0 && /^\s{4,}\S/.test(line) && !line.trim().startsWith('-')) {
+      const last = flags[flags.length - 1]
+      last.description = `${last.description} ${line.trim()}`.trim()
+      const def = last.description.match(/\s*\(default:\s*(.+?)\)$/)
+      if (def) {
+        last.default = def[1]
+        last.description = last.description.slice(0, def.index).trim()
+      }
+    }
+  }
+  return flags
+}
+
+/**
+ * Parse flags from --help output regardless of CLI framework: cobra prints a
+ * "Flags:" section (rpk ai, k8s, check), urfave/cli prints "OPTIONS:"
+ * (Redpanda Connect).
+ * @param {string} helpText
+ * @returns {Array<Object>}
+ */
+function parseHelpFlags(helpText) {
+  if (/^Flags:\s*$/m.test(helpText || '')) return parseCobraFlags(helpText)
+  if (/^OPTIONS:\s*$/m.test(helpText || '')) return parseUrfaveFlags(helpText)
+  return []
+}
+
+/**
  * Fill in flags for plugin subtree commands by running `--help` per command.
  * Plugin subcommand nodes come from the plugin's --help-autocomplete output,
  * which carries no flag information, so without this every plugin command
@@ -1561,7 +1630,7 @@ function enrichPluginTreeWithFlags(node, execHelp) {
     if (!cmd.flags || cmd.flags.length === 0) {
       const helpText = execHelp(argPath)
       if (helpText) {
-        const flags = parseCobraFlags(helpText)
+        const flags = parseHelpFlags(helpText)
         if (flags.length > 0) {
           cmd.flags = flags
           enriched++
@@ -2587,6 +2656,8 @@ module.exports = {
   downloadRpkRelease,
   fetchPluginSubtree,
   parseCobraFlags,
+  parseUrfaveFlags,
+  parseHelpFlags,
   mergeVisibleDeprecationsIntoOverrides,
   makeLinkablePredicate,
   enrichPluginTreeWithFlags,

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -2135,6 +2135,7 @@ async function handleRpkDocsGeneration(options = {}) {
         diffData: plugin ? pluginDiffData : diffData,
         validationResult,
         overrideValidation,
+        descriptionCoverage: computeDescriptionCoverage(tree, overridesData),
         outputDir: finalOutputDir
       })
 
@@ -2460,6 +2461,7 @@ async function handleRpkDocsGeneration(options = {}) {
       filesSkipped: result.filesSkipped,
       diffData,
       validationResult,
+      descriptionCoverage: computeDescriptionCoverage(tree, overridesData),
       outputDir: finalOutputDir
     })
 
@@ -2498,6 +2500,33 @@ async function handleRpkDocsGeneration(options = {}) {
  * @param {Object} options - Summary options
  * @returns {string} Markdown formatted summary
  */
+/**
+ * Find description overrides that replace substantially longer source help.
+ * Curation is legitimate, but silent replacement is how stale or wrong
+ * content survives regeneration, so every regen PR lists what is hidden.
+ * @param {Object} tree - Raw command tree
+ * @param {Object} overridesData - Parsed overrides
+ * @returns {Array<{commandPath: string, overrideChars: number, sourceChars: number}>}
+ */
+function computeDescriptionCoverage(tree, overridesData) {
+  if (!tree || !overridesData?.commands) return []
+  const commandMap = flattenToMap(tree)
+  const results = []
+  for (const [cmdPath, override] of Object.entries(overridesData.commands)) {
+    if (typeof override?.description !== 'string') continue
+    const cmd = commandMap.get(cmdPath)
+    if (!cmd || typeof cmd.description !== 'string') continue
+    const sourceChars = cmd.description.trim().length
+    // appendToDescription content still reaches the page, so count it
+    const appended = typeof override.appendToDescription === 'string' ? override.appendToDescription.trim().length : 0
+    const overrideChars = override.description.trim().length + appended
+    if (sourceChars - overrideChars > 500) {
+      results.push({ commandPath: cmdPath, overrideChars, sourceChars })
+    }
+  }
+  return results.sort((a, b) => (b.sourceChars - b.overrideChars) - (a.sourceChars - a.overrideChars))
+}
+
 function generatePRSummary(options) {
   const {
     rpkVersion,
@@ -2509,6 +2538,7 @@ function generatePRSummary(options) {
     diffData,
     validationResult,
     overrideValidation,
+    descriptionCoverage,
     outputDir
   } = options
 
@@ -2653,6 +2683,24 @@ function generatePRSummary(options) {
     lines.push('')
   }
 
+  // Description overrides that hide most of the source help. Curation is
+  // fine, but this is where stale content hides, so keep it reviewable.
+  if (descriptionCoverage && descriptionCoverage.length > 0) {
+    lines.push('### Curated descriptions replacing source help')
+    lines.push('')
+    lines.push('These overrides replace substantially longer help text from the rpk source. Confirm the curated version still carries every operational detail (or intentionally omits it):')
+    lines.push('')
+    lines.push('| Command | Override | Source help |')
+    lines.push('|---------|----------|-------------|')
+    for (const entry of descriptionCoverage.slice(0, 15)) {
+      lines.push(`| \`${entry.commandPath}\` | ${entry.overrideChars} chars | ${entry.sourceChars} chars |`)
+    }
+    if (descriptionCoverage.length > 15) {
+      lines.push(`| ... and ${descriptionCoverage.length - 15} more | | |`)
+    }
+    lines.push('')
+  }
+
   // Validation results
   if (validationResult) {
     lines.push('### Validation Report')
@@ -2779,6 +2827,7 @@ module.exports = {
   getPlatformDescription,
   getCurrentPlatform,
   updateOverridesWithIntroducedVersions,
+  computeDescriptionCoverage,
   updateWhatsNewFile,
   KNOWN_PLUGINS,
   extractCommandPaths,

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -2012,6 +2012,27 @@ async function handleRpkDocsGeneration(options = {}) {
       // Load and validate overrides
       const defaultOverridesPath = path.join(dataDir, 'rpk-overrides.json')
       const effectiveOverridesPath = overridesPath || defaultOverridesPath
+
+      // Stamp new commands and flags with introducedInVersion BEFORE the
+      // overrides load so this run's pages render the labels. Without this,
+      // a --from-json --diff run emits unlabeled pages and the labels only
+      // appear on the next regeneration (the from-source path stamps before
+      // rendering already).
+      if (diffVersion && !plugin) {
+        const oldDataForStamp = loadVersionedJson(diffVersion, dataDir)
+        if (oldDataForStamp) {
+          const stampDiff = generateRpkDiff(oldDataForStamp.raw_tree || oldDataForStamp.tree, tree, {
+            oldVersion: diffVersion,
+            newVersion: rpkVersion,
+            oldDeprecatedCommands: oldDataForStamp.deprecated_commands || {},
+            newDeprecatedCommands: jsonData.deprecated_commands || {}
+          })
+          if (stampDiff.details.newCommands.length > 0 || stampDiff.details.newFlags.length > 0) {
+            updateOverridesWithIntroducedVersions(stampDiff, effectiveOverridesPath, rpkVersion, pluginVersions)
+          }
+        }
+      }
+
       const { overrides: overridesData, validation: overrideValidation } = loadOverrides(effectiveOverridesPath, tree, { strict: false }) || {}
 
       if (overridesData) {
@@ -2385,7 +2406,7 @@ async function handleRpkDocsGeneration(options = {}) {
         // commands get the plugin's own version (plugins release on their own
         // cadence, so the rpk version would be wrong and the page note would
         // render "introduced in <plugin> version <rpk version>").
-        if (diffData.details.newCommands.length > 0 && effectiveOverridesPath) {
+        if ((diffData.details.newCommands.length > 0 || diffData.details.newFlags.length > 0) && effectiveOverridesPath) {
           updateOverridesWithIntroducedVersions(diffData, effectiveOverridesPath, rpkVersion, pluginVersions)
         }
 

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -856,13 +856,23 @@ function loadVersionedJson(version, dataDir) {
  * @param {Object} diffData - Diff data with new commands and flags
  * @param {string} overridesPath - Path to overrides JSON file
  * @param {string} version - Version to set as introducedInVersion
+ * @param {Object} [pluginVersions] - Plugin versions keyed by rpk command
+ *   name. Commands under a plugin subtree are stamped with the plugin's own
+ *   version (the page note renders "introduced in <plugin> version X"), not
+ *   the rpk version, because plugins release on their own cadence.
  */
-function updateOverridesWithIntroducedVersions(diffData, overridesPath, version) {
+function updateOverridesWithIntroducedVersions(diffData, overridesPath, version, pluginVersions = {}) {
   const hasNewCommands = diffData.details.newCommands && diffData.details.newCommands.length > 0
   const hasNewFlags = diffData.details.newFlags && diffData.details.newFlags.length > 0
 
   if (!hasNewCommands && !hasNewFlags) {
     return
+  }
+
+  // "rpk connect lint" -> pluginVersions.connect, else the rpk version
+  const versionFor = (cmdPath) => {
+    const topLevel = cmdPath.split(' ')[1]
+    return pluginVersions[topLevel] || version
   }
 
   let overrides = {}
@@ -891,7 +901,7 @@ function updateOverridesWithIntroducedVersions(diffData, overridesPath, version)
       }
       // Only set if not already set (preserve manual overrides)
       if (!overrides.commands[cmdPath].introducedInVersion) {
-        overrides.commands[cmdPath].introducedInVersion = version
+        overrides.commands[cmdPath].introducedInVersion = versionFor(cmdPath)
         commandsUpdated++
       }
     }
@@ -915,7 +925,7 @@ function updateOverridesWithIntroducedVersions(diffData, overridesPath, version)
 
       // Only set if not already set (preserve manual overrides)
       if (!overrides.commands[cmdPath].flags[flagName].introducedInVersion) {
-        overrides.commands[cmdPath].flags[flagName].introducedInVersion = version
+        overrides.commands[cmdPath].flags[flagName].introducedInVersion = versionFor(cmdPath)
         flagsUpdated++
       }
     }
@@ -1535,6 +1545,19 @@ async function handleRpkDocsGeneration(options = {}) {
           ` into snapshot for rpk ${rpkVersion}`
         )
 
+        // Stamp new plugin commands and flags with the plugin's own version
+        // so pages render "This command was introduced in <plugin> version X".
+        // Runs before the overrides load below, so the stamps apply to this
+        // run's rendering, not just the next one.
+        if (resolvedVersion) {
+          updateOverridesWithIntroducedVersions(
+            pluginDiffData,
+            overridesPath || path.join(dataDir, 'rpk-overrides.json'),
+            resolvedVersion,
+            { [plugin]: resolvedVersion }
+          )
+        }
+
         if (diffVersion) {
           console.warn('Note: --diff is ignored in --plugin mode (the summary uses a plugin-scoped diff)')
         }
@@ -1885,9 +1908,12 @@ async function handleRpkDocsGeneration(options = {}) {
         // Print diff report
         printDiffReport(diffData)
 
-        // Update overrides with introducedInVersion for new commands
+        // Update overrides with introducedInVersion for new commands. Plugin
+        // commands get the plugin's own version (plugins release on their own
+        // cadence, so the rpk version would be wrong and the page note would
+        // render "introduced in <plugin> version <rpk version>").
         if (diffData.details.newCommands.length > 0 && effectiveOverridesPath) {
-          updateOverridesWithIntroducedVersions(diffData, effectiveOverridesPath, rpkVersion)
+          updateOverridesWithIntroducedVersions(diffData, effectiveOverridesPath, rpkVersion, pluginVersions)
         }
 
         // Update what's-new file if requested

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -2093,24 +2093,35 @@ async function handleRpkDocsGeneration(options = {}) {
         console.log('Building rpk in Linux container...')
         const linuxTree = fetchRpkTreeFromLinuxSource(sourcePath, pluginPins)
 
-        // Build natively (on Darwin) - missing Linux-only commands
-        console.log('Building rpk natively for comparison...')
-        const darwinTree = fetchRpkTreeFromSource(sourcePath)
+        // Build natively (on Darwin) for comparison. The Linux tree is
+        // authoritative, so a comparison-build failure (for example, local
+        // Go older than go.mod requires) only skips dynamic platform
+        // detection - it must not discard the Linux tree.
+        let darwinTree = null
+        try {
+          console.log('Building rpk natively for comparison...')
+          darwinTree = fetchRpkTreeFromSource(sourcePath)
+        } catch (nativeErr) {
+          console.warn(`⚠ Native comparison build failed: ${nativeErr.message}`)
+          console.log('Skipping dynamic platform detection; using source scanning only.')
+        }
 
-        // Compare trees to find Linux-only commands
-        const dynamicLinuxOnly = detectLinuxOnlyByComparison(linuxTree, darwinTree)
-        if (dynamicLinuxOnly.size > 0) {
-          console.log(`Dynamic detection found ${dynamicLinuxOnly.size} Linux-only command(s):`)
-          for (const cmd of dynamicLinuxOnly) {
-            console.log(`  - ${cmd}`)
-            linuxOnlyCommands.add(cmd)
+        if (darwinTree) {
+          // Compare trees to find Linux-only commands
+          const dynamicLinuxOnly = detectLinuxOnlyByComparison(linuxTree, darwinTree)
+          if (dynamicLinuxOnly.size > 0) {
+            console.log(`Dynamic detection found ${dynamicLinuxOnly.size} Linux-only command(s):`)
+            for (const cmd of dynamicLinuxOnly) {
+              console.log(`  - ${cmd}`)
+              linuxOnlyCommands.add(cmd)
+            }
           }
         }
 
         // Use the Linux tree (has all commands)
         tree = linuxTree
       } catch (dockerErr) {
-        // Docker build failed (e.g., Go version mismatch) - fall back to native build
+        // Docker build failed - fall back to native build
         console.warn(`\n⚠ Docker build failed: ${dockerErr.message}`)
         console.log('Falling back to native Go build...')
         console.log('Note: Linux-only commands will be detected via source scanning only.\n')

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -487,13 +487,25 @@ function fetchRpkTreeFromLinuxSource(sourcePath, pluginPins = {}) {
   try {
     // Step 1: Build rpk binary
     console.log('Building rpk binary...')
-    const buildResult = spawnSync('docker', [
-      'exec', containerId,
-      'go', 'build', '-o', '/tmp/rpk', './cmd/rpk'
-    ], {
-      encoding: 'utf8',
-      timeout: 300000 // 5 minutes for build
-    })
+    // Module downloads from proxy.golang.org fail transiently (stream
+    // INTERNAL_ERROR), especially on a cold module cache. Retry: the second
+    // attempt reuses whatever the first already downloaded.
+    let buildResult
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      buildResult = spawnSync('docker', [
+        'exec', containerId,
+        'go', 'build', '-o', '/tmp/rpk', './cmd/rpk'
+      ], {
+        encoding: 'utf8',
+        timeout: 300000 // 5 minutes per attempt
+      })
+      if (buildResult.status === 0) break
+      if (attempt < 3) {
+        const firstError = (buildResult.stderr || buildResult.signal || 'unknown error')
+          .toString().trim().split('\n').slice(-1)[0]
+        console.warn(`  Build attempt ${attempt} failed (${firstError}); retrying...`)
+      }
+    }
 
     if (buildResult.status !== 0) {
       const stderr = buildResult.stderr || ''
@@ -503,6 +515,18 @@ function fetchRpkTreeFromLinuxSource(sourcePath, pluginPins = {}) {
         '  1. Source code is out of date - run: git pull origin dev\n' +
         '  2. Go module issues - the container will download dependencies automatically\n' +
         '  3. Insufficient Docker resources - check Docker Desktop settings'
+      )
+    }
+
+    // Trust but verify: a zero exit with no binary has been observed after
+    // Docker daemon recoveries, and everything downstream execs /tmp/rpk
+    const binCheck = spawnSync('docker', [
+      'exec', containerId, 'test', '-x', '/tmp/rpk'
+    ], { encoding: 'utf8', timeout: 15000 })
+    if (binCheck.status !== 0) {
+      throw new Error(
+        'rpk build reported success but /tmp/rpk does not exist in the ' +
+        'build container. Retry the run; if it persists, restart Docker.'
       )
     }
     console.log('  ✓ rpk binary built')

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -381,7 +381,7 @@ function fetchRpkTreeFromSource(sourcePath) {
  * @param {string} sourcePath - Path to rpk Go source directory (e.g., ~/redpanda/src/go/rpk)
  * @returns {Object} Parsed JSON tree
  */
-function fetchRpkTreeFromLinuxSource(sourcePath) {
+function fetchRpkTreeFromLinuxSource(sourcePath, pluginPins = {}) {
   // Resolve to absolute path
   const absoluteSourcePath = path.resolve(sourcePath)
 
@@ -510,14 +510,29 @@ function fetchRpkTreeFromLinuxSource(sourcePath) {
     // Step 2: Install plugins
     console.log('Installing plugins for complete command coverage...')
     for (const plugin of KNOWN_PLUGINS) {
-      console.log(`  Installing plugin: ${plugin}...`)
-      const installResult = spawnSync('docker', [
-        'exec', containerId,
-        '/tmp/rpk', plugin, 'install'
-      ], {
-        encoding: 'utf8',
-        timeout: 120000
-      })
+      // A pin installs a specific version instead of the manifest's latest.
+      // This is how pre-GA plugins (no version promoted to latest) get into a
+      // full regeneration at all — without a pin their install resolves
+      // nothing and their commands are absent from the tree.
+      const pin = pluginPins[plugin]
+      const versionFlag = PLUGIN_INSTALL_VERSION_FLAGS[plugin]
+      const runInstall = (pinned) => {
+        const args = ['exec', containerId, '/tmp/rpk', plugin, 'install']
+        if (pinned && pin && versionFlag) {
+          args.push(versionFlag, pin)
+        }
+        return spawnSync('docker', args, { encoding: 'utf8', timeout: 120000 })
+      }
+
+      console.log(`  Installing plugin: ${plugin}${pin ? ` (pinned to ${pin})` : ''}...`)
+      let installResult = runInstall(true)
+      if (installResult.status !== 0 && pin) {
+        const output = `${installResult.stderr || ''}${installResult.stdout || ''}`
+        if (output.includes('unknown flag') || output.includes('is not valid')) {
+          console.warn(`    rpk rejected the version pin for ${plugin}; retrying without the pin (installs latest)`)
+          installResult = runInstall(false)
+        }
+      }
 
       if (installResult.status === 0) {
         console.log(`    ✓ ${plugin} installed`)
@@ -530,11 +545,11 @@ function fetchRpkTreeFromLinuxSource(sourcePath) {
           console.log(`    - ${plugin} is not an installable plugin`)
         } else {
           // A failed install is non-fatal: generation continues, but this
-          // plugin's commands will be absent from the tree. Expected for `k8s`
-          // during the 26.2 beta window — `rpk k8s install` finds no `latest`
-          // release because the plugin publisher's stableVersionRe only promotes
-          // pure X.Y.Z versions, so k8s commands only appear at GA. A pre-GA
-          // regen that omits `rpk k8s` pages is this, not a generator bug.
+          // plugin's commands will be absent from the tree. Expected for
+          // beta-only plugins with no version pin — `rpk <plugin> install`
+          // finds no `latest` release because the plugin publisher's
+          // stableVersionRe only promotes pure X.Y.Z versions, so their
+          // commands only appear at GA unless the run pins a version.
           // See redpanda-data/docs#1801.
           console.warn(`    ✗ Failed to install ${plugin}: ${stderr || stdout}`)
         }
@@ -1405,6 +1420,7 @@ async function handleRpkDocsGeneration(options = {}) {
     fromJson, // Path to existing versioned JSON file to regenerate from
     plugin, // Refresh a single plugin's subtree (requires fromJson)
     pluginVersion, // Version to pin for the plugin install (defaults to latest)
+    pluginPins = {}, // Per-plugin version pins for full generation (pre-GA plugins)
     rpkBin, // Existing rpk binary to use for the plugin refresh
     ref, // Git ref (branch or tag) to document
     sourceRef, // Alias for ref
@@ -1421,6 +1437,15 @@ async function handleRpkDocsGeneration(options = {}) {
 
   // Normalize ref/sourceRef
   const effectiveRef = ref || sourceRef
+
+  for (const pinnedPlugin of Object.keys(pluginPins)) {
+    if (!REFRESHABLE_PLUGINS.includes(pinnedPlugin)) {
+      console.warn(
+        `Warning: --plugin-pin for unknown plugin '${pinnedPlugin}' ` +
+        `(known plugins: ${REFRESHABLE_PLUGINS.join(', ')}); the pin will have no effect`
+      )
+    }
+  }
 
   const repoRoot = findRepoRoot()
   const dataDir = customDataDir || path.join(repoRoot, 'docs-data')
@@ -1762,7 +1787,7 @@ async function handleRpkDocsGeneration(options = {}) {
       try {
         // Build on Linux (in container) - has all commands
         console.log('Building rpk in Linux container...')
-        const linuxTree = fetchRpkTreeFromLinuxSource(sourcePath)
+        const linuxTree = fetchRpkTreeFromLinuxSource(sourcePath, pluginPins)
 
         // Build natively (on Darwin) - missing Linux-only commands
         console.log('Building rpk natively for comparison...')
@@ -1790,7 +1815,7 @@ async function handleRpkDocsGeneration(options = {}) {
     } else if (canBuildLinux) {
       console.log('\nBuilding rpk in Linux container...')
       try {
-        tree = fetchRpkTreeFromLinuxSource(sourcePath)
+        tree = fetchRpkTreeFromLinuxSource(sourcePath, pluginPins)
       } catch (dockerErr) {
         if (canBuildNative) {
           console.warn(`\n⚠ Docker build failed: ${dockerErr.message}`)
@@ -1829,9 +1854,9 @@ async function handleRpkDocsGeneration(options = {}) {
     for (const pluginName of REFRESHABLE_PLUGINS) {
       const node = (tree.commands || []).find(c => c.name === pluginName)
       if (node && pluginNodeHasRealCommands(node)) {
-        const latestVersion = fetchLatestPluginVersion(pluginName)
-        if (latestVersion) {
-          pluginVersions[pluginName] = latestVersion
+        const installedVersion = pluginPins[pluginName] || fetchLatestPluginVersion(pluginName)
+        if (installedVersion) {
+          pluginVersions[pluginName] = installedVersion
         }
       }
     }

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -2082,52 +2082,83 @@ function generatePRSummary(options) {
     lines.push('### Changes from Previous Version')
     lines.push('')
 
-    const { newCommands, removedCommands, newFlags, removedFlags, changedDescriptions } = diffData.summary
+    const {
+      newCommands,
+      removedCommands,
+      newFlags,
+      removedFlags,
+      changedDefaults = 0,
+      changedFlagTypes = 0,
+      changedFlagRequirements = 0,
+      changedFlagDescriptions = 0,
+      descriptionChanges = 0,
+      newlyDeprecatedCommands = 0
+    } = diffData.summary
 
-    if (newCommands === 0 && removedCommands === 0 && newFlags === 0 && removedFlags === 0) {
-      lines.push('No command or flag changes detected.')
+    const totalChanges = newCommands + removedCommands + newFlags + removedFlags +
+      changedDefaults + changedFlagTypes + changedFlagRequirements +
+      changedFlagDescriptions + descriptionChanges + newlyDeprecatedCommands
+
+    if (totalChanges === 0) {
+      lines.push('No command, flag, or default changes detected.')
     } else {
       lines.push(`| Change Type | Count |`)
       lines.push(`|-------------|-------|`)
       if (newCommands > 0) lines.push(`| New commands | ${newCommands} |`)
+      if (newlyDeprecatedCommands > 0) lines.push(`| Deprecated commands | ${newlyDeprecatedCommands} |`)
       if (removedCommands > 0) lines.push(`| Removed commands | ${removedCommands} |`)
       if (newFlags > 0) lines.push(`| New flags | ${newFlags} |`)
       if (removedFlags > 0) lines.push(`| Removed flags | ${removedFlags} |`)
-      if (changedDescriptions > 0) lines.push(`| Changed descriptions | ${changedDescriptions} |`)
+      if (changedDefaults > 0) lines.push(`| Changed flag defaults | ${changedDefaults} |`)
+      if (changedFlagTypes > 0) lines.push(`| Changed flag types | ${changedFlagTypes} |`)
+      if (changedFlagRequirements > 0) lines.push(`| Changed flag requirements | ${changedFlagRequirements} |`)
+      if (changedFlagDescriptions > 0) lines.push(`| Changed flag descriptions | ${changedFlagDescriptions} |`)
+      if (descriptionChanges > 0) lines.push(`| Changed command descriptions | ${descriptionChanges} |`)
     }
     lines.push('')
 
-    // List new commands
-    if (diffData.details?.newCommands?.length > 0) {
+    // Collapsible list helper: itemized up to a cap, with an overflow note
+    const pushDetailsList = (title, items, renderItem) => {
+      if (!items || items.length === 0) return
       lines.push('<details>')
-      lines.push('<summary>New Commands</summary>')
+      lines.push(`<summary>${title}</summary>`)
       lines.push('')
-      for (const cmd of diffData.details.newCommands.slice(0, 20)) {
-        lines.push(`- \`${cmd.path}\``)
+      for (const item of items.slice(0, 30)) {
+        lines.push(renderItem(item))
       }
-      if (diffData.details.newCommands.length > 20) {
-        lines.push(`- ... and ${diffData.details.newCommands.length - 20} more`)
+      if (items.length > 30) {
+        lines.push(`- ... and ${items.length - 30} more (see the diff JSON in docs-data/)`)
       }
       lines.push('')
       lines.push('</details>')
       lines.push('')
     }
 
-    // List removed commands
-    if (diffData.details?.removedCommands?.length > 0) {
-      lines.push('<details>')
-      lines.push('<summary>Removed Commands</summary>')
-      lines.push('')
-      for (const cmd of diffData.details.removedCommands.slice(0, 20)) {
-        lines.push(`- \`${cmd.path}\``)
-      }
-      if (diffData.details.removedCommands.length > 20) {
-        lines.push(`- ... and ${diffData.details.removedCommands.length - 20} more`)
-      }
-      lines.push('')
-      lines.push('</details>')
-      lines.push('')
+    const formatValue = (value) => {
+      if (value === undefined) return 'unset'
+      if (value === null) return 'null'
+      if (typeof value === 'object') return JSON.stringify(value)
+      return String(value)
     }
+
+    pushDetailsList('New Commands', diffData.details?.newCommands,
+      cmd => `- \`${cmd.path}\``)
+    pushDetailsList('Deprecated Commands', diffData.details?.newlyDeprecatedCommands,
+      cmd => `- \`${cmd.path}\`${cmd.message ? ` — ${cmd.message}` : ''}${cmd.hidden ? ' _(hidden from help output)_' : ''}`)
+    pushDetailsList('Removed Commands', diffData.details?.removedCommands,
+      cmd => `- \`${cmd.path}\``)
+    pushDetailsList('New Flags', diffData.details?.newFlags,
+      flag => `- \`${flag.commandPath}\`: \`--${flag.flagName}\` (${flag.type})`)
+    pushDetailsList('Removed Flags', diffData.details?.removedFlags,
+      flag => `- \`${flag.commandPath}\`: \`--${flag.flagName}\``)
+    pushDetailsList('Changed Flag Defaults', diffData.details?.changedDefaults,
+      change => `- \`${change.commandPath}\`: \`--${change.flagName}\` default \`${formatValue(change.oldDefault)}\` → \`${formatValue(change.newDefault)}\``)
+    pushDetailsList('Changed Flag Types', diffData.details?.changedFlagTypes,
+      change => `- \`${change.commandPath}\`: \`--${change.flagName}\` type \`${change.oldType}\` → \`${change.newType}\``)
+    pushDetailsList('Changed Flag Requirements', diffData.details?.changedFlagRequirements,
+      change => `- \`${change.commandPath}\`: \`--${change.flagName}\` required \`${change.oldRequired}\` → \`${change.newRequired}\``)
+    pushDetailsList('Changed Command Descriptions', diffData.details?.descriptionChanges,
+      change => `- \`${change.path}\``)
   }
 
   // Validation results

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -583,8 +583,9 @@ function fetchRpkTreeFromLinuxSource(sourcePath, pluginPins = {}) {
       )
     }
 
+    let tree
     try {
-      return JSON.parse(result.stdout)
+      tree = JSON.parse(result.stdout)
     } catch (err) {
       throw new Error(
         `Failed to parse rpk tree JSON from Linux source build: ${err.message}\n` +
@@ -592,6 +593,26 @@ function fetchRpkTreeFromLinuxSource(sourcePath, pluginPins = {}) {
         'This may indicate a version mismatch or corrupted source.'
       )
     }
+
+    // Step 4: Fill in flags for plugin subtrees. Their commands come from
+    // --help-autocomplete, which carries no flag data, so without this every
+    // plugin command page renders an empty flags section.
+    console.log('Extracting flags from plugin command help output...')
+    for (const plugin of KNOWN_PLUGINS) {
+      const node = (tree.commands || []).find(c => c.name === plugin)
+      if (!node || !pluginNodeHasRealCommands(node)) continue
+      const enriched = enrichPluginTreeWithFlags(node, (argPath) => {
+        const helpResult = spawnSync('docker', [
+          'exec', containerId, '/tmp/rpk', ...argPath, '--help'
+        ], { encoding: 'utf8', timeout: 30000 })
+        return helpResult.status === 0 ? helpResult.stdout : null
+      })
+      if (enriched > 0) {
+        console.log(`  ${plugin}: extracted flags for ${enriched} command(s)`)
+      }
+    }
+
+    return tree
   } finally {
     // Clean up container
     console.log('Cleaning up build container...')
@@ -1407,6 +1428,89 @@ function splicePluginNode(tree, plugin, freshNode) {
 }
 
 /**
+ * Parse the local "Flags:" section of cobra --help output into flag objects
+ * matching the shape rpk --print-tree emits for compiled-in commands.
+ * The "Global Flags:" section is ignored: rpk-core globals are documented by
+ * the shared global-flags table, and plugin-global flags are captured from
+ * the plugin root command's own Flags section.
+ * @param {string} helpText - Output of `rpk <command> --help`
+ * @returns {Array<Object>} Flags: { name, shorthand?, type, description, default? }
+ */
+function parseCobraFlags(helpText) {
+  const lines = (helpText || '').split('\n')
+  const start = lines.findIndex(l => /^Flags:\s*$/.test(l))
+  if (start === -1) return []
+
+  const flags = []
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (/^\S/.test(line)) break // next section (Global Flags:, Use "...", ...)
+    if (line.trim() === '') break
+
+    const m = line.match(/^\s+(?:-(\w),\s+)?--([\w.-]+)(?:\s+(\S+))?\s{2,}(.*)$/)
+    if (m) {
+      const [, shorthand, name, valueType, desc] = m
+      if (name === 'help') continue
+      const flag = {
+        name,
+        type: valueType || 'bool',
+        description: desc.trim()
+      }
+      if (shorthand) flag.shorthand = shorthand
+      const def = flag.description.match(/\s*\(default (.+)\)$/)
+      if (def) {
+        flag.default = def[1]
+        flag.description = flag.description.slice(0, def.index).trim()
+      }
+      flags.push(flag)
+    } else if (flags.length > 0 && /^\s{4,}\S/.test(line) && !line.trim().startsWith('-')) {
+      // Wrapped description continuation
+      const last = flags[flags.length - 1]
+      last.description = `${last.description} ${line.trim()}`.trim()
+      const def = last.description.match(/\s*\(default (.+)\)$/)
+      if (def) {
+        last.default = def[1]
+        last.description = last.description.slice(0, def.index).trim()
+      }
+    }
+  }
+  return flags
+}
+
+/**
+ * Fill in flags for plugin subtree commands by running `--help` per command.
+ * Plugin subcommand nodes come from the plugin's --help-autocomplete output,
+ * which carries no flag information, so without this every plugin command
+ * page renders with an empty flags section. Nodes that already have flags
+ * (the install/uninstall/upgrade shim compiled into rpk) are left alone.
+ * Help failures are non-fatal: the affected command keeps an empty list.
+ * @param {Object} node - The plugin's top-level command node (mutated)
+ * @param {Function} execHelp - (argPath: string[]) => string|null, returns
+ *   the help text for `rpk <argPath...> --help`
+ * @returns {number} Number of commands enriched
+ */
+function enrichPluginTreeWithFlags(node, execHelp) {
+  let enriched = 0
+  const walk = (cmd, argPath) => {
+    if (!cmd.flags || cmd.flags.length === 0) {
+      const helpText = execHelp(argPath)
+      if (helpText) {
+        const flags = parseCobraFlags(helpText)
+        if (flags.length > 0) {
+          cmd.flags = flags
+          enriched++
+        }
+      }
+    }
+    for (const child of cmd.commands || []) {
+      walk(child, [...argPath, child.name])
+    }
+  }
+  walk(node, [node.name])
+  return enriched
+}
+
+/**
  * Install a single plugin and capture its fresh command subtree.
  * Runs with an isolated HOME so the install never touches the caller's
  * rpk plugin state, and the caller's installed plugins never leak in.
@@ -1486,6 +1590,19 @@ function fetchPluginSubtree({ plugin, pluginVersion, rpkBinPath }) {
       `--plugin-version <version>`
     )
   }
+
+  // Fill in per-command flags: autocomplete trees carry none, but the plugin
+  // binary is installed, so each command's --help documents them
+  console.log(`Extracting flags from ${plugin} command help output...`)
+  const enriched = enrichPluginTreeWithFlags(node, (argPath) => {
+    const helpResult = spawnSync(rpkBinPath, [...argPath, '--help'], {
+      encoding: 'utf8',
+      env,
+      timeout: 30000
+    })
+    return helpResult.status === 0 ? helpResult.stdout : null
+  })
+  console.log(`  Extracted flags for ${enriched} command(s)`)
 
   // When the pin was applied, record it. When we fell back to latest (or no
   // pin was given), record what the manifest says latest is: that is what
@@ -2384,6 +2501,8 @@ module.exports = {
   buildRpkBinary,
   downloadRpkRelease,
   fetchPluginSubtree,
+  parseCobraFlags,
+  enrichPluginTreeWithFlags,
   fetchLatestPluginVersion,
   pluginNodeHasRealCommands,
   splicePluginNode,

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -1105,12 +1105,32 @@ function countCommands(node) {
  * @param {Object|null} overridesData - Loaded overrides
  * @returns {Function} (commandPath) => boolean
  */
+/**
+ * Build a predicate that reports whether a command path has subcommands,
+ * which determines its page location (groups render into their own dir).
+ * @param {Object} tree - Full command tree
+ * @returns {Function} (commandPath) => boolean
+ */
+function makeSubcommandPredicate(tree) {
+  const commandMap = flattenToMap(tree)
+  return (commandPath) => {
+    const node = commandMap.get(commandPath)
+    return Boolean(node && (node.commands || []).length > 0)
+  }
+}
+
 function makeLinkablePredicate(overridesData) {
-  if (!overridesData) return () => true
-  const resolved = resolveReferences(overridesData, overridesData)
-  return (commandPath) =>
-    !shouldExcludeCommand(resolved, commandPath) &&
-    !shouldUsePartialDir(resolved, commandPath)
+  const resolved = overridesData ? resolveReferences(overridesData, overridesData) : null
+  return (commandPath) => {
+    // rpk cloud and rpk security secret render to partials (single-sourced
+    // into cloud docs), so this repo has no linkable pages for them
+    if (commandPath.startsWith('rpk cloud') || commandPath.startsWith('rpk security secret')) {
+      return false
+    }
+    if (!resolved) return true
+    return !shouldExcludeCommand(resolved, commandPath) &&
+      !shouldUsePartialDir(resolved, commandPath)
+  }
 }
 
 function updateWhatsNewFile(diffData, whatsNewPath, version, options = {}) {
@@ -1929,7 +1949,7 @@ async function handleRpkDocsGeneration(options = {}) {
 
           // Update what's-new file if requested
           if (whatsNewPath) {
-            updateWhatsNewFile(diffData, whatsNewPath, rpkVersion, { linkable: makeLinkablePredicate(overridesData) })
+            updateWhatsNewFile(diffData, whatsNewPath, rpkVersion, { linkable: makeLinkablePredicate(overridesData), hasSubcommands: makeSubcommandPredicate(tree) })
           }
         } else {
           console.warn(`Warning: Could not load previous version ${diffVersion} for diff`)
@@ -2211,7 +2231,7 @@ async function handleRpkDocsGeneration(options = {}) {
 
         // Update what's-new file if requested
         if (whatsNewPath) {
-          updateWhatsNewFile(diffData, whatsNewPath, rpkVersion, { linkable: makeLinkablePredicate(overridesData) })
+          updateWhatsNewFile(diffData, whatsNewPath, rpkVersion, { linkable: makeLinkablePredicate(overridesData), hasSubcommands: makeSubcommandPredicate(tree) })
         }
       } else {
         console.warn(`Warning: Could not load previous version ${diffVersion} for diff`)
@@ -2528,6 +2548,8 @@ module.exports = {
   downloadRpkRelease,
   fetchPluginSubtree,
   parseCobraFlags,
+  mergeVisibleDeprecationsIntoOverrides,
+  makeLinkablePredicate,
   enrichPluginTreeWithFlags,
   fetchLatestPluginVersion,
   pluginNodeHasRealCommands,

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -379,7 +379,10 @@ function fetchRpkTreeFromSource(sourcePath) {
  * Builds rpk binary, installs plugins, then runs --print-tree for complete command coverage.
  * Falls back to native Go build if Docker is unavailable.
  * @param {string} sourcePath - Path to rpk Go source directory (e.g., ~/redpanda/src/go/rpk)
- * @returns {Object} Parsed JSON tree
+ * @returns {Object} { tree, failedPlugins } — the parsed JSON tree plus the
+ *   names of managed plugins whose install failed this run. Callers pass
+ *   failedPlugins to generateRpkDocs as protectedPlugins so those plugins'
+ *   existing pages and nav entries are preserved instead of treated as stale.
  */
 function fetchRpkTreeFromLinuxSource(sourcePath, pluginPins = {}) {
   // Resolve to absolute path
@@ -642,7 +645,7 @@ function fetchRpkTreeFromLinuxSource(sourcePath, pluginPins = {}) {
       }
     }
 
-    return tree
+    return { tree, failedPlugins }
   } finally {
     // Clean up container
     console.log('Cleaning up build container...')
@@ -1841,6 +1844,10 @@ async function handleRpkDocsGeneration(options = {}) {
   let tree
   let rpkVersion
   let sourcePath
+  // Managed plugins whose install failed this run. Passed to generateRpkDocs
+  // as explicit protectedPlugins (merged there with auto-detection) so a
+  // failed install never deletes or rewrites that plugin's existing docs.
+  let failedPlugins = []
 
   try {
     // Fast path: regenerate from existing JSON file
@@ -2003,7 +2010,8 @@ async function handleRpkDocsGeneration(options = {}) {
         pluginVersions,
         draftMissing,
         preservationsDir: preserveFrom,
-        navFile
+        navFile,
+        protectedPlugins: failedPlugins
       })
 
       console.log(`\nGeneration complete!`)
@@ -2166,7 +2174,7 @@ async function handleRpkDocsGeneration(options = {}) {
       try {
         // Build on Linux (in container) - has all commands
         console.log('Building rpk in Linux container...')
-        const linuxTree = fetchRpkTreeFromLinuxSource(sourcePath, pluginPins)
+        const { tree: linuxTree, failedPlugins: linuxFailedPlugins } = fetchRpkTreeFromLinuxSource(sourcePath, pluginPins)
 
         // Build natively (on Darwin) for comparison. The Linux tree is
         // authoritative, so a comparison-build failure (for example, local
@@ -2195,6 +2203,7 @@ async function handleRpkDocsGeneration(options = {}) {
 
         // Use the Linux tree (has all commands)
         tree = linuxTree
+        failedPlugins = linuxFailedPlugins
       } catch (dockerErr) {
         // Docker build failed - fall back to native build
         console.warn(`\n⚠ Docker build failed: ${dockerErr.message}`)
@@ -2205,7 +2214,7 @@ async function handleRpkDocsGeneration(options = {}) {
     } else if (canBuildLinux) {
       console.log('\nBuilding rpk in Linux container...')
       try {
-        tree = fetchRpkTreeFromLinuxSource(sourcePath, pluginPins)
+        ({ tree, failedPlugins } = fetchRpkTreeFromLinuxSource(sourcePath, pluginPins))
       } catch (dockerErr) {
         if (canBuildNative) {
           console.warn(`\n⚠ Docker build failed: ${dockerErr.message}`)
@@ -2360,7 +2369,8 @@ async function handleRpkDocsGeneration(options = {}) {
       pluginVersions,
       draftMissing,
       preservationsDir: preserveFrom,
-      navFile
+      navFile,
+      protectedPlugins: failedPlugins
     })
 
     console.log(`\nGeneration complete!`)

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { spawnSync } = require('child_process')
+const crypto = require('crypto')
 const path = require('path')
 const fs = require('fs')
 const os = require('os')
@@ -15,6 +16,37 @@ const { validateDirectory, formatResults } = require('./validate-output')
  * Known rpk plugins that are managed separately (have install/uninstall commands)
  */
 const KNOWN_PLUGINS = ['ai', 'check', 'connect', 'k8s', 'oxla']
+
+/**
+ * Plugins whose docs can be refreshed individually with --plugin.
+ * oxla is excluded: it is a "Coming Soon" stub with no installable binary.
+ */
+const REFRESHABLE_PLUGINS = ['ai', 'check', 'connect', 'k8s']
+
+/**
+ * Per-plugin install flags that pin a version (rpk <plugin> install <flag> <version>).
+ * k8s uses the generic flag name; the others embed the plugin name.
+ */
+const PLUGIN_INSTALL_VERSION_FLAGS = {
+  ai: '--ai-version',
+  check: '--check-version',
+  connect: '--connect-version',
+  k8s: '--plugin-version'
+}
+
+/**
+ * Manifest slugs at https://rpk-plugins.redpanda.com/<slug>/manifest.json
+ * where the slug differs from the rpk command name.
+ */
+const PLUGIN_MANIFEST_SLUGS = { ai: 'rpai' }
+
+const PLUGIN_MANIFEST_HOST = 'https://rpk-plugins.redpanda.com'
+
+/**
+ * Subcommands compiled into rpk itself for managed plugins. A plugin node
+ * whose children are only these never actually installed.
+ */
+const PLUGIN_SHIM_SUBCOMMANDS = new Set(['install', 'uninstall', 'upgrade'])
 
 /**
  * Parse Go version from 'go version' output
@@ -1027,6 +1059,310 @@ function updateWhatsNewFile(diffData, whatsNewPath, version) {
 }
 
 /**
+ * Build an rpk binary natively from Go source.
+ * @param {string} sourcePath - Path to rpk Go source directory (src/go/rpk)
+ * @param {string} outPath - Where to write the binary
+ * @returns {string} Path to the built binary
+ */
+function buildRpkBinary(sourcePath, outPath) {
+  const goCheck = spawnSync('go', ['version'], { encoding: 'utf8', timeout: 5000 })
+  if (goCheck.status !== 0) {
+    throw new Error(
+      'Go is required to build rpk from source but was not found.\n' +
+      'Install Go from https://go.dev/ and ensure it\'s in your PATH.'
+    )
+  }
+
+  const installedGoVersion = parseGoVersion(goCheck.stdout)
+  const requiredGoVersion = getRequiredGoVersion(sourcePath)
+  if (installedGoVersion && requiredGoVersion &&
+      !checkGoVersionSufficient(installedGoVersion, requiredGoVersion)) {
+    throw new Error(
+      `Go version mismatch: installed ${installedGoVersion}, required >= ${requiredGoVersion}\n` +
+      `The rpk source (go.mod) requires Go ${requiredGoVersion} or newer.`
+    )
+  }
+
+  console.log(`Building rpk from source at ${sourcePath}...`)
+  const buildResult = spawnSync('go', ['build', '-o', outPath, './cmd/rpk'], {
+    cwd: sourcePath,
+    encoding: 'utf8',
+    timeout: 300000
+  })
+
+  if (buildResult.status !== 0) {
+    throw new Error(`Failed to build rpk from source: ${buildResult.stderr}`)
+  }
+
+  return outPath
+}
+
+/**
+ * Download an official rpk release binary for the current platform.
+ * @param {string} tag - Release tag (e.g., v26.1.12)
+ * @param {string} destDir - Directory to download and extract into
+ * @returns {string|null} Path to the extracted binary, or null if the
+ *   release asset is unavailable (caller falls back to a source build)
+ */
+function downloadRpkRelease(tag, destDir) {
+  const osName = { darwin: 'darwin', linux: 'linux', win32: 'windows' }[process.platform]
+  const archName = { arm64: 'arm64', x64: 'amd64' }[process.arch]
+  if (!osName || !archName) {
+    console.warn(`No rpk release asset for platform ${process.platform}/${process.arch}`)
+    return null
+  }
+
+  const assetName = `rpk-${osName}-${archName}.zip`
+  const baseUrl = `https://github.com/redpanda-data/redpanda/releases/download/${tag}`
+  const zipPath = path.join(destDir, assetName)
+
+  console.log(`Downloading ${assetName} for ${tag}...`)
+  const curlResult = spawnSync('curl', [
+    '-fL', '--retry', '5', '--retry-all-errors',
+    '--connect-timeout', '30', '--max-time', '300',
+    '-o', zipPath, `${baseUrl}/${assetName}`
+  ], { encoding: 'utf8', timeout: 360000 })
+
+  if (curlResult.status !== 0) {
+    console.warn(`Could not download rpk release for ${tag} (draft or missing release asset)`)
+    return null
+  }
+
+  // Verify against the release checksum file when it exists
+  const checksumAsset = `rpk_${tag.replace(/^v/, '')}_checksums.txt`
+  const checksumPath = path.join(destDir, checksumAsset)
+  const checksumResult = spawnSync('curl', [
+    '-fsSL', '--retry', '3', '--connect-timeout', '30', '--max-time', '60',
+    '-o', checksumPath, `${baseUrl}/${checksumAsset}`
+  ], { encoding: 'utf8', timeout: 90000 })
+
+  if (checksumResult.status === 0) {
+    const expectedLine = fs.readFileSync(checksumPath, 'utf8')
+      .split('\n')
+      .find(line => line.trim().endsWith(assetName))
+    if (expectedLine) {
+      const expected = expectedLine.trim().split(/\s+/)[0]
+      const actual = crypto.createHash('sha256').update(fs.readFileSync(zipPath)).digest('hex')
+      if (expected !== actual) {
+        throw new Error(
+          `Checksum mismatch for ${assetName} (${tag}):\n` +
+          `  expected ${expected}\n  actual   ${actual}`
+        )
+      }
+      console.log('Checksum verified')
+    }
+  } else {
+    console.warn('No checksum file published for this release; skipping verification')
+  }
+
+  const unzipResult = spawnSync('unzip', ['-o', zipPath, '-d', destDir], {
+    encoding: 'utf8',
+    timeout: 60000
+  })
+  if (unzipResult.status !== 0) {
+    throw new Error(`Failed to extract ${assetName}: ${unzipResult.stderr}`)
+  }
+
+  const binPath = path.join(destDir, 'rpk')
+  if (!fs.existsSync(binPath)) {
+    throw new Error(`Extracted archive did not contain an rpk binary: ${zipPath}`)
+  }
+  fs.chmodSync(binPath, 0o755)
+  return binPath
+}
+
+/**
+ * Get an rpk binary matching the given version.
+ * Prefers the official release download (published stable releases only;
+ * RC releases are drafts, so their assets are not publicly downloadable).
+ * Falls back to building from source at the tag.
+ * @param {string} rpkVersion - Version tag from the snapshot (e.g., v26.1.12, v26.2.1-rc2)
+ * @param {Object} [options]
+ * @param {string} [options.rpkBin] - Existing binary to use, skipping download/build
+ * @returns {string} Path to an rpk binary
+ */
+function acquireRpkBinary(rpkVersion, options = {}) {
+  const { rpkBin } = options
+
+  if (rpkBin) {
+    const binPath = path.resolve(rpkBin)
+    if (!fs.existsSync(binPath)) {
+      throw new Error(`rpk binary not found: ${binPath}`)
+    }
+    console.log(`Using provided rpk binary: ${binPath}`)
+    return binPath
+  }
+
+  const tag = rpkVersion.startsWith('v') ? rpkVersion : `v${rpkVersion}`
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rpk-bin-'))
+
+  // Only published (non-draft) releases have downloadable assets
+  if (/^v\d+\.\d+\.\d+$/.test(tag)) {
+    const downloaded = downloadRpkRelease(tag, workDir)
+    if (downloaded) {
+      return downloaded
+    }
+    console.log('Falling back to building rpk from source...')
+  } else {
+    console.log(`No published release binary for ${tag}; building from source...`)
+  }
+
+  if (!/^v\d+\.\d+\.\d+(-rc\d+)?$/.test(tag) && tag !== 'vdev') {
+    throw new Error(
+      `Cannot acquire an rpk binary for version '${rpkVersion}'.\n` +
+      'The snapshot\'s rpk_version is not a release tag. ' +
+      'Pass --rpk-bin <path> to use a local rpk binary instead.'
+    )
+  }
+
+  const sourceRef = tag === 'vdev' ? 'dev' : tag
+  const sourcePath = prepareSourceFromRef(sourceRef, null)
+  return buildRpkBinary(sourcePath, path.join(workDir, 'rpk'))
+}
+
+/**
+ * Look up the latest published version of a plugin from its manifest.
+ * @param {string} plugin - rpk command name (ai, connect, k8s, check)
+ * @returns {string|null} Latest version, or null if unavailable
+ */
+function fetchLatestPluginVersion(plugin) {
+  const slug = PLUGIN_MANIFEST_SLUGS[plugin] || plugin
+  const result = spawnSync('curl', [
+    '-fsSL', '--retry', '3', '--connect-timeout', '15', '--max-time', '30',
+    `${PLUGIN_MANIFEST_HOST}/${slug}/manifest.json`
+  ], { encoding: 'utf8', timeout: 60000 })
+
+  if (result.status !== 0) {
+    console.warn(`Could not fetch plugin manifest for ${plugin} (slug: ${slug})`)
+    return null
+  }
+
+  try {
+    const manifest = JSON.parse(result.stdout)
+    const latest = (manifest.archives || []).find(a => a.is_latest)
+    return latest ? latest.version : null
+  } catch (err) {
+    console.warn(`Could not parse plugin manifest for ${plugin}: ${err.message}`)
+    return null
+  }
+}
+
+/**
+ * Check whether a plugin node contains real plugin commands, as opposed to
+ * only the install/uninstall/upgrade shim compiled into rpk itself.
+ * @param {Object} node - Top-level command node for the plugin
+ * @returns {boolean}
+ */
+function pluginNodeHasRealCommands(node) {
+  return (node.commands || []).some(c => !PLUGIN_SHIM_SUBCOMMANDS.has(c.name))
+}
+
+/**
+ * Replace a plugin's top-level node in a command tree.
+ * Replace-only: throws if the plugin is not already present, so a refresh
+ * can never introduce a command that the snapshot's rpk version lacks.
+ * @param {Object} tree - Full command tree (root node)
+ * @param {string} plugin - rpk command name
+ * @param {Object} freshNode - Replacement node
+ * @returns {Object} New tree with the node replaced
+ */
+function splicePluginNode(tree, plugin, freshNode) {
+  const commands = tree.commands || []
+  if (!commands.some(c => c.name === plugin)) {
+    throw new Error(`Cannot splice plugin '${plugin}': not present in the base tree`)
+  }
+  return {
+    ...tree,
+    commands: commands.map(c => (c.name === plugin ? freshNode : c))
+  }
+}
+
+/**
+ * Install a single plugin and capture its fresh command subtree.
+ * Runs with an isolated HOME so the install never touches the caller's
+ * rpk plugin state, and the caller's installed plugins never leak in.
+ * @param {Object} params
+ * @param {string} params.plugin - rpk command name (ai, connect, k8s, check)
+ * @param {string} [params.pluginVersion] - Version to pin; defaults to latest
+ * @param {string} params.rpkBinPath - rpk binary to run
+ * @returns {Object} { node, version } - Fresh plugin node and the version recorded
+ */
+function fetchPluginSubtree({ plugin, pluginVersion, rpkBinPath }) {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'rpk-plugin-home-'))
+  const env = { ...process.env, HOME: tmpHome }
+
+  const runInstall = (pinned) => {
+    const args = [plugin, 'install']
+    const versionFlag = PLUGIN_INSTALL_VERSION_FLAGS[plugin]
+    if (pinned && pluginVersion && versionFlag) {
+      args.push(versionFlag, pluginVersion)
+    }
+    console.log(`Installing plugin: rpk ${args.join(' ')}`)
+    return spawnSync(rpkBinPath, args, { encoding: 'utf8', env, timeout: 300000 })
+  }
+
+  let installResult = runInstall(true)
+  if (installResult.status !== 0 && pluginVersion) {
+    const output = `${installResult.stderr || ''}${installResult.stdout || ''}`
+    if (output.includes('unknown flag')) {
+      console.warn(
+        `Version flag ${PLUGIN_INSTALL_VERSION_FLAGS[plugin]} not supported by this rpk; ` +
+        'retrying without the pin (installs latest)'
+      )
+      installResult = runInstall(false)
+    }
+  }
+  if (installResult.status !== 0) {
+    throw new Error(
+      `Failed to install plugin '${plugin}':\n` +
+      `${installResult.stderr || installResult.stdout || 'no output'}`
+    )
+  }
+
+  const treeResult = spawnSync(rpkBinPath, ['--print-tree'], {
+    encoding: 'utf8',
+    env,
+    timeout: 120000,
+    maxBuffer: 50 * 1024 * 1024
+  })
+  if (treeResult.status !== 0) {
+    const stderr = treeResult.stderr || ''
+    if (stderr.includes('unknown flag')) {
+      throw new Error(
+        'This rpk binary does not support --print-tree (requires rpk >= v26.2.0).\n' +
+        'Pass --rpk-bin with a newer binary.'
+      )
+    }
+    throw new Error(`Failed to run rpk --print-tree: ${stderr}`)
+  }
+
+  const freshTree = JSON.parse(treeResult.stdout)
+  const node = (freshTree.commands || []).find(c => c.name === plugin)
+  if (!node) {
+    throw new Error(`Plugin '${plugin}' not found in rpk command tree after install`)
+  }
+  if (!pluginNodeHasRealCommands(node)) {
+    throw new Error(
+      `Plugin '${plugin}' installed but exposed no commands beyond the ` +
+      'install/uninstall/upgrade shim.\n' +
+      'The install likely resolved nothing. For pre-GA plugins (no promoted ' +
+      'latest version in the manifest), a version pin is required: ' +
+      `--plugin-version <version>`
+    )
+  }
+
+  const version = pluginVersion || fetchLatestPluginVersion(plugin)
+  if (!version) {
+    console.warn(
+      `Could not determine the installed version of '${plugin}'; ` +
+      'plugin_versions will not be updated for this run'
+    )
+  }
+
+  return { node, version }
+}
+
+/**
  * Main handler for rpk docs generation
  *
  * Simplified workflow:
@@ -1042,6 +1378,9 @@ async function handleRpkDocsGeneration(options = {}) {
     overrides: overridesPath,
     fromSource, // Path to local rpk Go source directory
     fromJson, // Path to existing versioned JSON file to regenerate from
+    plugin, // Refresh a single plugin's subtree (requires fromJson)
+    pluginVersion, // Version to pin for the plugin install (defaults to latest)
+    rpkBin, // Existing rpk binary to use for the plugin refresh
     ref, // Git ref (branch or tag) to document
     sourceRef, // Alias for ref
     diff: diffVersion,
@@ -1113,6 +1452,70 @@ async function handleRpkDocsGeneration(options = {}) {
 
       console.log(`Loaded tree with rpk version: ${rpkVersion}`)
 
+      // Refresh a single plugin's subtree in the snapshot before rendering.
+      // Plugins release on their own cadence, so their commands can change
+      // without a new rpk release. Splice the fresh subtree into the full
+      // tree and re-render everything: only the plugin's pages actually
+      // change, and stale-file cleanup, nav rebuild, and override
+      // validation all see a complete tree.
+      let pluginVersions = jsonData.plugin_versions || {}
+      let pluginDiffData = null
+      if (plugin) {
+        if (!REFRESHABLE_PLUGINS.includes(plugin)) {
+          throw new Error(
+            `Unknown plugin '${plugin}'. Supported plugins: ${REFRESHABLE_PLUGINS.join(', ')}\n` +
+            'Use the rpk command name (for example "ai"), not the manifest slug ("rpai").'
+          )
+        }
+
+        const oldNode = (tree.commands || []).find(c => c.name === plugin)
+        if (!oldNode) {
+          console.log(
+            `rpk ${rpkVersion} has no '${plugin}' command; nothing to update. ` +
+            'This is expected when the plugin only exists in a newer rpk line.'
+          )
+          return {
+            success: true,
+            skipped: true,
+            reason: `plugin '${plugin}' not present in rpk ${rpkVersion}`,
+            rpkVersion
+          }
+        }
+
+        const rpkBinPath = acquireRpkBinary(rpkVersion, { rpkBin })
+        const { node: freshNode, version: resolvedVersion } = fetchPluginSubtree({
+          plugin,
+          pluginVersion,
+          rpkBinPath
+        })
+
+        // Plugin-scoped diff for the PR summary: compare only the plugin's
+        // subtree, old snapshot state vs fresh install
+        pluginDiffData = generateRpkDiff(
+          { ...tree, commands: [oldNode] },
+          { ...tree, commands: [freshNode] },
+          {
+            oldVersion: pluginVersions[plugin] || 'previous snapshot',
+            newVersion: resolvedVersion || 'latest'
+          }
+        )
+        printDiffReport(pluginDiffData)
+
+        tree = splicePluginNode(tree, plugin, freshNode)
+        if (resolvedVersion) {
+          pluginVersions = { ...pluginVersions, [plugin]: resolvedVersion }
+        }
+        console.log(
+          `Spliced fresh '${plugin}' subtree` +
+          (resolvedVersion ? ` (version ${resolvedVersion})` : '') +
+          ` into snapshot for rpk ${rpkVersion}`
+        )
+
+        if (diffVersion) {
+          console.warn('Note: --diff is ignored in --plugin mode (the summary uses a plugin-scoped diff)')
+        }
+      }
+
       // Skip to documentation generation (after the source building steps)
       // Load and validate overrides
       const defaultOverridesPath = path.join(dataDir, 'rpk-overrides.json')
@@ -1121,6 +1524,22 @@ async function handleRpkDocsGeneration(options = {}) {
 
       if (overridesData) {
         console.log(`Loaded overrides from ${effectiveOverridesPath}`)
+      }
+
+      // Persist the merged snapshot so the refreshed plugin subtree and its
+      // recorded version become the new baseline (mirrors the from-source
+      // path's augmentedData structure)
+      if (plugin) {
+        let enhancedTree = tree
+        if (overridesData) {
+          const resolvedOverrides = resolveReferences(overridesData, overridesData)
+          enhancedTree = applyOverridesToTree(tree, resolvedOverrides, '')
+        }
+        jsonData.raw_tree = tree
+        jsonData.tree = enhancedTree
+        jsonData.plugin_versions = pluginVersions
+        jsonData.generated_at = new Date().toISOString()
+        saveVersionedJson(jsonData, rpkVersion, dataDir)
       }
 
       // Generate AsciiDoc documentation
@@ -1132,7 +1551,7 @@ async function handleRpkDocsGeneration(options = {}) {
         outputDir: finalOutputDir,
         cloudSecretDir: finalCloudSecretDir,
         rpkVersion,
-        pluginVersions: {},
+        pluginVersions,
         draftMissing,
         preservationsDir: preserveFrom,
         navFile
@@ -1154,9 +1573,10 @@ async function handleRpkDocsGeneration(options = {}) {
         showInfo
       })
 
-      // Generate diff if requested
+      // Generate diff if requested (rpk-version diff; not used in --plugin
+      // mode, which produces its own plugin-scoped diff)
       let diffData = null
-      if (diffVersion) {
+      if (diffVersion && !plugin) {
         const oldData = loadVersionedJson(diffVersion, dataDir)
         if (oldData) {
           // Use raw_tree for diffing (falls back to tree for backward compatibility)
@@ -1187,10 +1607,12 @@ async function handleRpkDocsGeneration(options = {}) {
       // Generate PR summary
       const prSummary = generatePRSummary({
         rpkVersion,
+        plugin,
+        pluginVersion: plugin ? pluginVersions[plugin] : undefined,
         commandCount: result.commandCount,
         filesGenerated: result.filesGenerated,
         filesSkipped: result.filesSkipped,
-        diffData,
+        diffData: plugin ? pluginDiffData : diffData,
         validationResult,
         outputDir: finalOutputDir
       })
@@ -1211,10 +1633,19 @@ async function handleRpkDocsGeneration(options = {}) {
         filesSkipped: result.filesSkipped,
         outputDir: finalOutputDir,
         rpkVersion,
-        diffData,
+        plugin,
+        pluginVersion: plugin ? pluginVersions[plugin] : undefined,
+        diffData: plugin ? pluginDiffData : diffData,
         validationResult,
         prSummary
       }
+    }
+
+    if (plugin) {
+      throw new Error(
+        '--plugin requires --from-json <snapshot>.\n' +
+        'A plugin refresh splices the fresh subtree into an existing committed snapshot.'
+      )
     }
 
     // Step 1: Get source code
@@ -1343,8 +1774,23 @@ async function handleRpkDocsGeneration(options = {}) {
     const plugins = detectPlugins(tree)
     console.log(`Detected plugins: ${plugins.join(', ') || 'none'}`)
 
-    // Note: Plugin versions not available when building from source
+    // Record the version of each plugin that actually installed during the
+    // build (`rpk <plugin> install` resolves the manifest's latest, so the
+    // manifest lookup reflects what the tree contains). Shim-only plugins
+    // (failed installs) are skipped: their subtree carries no plugin commands.
     const pluginVersions = {}
+    for (const pluginName of REFRESHABLE_PLUGINS) {
+      const node = (tree.commands || []).find(c => c.name === pluginName)
+      if (node && pluginNodeHasRealCommands(node)) {
+        const latestVersion = fetchLatestPluginVersion(pluginName)
+        if (latestVersion) {
+          pluginVersions[pluginName] = latestVersion
+        }
+      }
+    }
+    if (Object.keys(pluginVersions).length > 0) {
+      console.log(`Plugin versions: ${JSON.stringify(pluginVersions)}`)
+    }
 
     // Step 5: Scan source for deprecated/hidden commands
     let deprecatedCommands = {}
@@ -1509,6 +1955,8 @@ async function handleRpkDocsGeneration(options = {}) {
 function generatePRSummary(options) {
   const {
     rpkVersion,
+    plugin,
+    pluginVersion,
     commandCount,
     filesGenerated,
     filesSkipped = 0,
@@ -1520,12 +1968,27 @@ function generatePRSummary(options) {
   const lines = []
 
   // Header
-  lines.push('## rpk Documentation Generation Summary')
-  lines.push('')
+  if (plugin) {
+    lines.push(`## rpk ${plugin} Plugin Documentation Update`)
+    lines.push('')
+    if (pluginVersion) {
+      lines.push(`**Plugin version:** ${pluginVersion}`)
+    }
+    lines.push(`**Base rpk snapshot:** ${rpkVersion}`)
+    lines.push('')
+    lines.push(
+      `Only the \`rpk ${plugin}\` subtree was refreshed. ` +
+      'All other pages were re-rendered from the committed snapshot and are unchanged.'
+    )
+    lines.push('')
+  } else {
+    lines.push('## rpk Documentation Generation Summary')
+    lines.push('')
 
-  // Version info
-  lines.push(`**Version:** ${rpkVersion}`)
-  lines.push('')
+    // Version info
+    lines.push(`**Version:** ${rpkVersion}`)
+    lines.push('')
+  }
 
   // Generation stats
   lines.push('### Generation Statistics')
@@ -1686,6 +2149,16 @@ module.exports = {
   handleRpkDocsGeneration,
   fetchRpkTreeFromSource,
   fetchRpkTreeFromLinuxSource,
+  acquireRpkBinary,
+  buildRpkBinary,
+  downloadRpkRelease,
+  fetchPluginSubtree,
+  fetchLatestPluginVersion,
+  pluginNodeHasRealCommands,
+  splicePluginNode,
+  REFRESHABLE_PLUGINS,
+  PLUGIN_INSTALL_VERSION_FLAGS,
+  PLUGIN_MANIFEST_SLUGS,
   getRequiredGoVersion,
   prepareSourceFromRef,
   detectLinuxOnlyFromSource,

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -2568,6 +2568,7 @@ function generatePRSummary(options) {
       if (changedFlagRequirements > 0) lines.push(`| Changed flag requirements | ${changedFlagRequirements} |`)
       if (changedFlagDescriptions > 0) lines.push(`| Changed flag descriptions | ${changedFlagDescriptions} |`)
       if (descriptionChanges > 0) lines.push(`| Changed command descriptions | ${descriptionChanges} |`)
+      if (diffData.summary?.flagDataBackfilled > 0) lines.push(`| Flag docs backfilled (not new flags) | ${diffData.summary.flagDataBackfilled} commands |`)
     }
     lines.push('')
 

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -7,7 +7,7 @@ const fs = require('fs')
 const os = require('os')
 const semver = require('semver')
 const { findRepoRoot } = require('../../cli-utils/doc-tools-utils')
-const { generateRpkDocs, applyOverridesToTree, resolveReferences } = require('./generate-rpk-docs')
+const { generateRpkDocs, applyOverridesToTree, resolveReferences, shouldExcludeCommand, shouldUsePartialDir } = require('./generate-rpk-docs')
 const { generateRpkDiff, printDiffReport, generateWhatsNewSection, flattenToMap } = require('./report-delta')
 const { loadAndValidateOverrides, ValidationResult } = require('./validate-overrides')
 const { validateDirectory, formatResults } = require('./validate-output')
@@ -1078,8 +1078,22 @@ function countCommands(node) {
  * @param {string} whatsNewPath - Path to what's-new.adoc file
  * @param {string} version - Version string for display
  */
-function updateWhatsNewFile(diffData, whatsNewPath, version) {
-  const whatsNewContent = generateWhatsNewSection(diffData, { version })
+/**
+ * Build a predicate that reports whether a command path renders as a
+ * linkable page (not excluded and not routed to partials by the overrides).
+ * @param {Object|null} overridesData - Loaded overrides
+ * @returns {Function} (commandPath) => boolean
+ */
+function makeLinkablePredicate(overridesData) {
+  if (!overridesData) return () => true
+  const resolved = resolveReferences(overridesData, overridesData)
+  return (commandPath) =>
+    !shouldExcludeCommand(resolved, commandPath) &&
+    !shouldUsePartialDir(resolved, commandPath)
+}
+
+function updateWhatsNewFile(diffData, whatsNewPath, version, options = {}) {
+  const whatsNewContent = generateWhatsNewSection(diffData, { version, ...options })
 
   if (!whatsNewContent) {
     console.log('No Redpanda CLI changes to add to what\'s new')
@@ -1095,9 +1109,39 @@ function updateWhatsNewFile(diffData, whatsNewPath, version) {
 
   const existingContent = fs.readFileSync(whatsNewPath, 'utf8')
 
-  // Check if Redpanda CLI section already exists
-  if (existingContent.includes('== Redpanda CLI')) {
-    console.log('Redpanda CLI section already exists in what\'s-new file')
+  // Version-scoped marker block: re-runs for the same version replace their
+  // own block, and later versions (for example, successive RCs in a beta
+  // cycle, or plugin releases) append their own blocks inside the existing
+  // Redpanda CLI section instead of being dropped. Writers can edit or
+  // remove blocks freely; the automation only ever touches content between
+  // its own markers for the same version label.
+  const startMarker = `// AUTOGEN-RPK-CHANGES ${version} START`
+  const endMarker = `// AUTOGEN-RPK-CHANGES ${version} END`
+  const sectionBody = whatsNewContent.replace(/^== Redpanda CLI[^\n]*\n+/, '')
+  const block = `${startMarker}\n${sectionBody.trimEnd()}\n${endMarker}`
+  const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+  if (existingContent.includes(startMarker)) {
+    // Replace this version's existing block (idempotent re-runs)
+    const blockRe = new RegExp(`${escapeRe(startMarker)}[\\s\\S]*?${escapeRe(endMarker)}`)
+    const updatedContent = existingContent.replace(blockRe, block)
+    fs.writeFileSync(whatsNewPath, updatedContent, 'utf8')
+    console.log(`Refreshed existing ${version} block in what's-new file: ${whatsNewPath}`)
+    return
+  }
+
+  const headingMatch = existingContent.match(/^== Redpanda CLI[^\n]*$/m)
+  if (headingMatch) {
+    // Append this version's block at the end of the existing section, just
+    // before the next level-2 heading (or end of file)
+    const sectionStart = headingMatch.index + headingMatch[0].length
+    const rest = existingContent.slice(sectionStart)
+    const nextHeading = rest.search(/\n== /)
+    const insertAt = nextHeading === -1 ? existingContent.length : sectionStart + nextHeading
+    const before = existingContent.slice(0, insertAt).replace(/\s*$/, '\n\n')
+    const after = existingContent.slice(insertAt).replace(/^\n*/, '\n')
+    fs.writeFileSync(whatsNewPath, `${before}${block}${after}`, 'utf8')
+    console.log(`Appended ${version} block to the Redpanda CLI section in: ${whatsNewPath}`)
     return
   }
 
@@ -1119,19 +1163,21 @@ function updateWhatsNewFile(diffData, whatsNewPath, version) {
     }
   }
 
+  const fullSection = `== Redpanda CLI\n\n${block}\n`
+
   let updatedContent
   if (insertIndex > 0) {
     // Insert before the matched section
     updatedContent = existingContent.slice(0, insertIndex) +
-      whatsNewContent + '\n' +
+      fullSection + '\n' +
       existingContent.slice(insertIndex)
   } else {
     // Append at the end
-    updatedContent = existingContent + '\n' + whatsNewContent
+    updatedContent = existingContent.replace(/\s*$/, '\n\n') + fullSection
   }
 
   fs.writeFileSync(whatsNewPath, updatedContent, 'utf8')
-  console.log(`Updated what's-new file: ${whatsNewPath}`)
+  console.log(`Created Redpanda CLI section in what's-new file: ${whatsNewPath}`)
 }
 
 /**
@@ -1637,6 +1683,17 @@ async function handleRpkDocsGeneration(options = {}) {
         if (diffVersion) {
           console.warn('Note: --diff is ignored in --plugin mode (the summary uses a plugin-scoped diff)')
         }
+
+        // Plugin releases land in What's new too when requested: their
+        // changes never arrive through a Redpanda release diff. Entries
+        // render without xrefs because plugin subtrees may render as
+        // partials with no linkable pages.
+        if (whatsNewPath) {
+          const label = resolvedVersion
+            ? `${plugin} plugin ${resolvedVersion}`
+            : `${plugin} plugin`
+          updateWhatsNewFile(pluginDiffData, whatsNewPath, label, { xrefs: false })
+        }
       }
 
       // Skip to documentation generation (after the source building steps)
@@ -1722,7 +1779,7 @@ async function handleRpkDocsGeneration(options = {}) {
 
           // Update what's-new file if requested
           if (whatsNewPath) {
-            updateWhatsNewFile(diffData, whatsNewPath, rpkVersion)
+            updateWhatsNewFile(diffData, whatsNewPath, rpkVersion, { linkable: makeLinkablePredicate(overridesData) })
           }
         } else {
           console.warn(`Warning: Could not load previous version ${diffVersion} for diff`)
@@ -2004,7 +2061,7 @@ async function handleRpkDocsGeneration(options = {}) {
 
         // Update what's-new file if requested
         if (whatsNewPath) {
-          updateWhatsNewFile(diffData, whatsNewPath, rpkVersion)
+          updateWhatsNewFile(diffData, whatsNewPath, rpkVersion, { linkable: makeLinkablePredicate(overridesData) })
         }
       } else {
         console.warn(`Warning: Could not load previous version ${diffVersion} for diff`)
@@ -2341,6 +2398,7 @@ module.exports = {
   getPlatformDescription,
   getCurrentPlatform,
   updateOverridesWithIntroducedVersions,
+  updateWhatsNewFile,
   KNOWN_PLUGINS,
   extractCommandPaths,
   detectLinuxOnlyByComparison,

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -491,7 +491,8 @@ function fetchRpkTreeFromLinuxSource(sourcePath, pluginPins = {}) {
     // INTERNAL_ERROR), especially on a cold module cache. Retry: the second
     // attempt reuses whatever the first already downloaded.
     let buildResult
-    for (let attempt = 1; attempt <= 3; attempt++) {
+    let binaryExists = false
+    for (let attempt = 1; attempt <= 4; attempt++) {
       buildResult = spawnSync('docker', [
         'exec', containerId,
         'go', 'build', '-o', '/tmp/rpk', './cmd/rpk'
@@ -499,34 +500,37 @@ function fetchRpkTreeFromLinuxSource(sourcePath, pluginPins = {}) {
         encoding: 'utf8',
         timeout: 300000 // 5 minutes per attempt
       })
-      if (buildResult.status === 0) break
-      if (attempt < 3) {
+
+      if (buildResult.status === 0) {
+        // Trust but verify: docker exec has been observed returning zero for
+        // a build that produced nothing, and everything downstream execs
+        // /tmp/rpk. Treat a phantom success as a failed attempt.
+        const binCheck = spawnSync('docker', [
+          'exec', containerId, 'test', '-x', '/tmp/rpk'
+        ], { encoding: 'utf8', timeout: 15000 })
+        if (binCheck.status === 0) {
+          binaryExists = true
+          break
+        }
+        if (attempt < 4) {
+          console.warn(`  Build attempt ${attempt} reported success but produced no binary; retrying...`)
+          continue
+        }
+      } else if (attempt < 4) {
         const firstError = (buildResult.stderr || buildResult.signal || 'unknown error')
           .toString().trim().split('\n').slice(-1)[0]
         console.warn(`  Build attempt ${attempt} failed (${firstError}); retrying...`)
       }
     }
 
-    if (buildResult.status !== 0) {
+    if (!binaryExists) {
       const stderr = buildResult.stderr || ''
       throw new Error(
-        `Failed to build rpk in Linux container: ${stderr}\n` +
+        `Failed to build rpk in Linux container: ${stderr || 'build produced no binary'}\n` +
         'Common causes:\n' +
         '  1. Source code is out of date - run: git pull origin dev\n' +
         '  2. Go module issues - the container will download dependencies automatically\n' +
         '  3. Insufficient Docker resources - check Docker Desktop settings'
-      )
-    }
-
-    // Trust but verify: a zero exit with no binary has been observed after
-    // Docker daemon recoveries, and everything downstream execs /tmp/rpk
-    const binCheck = spawnSync('docker', [
-      'exec', containerId, 'test', '-x', '/tmp/rpk'
-    ], { encoding: 'utf8', timeout: 15000 })
-    if (binCheck.status !== 0) {
-      throw new Error(
-        'rpk build reported success but /tmp/rpk does not exist in the ' +
-        'build container. Retry the run; if it persists, restart Docker.'
       )
     }
     console.log('  ✓ rpk binary built')

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -1301,14 +1301,21 @@ function fetchPluginSubtree({ plugin, pluginVersion, rpkBinPath }) {
     return spawnSync(rpkBinPath, args, { encoding: 'utf8', env, timeout: 300000 })
   }
 
+  let pinApplied = Boolean(pluginVersion)
   let installResult = runInstall(true)
   if (installResult.status !== 0 && pluginVersion) {
     const output = `${installResult.stderr || ''}${installResult.stdout || ''}`
-    if (output.includes('unknown flag')) {
+    // 'unknown flag': this rpk predates the pin flag.
+    // 'is not valid': rpk's version validation rejected the pin (its regex
+    // caps each segment at two digits, so connect versions like 4.102.0
+    // fail). In both cases installing latest is the right recovery: the
+    // dispatch fires right after a release, when latest IS the release.
+    if (output.includes('unknown flag') || output.includes('is not valid')) {
       console.warn(
-        `Version flag ${PLUGIN_INSTALL_VERSION_FLAGS[plugin]} not supported by this rpk; ` +
-        'retrying without the pin (installs latest)'
+        `rpk rejected the version pin for '${plugin}' ` +
+        `(${output.trim().split('\n')[0]}); retrying without the pin (installs latest)`
       )
+      pinApplied = false
       installResult = runInstall(false)
     }
   }
@@ -1351,11 +1358,19 @@ function fetchPluginSubtree({ plugin, pluginVersion, rpkBinPath }) {
     )
   }
 
-  const version = pluginVersion || fetchLatestPluginVersion(plugin)
+  // When the pin was applied, record it. When we fell back to latest (or no
+  // pin was given), record what the manifest says latest is: that is what
+  // actually installed.
+  const version = pinApplied ? pluginVersion : fetchLatestPluginVersion(plugin)
   if (!version) {
     console.warn(
       `Could not determine the installed version of '${plugin}'; ` +
       'plugin_versions will not be updated for this run'
+    )
+  } else if (pluginVersion && version !== pluginVersion) {
+    console.warn(
+      `Requested ${plugin} ${pluginVersion} but installed latest (${version}) ` +
+      'because rpk rejected the version pin'
     )
   }
 
@@ -1483,11 +1498,20 @@ async function handleRpkDocsGeneration(options = {}) {
         }
 
         const rpkBinPath = acquireRpkBinary(rpkVersion, { rpkBin })
-        const { node: freshNode, version: resolvedVersion } = fetchPluginSubtree({
+        const { node: rawNode, version: resolvedVersion } = fetchPluginSubtree({
           plugin,
           pluginVersion,
           rpkBinPath
         })
+
+        // Reapply platform markers: the fresh subtree comes from a plain
+        // --print-tree run, but every command in the snapshot's tree carries
+        // a platforms field. Reuse the snapshot's recorded Linux-only list.
+        const linuxOnly = new Set(tree.linux_only_commands || [])
+        const freshNode = addPlatformMarkersFromSource(
+          { commands: [rawNode] },
+          linuxOnly
+        ).commands[0]
 
         // Plugin-scoped diff for the PR summary: compare only the plugin's
         // subtree, old snapshot state vs fresh install

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -537,6 +537,7 @@ function fetchRpkTreeFromLinuxSource(sourcePath, pluginPins = {}) {
 
     // Step 2: Install plugins
     console.log('Installing plugins for complete command coverage...')
+    const failedPlugins = []
     for (const plugin of KNOWN_PLUGINS) {
       // A pin installs a specific version instead of the manifest's latest.
       // This is how pre-GA plugins (no version promoted to latest) get into a
@@ -580,6 +581,7 @@ function fetchRpkTreeFromLinuxSource(sourcePath, pluginPins = {}) {
           // commands only appear at GA unless the run pins a version.
           // See redpanda-data/docs#1801.
           console.warn(`    ✗ Failed to install ${plugin}: ${stderr || stdout}`)
+          failedPlugins.push(plugin)
         }
       }
     }

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -1428,6 +1428,24 @@ function splicePluginNode(tree, plugin, freshNode) {
 }
 
 /**
+ * Carry a snapshot's recorded Linux-only command list onto a working tree.
+ * The list comes from scanning Go build tags in the rpk source, which
+ * from-json runs (including --plugin refreshes) never see, so it can only be
+ * inherited from the existing snapshot. Without it the refreshed snapshot
+ * would lose its platform markers for every future from-json run.
+ * @param {Object} tree - Working command tree (root node)
+ * @param {Object} [fallbackTree] - Tree to inherit linux_only_commands from
+ *   when the working tree does not carry the field itself
+ * @returns {Object} Tree that carries linux_only_commands when available
+ */
+function preserveLinuxOnlyCommands(tree, fallbackTree) {
+  if (!tree || tree.linux_only_commands) return tree
+  const inherited = fallbackTree && fallbackTree.linux_only_commands
+  if (!inherited) return tree
+  return { ...tree, linux_only_commands: [...inherited] }
+}
+
+/**
  * Parse the local "Flags:" section of cobra --help output into flag objects
  * matching the shape rpk --print-tree emits for compiled-in commands.
  * The "Global Flags:" section is ignored: rpk-core globals are documented by
@@ -1715,6 +1733,10 @@ async function handleRpkDocsGeneration(options = {}) {
       console.log(`Loading command tree from ${jsonPath}`)
       const jsonData = JSON.parse(fs.readFileSync(jsonPath, 'utf8'))
       tree = jsonData.raw_tree || jsonData.tree
+      // Inherit the Linux-only command list from whichever stored tree
+      // carries it: it cannot be re-detected without the rpk source, and
+      // both rendering and the re-saved snapshot below depend on it.
+      tree = preserveLinuxOnlyCommands(tree, jsonData.tree || jsonData.raw_tree)
       rpkVersion = jsonData.rpk_version || 'local'
 
       if (!tree) {
@@ -1834,6 +1856,10 @@ async function handleRpkDocsGeneration(options = {}) {
       // recorded version become the new baseline (mirrors the from-source
       // path's augmentedData structure)
       if (plugin) {
+        // The Linux-only list can't be re-detected during a plugin refresh
+        // (it comes from Go build-tag scanning of the rpk source), so make
+        // sure the saved snapshot's trees still carry it before persisting.
+        tree = preserveLinuxOnlyCommands(tree, jsonData.raw_tree || jsonData.tree)
         let enhancedTree = tree
         if (overridesData) {
           const resolvedOverrides = resolveReferences(overridesData, overridesData)
@@ -2506,6 +2532,7 @@ module.exports = {
   fetchLatestPluginVersion,
   pluginNodeHasRealCommands,
   splicePluginNode,
+  preserveLinuxOnlyCommands,
   REFRESHABLE_PLUGINS,
   PLUGIN_INSTALL_VERSION_FLAGS,
   PLUGIN_MANIFEST_SLUGS,

--- a/tools/rpk-docs/templates/command.hbs
+++ b/tools/rpk-docs/templates/command.hbs
@@ -24,6 +24,11 @@ ifndef::env-cloud[]
 {{/each}}
 
 // tag::single-source[]
+:description: {{{wrapDescriptionPassthrough shortDesc}}}
+{{!-- The description attribute is repeated inside the tagged region so
+     single-sourcing consumers (stub pages that include this tag) inherit
+     the meta description. page-aliases and page-platforms deliberately stay
+     outside the tag: consumers must not inherit alias registrations. --}}
 {{!-- Deprecation notice --}}
 {{#if deprecated}}
 [CAUTION]

--- a/tools/rpk-docs/templates/content-item.hbs
+++ b/tools/rpk-docs/templates/content-item.hbs
@@ -2,7 +2,7 @@
 {{~#if (eq type "example")~}}
 {{!-- Single structured example --}}
 {{#if description}}
-{{{description}}}.
+{{{ensurePeriod description}}}
 
 {{/if}}
 [,{{#if language}}{{language}}{{else}}bash{{/if}}{{#if attributes}}{{#each attributes}}{{#if @first}},{{/if}}{{@key}}="{{this}}"{{/each}}{{/if}}]
@@ -27,7 +27,7 @@ This section provides examples of how to use `{{commandPath}}`.
 
 {{#each items}}
 {{#if description}}
-{{{description}}}.
+{{{ensurePeriod description}}}
 
 {{/if}}
 [,{{#if language}}{{language}}{{else}}bash{{/if}}{{#if attributes}}{{#each attributes}}{{#if @first}},{{/if}}{{@key}}="{{this}}"{{/each}}{{/if}}]


### PR DESCRIPTION
## Summary

rpk plugins release on their own cadence, independent of rpk itself: connect ships ~weekly from redpanda-data/connect, rpk ai several times a week from cloudv2's `adp/v*` tags, rpk k8s per operator release, and rpk check from redpanda-data/redpanda-check. Their docs currently refresh only when a Redpanda release triggers a full rpk regeneration.

This adds a `--plugin` mode so a single plugin's docs can be regenerated on the plugin's own release schedule:

```
doc-tools generate rpk-docs --plugin connect --plugin-version 4.102.0 --from-json docs-data/rpk-v26.1.12.json
```

### How it works (splice-and-rerender)

1. Acquire an rpk binary matching the snapshot's `rpk_version` — official release download for published tags, build-from-source fallback for RC snapshots (RC releases are drafts, so their assets are not publicly downloadable). `--rpk-bin` skips both for local runs.
2. Install only the target plugin in an isolated `HOME` (pinned via the plugin's version flag when `--plugin-version` is given), run `rpk --print-tree`, and extract the plugin's top-level node.
3. Reapply platform markers from the snapshot's recorded `linux_only_commands`, splice the node into the snapshot (replace-only), record the version in `plugin_versions`, and save.
4. Re-render the **full** tree with normal `--from-json` semantics. Only the plugin's pages change in git, and stale-file cleanup, the nav rebuild, and override validation all see a complete tree.

### Also fixed along the way

- `plugin_versions` plumbing (snapshot field → page context → "introduced in {plugin} version X" template) existed end-to-end but was never populated. `--plugin` records the refreshed version, the from-source path now records manifest versions for plugins that actually installed, and `--from-json` passes recorded versions through instead of hardcoding `{}`.
- rpk's install version validation caps each version segment at two digits (`^v?\d{1,2}\.\d{1,2}\.\d{1,2}` in `pkg/cli/connect/install.go`), so pins like connect **4.102.0** are rejected. The installer falls back to latest and records the manifest-resolved version. Upstream bug worth filing against rpk.

### Validation (against real docs snapshots)

- `--plugin connect` on main's `rpk-v26.1.12.json`: only the snapshot, nav, and `rpk-connect/` pages change; platform markers preserved; second run changes only `generated_at`.
- `--plugin k8s --plugin-version 26.2.1-beta.3` on beta's `rpk-v26.2.1-rc2.json`: exercises the source-build fallback and the pre-GA pin, and restores the 5 `rpk k8s multicluster` pages that the rc2 regen deleted (redpanda-data/docs#1831).
- `--plugin k8s` against main's snapshot: clean skip with exit 0 (no `k8s` command in rpk 26.1).
- 298 jest tests pass, including new coverage for the splice and shim-detection logic.

Consumer side: redpanda-data/docs gains an `update-rpk-plugin-docs` workflow that calls this mode, with senders in each plugin's release workflow.

## Test it locally

Everything runs against the **real committed snapshots** in the docs repo — no Docker, no Redpanda build. You need Node 20+, this branch, and a checkout of redpanda-data/docs on `main`.

```bash
# 1. This branch
git clone https://github.com/redpanda-data/docs-extensions-and-macros
cd docs-extensions-and-macros
git checkout feat/rpk-plugin-docs
npm install
DOC_TOOLS=$PWD/bin/doc-tools.js

# 2. From a clean docs-repo checkout (main):
cd /path/to/docs
```

**A. Release diff → What's-new + PR summary** (the change-detection overhaul, ~1 min):

```bash
node $DOC_TOOLS generate rpk-docs \
  --from-json docs-data/rpk-v26.2.1-rc2.json \
  --diff v26.1.12 \
  --update-whats-new \
  --summary-file /tmp/pr-summary.md
```

Then look at:
- The console diff report: **Deprecated commands: 1** — `rpk redpanda admin` with the `rpk cluster` migration message (the old pipeline reported these as 12 removals).
- `/tmp/pr-summary.md`: the change table now includes changed flag defaults / descriptions, each with itemized lists.
- `git diff modules/get-started/pages/release-notes/redpanda.adoc`: a `// AUTOGEN-RPK-CHANGES … START/END` block appended **inside** the existing hand-written `== Redpanda CLI (rpk)` section, which is left untouched. Re-run the command — the block is replaced, not duplicated.

**B. Single-plugin refresh** (the `--plugin` mode, ~1–2 min, downloads a released rpk binary + the plugin):

```bash
git checkout -- . && git clean -fd modules docs-data
node $DOC_TOOLS generate rpk-docs \
  --plugin ai \
  --from-json docs-data/rpk-v26.2.1-rc2.json \
  --update-whats-new
```

> Use the **newest** snapshot on the branch (what the workflow auto-selects). Running against an older snapshot regenerates pages for an rpk line the branch has moved past. Expect one-time modifications across all rpk pages on the first 5.3.0 run (the `:description:`-in-tag template change), `Preserving rpk-check/ … rpk-k8s/` log lines (shim-only plugins in the rc2 snapshot are protected, not deleted), and exactly two deletions: the stale `rpk-ai-llm.adoc`/`rpk-ai-mcp-create.adoc` partials that redpanda-data/docs#1849 also removes.

Then look at:
- `git status`: only the snapshot, `rpk-ai` partials, nav, overrides, and the release-notes page change — nothing else.
- The snapshot's `plugin_versions` now records the installed ai version, and new plugin commands got `introducedInVersion` stamped with the **plugin** version in `docs-data/rpk-overrides.json`.
- The release-notes page gained a `== rpk plugins` section with an `=== ai plugin <version>` block (plain command names, no xrefs — ai renders as partials).

**C. Unit tests**: `npm test` in this repo (797 tests; the rpk-docs suites are `npx jest __tests__/tools/rpk-docs/`).

Reset the docs repo with `git checkout -- . && git clean -fd modules docs-data` when done.


## Related Jira

- **DOC-2355** (rp-connect-docs#132): users asked for a reference listing the Connect CLI's commands, arguments, and options. The plugin flag extraction here (cobra + urfave/cli parsers) makes those options documentable for the first time, and the `rpk-plugin-stubs` reconciler can publish the reference on the RPCN site via page-family single-source stubs (workflows drafted, pending the RPCN team's placement decision).
- **DOC-1090**: groundwork for the deprecations redesign — rpk command deprecations are now detected automatically from source, reported in What's-new and PR summaries with migration messages, and page deprecation banners are auto-annotated in overrides.


## Related PRs (rpk docs automation train)

| PR | Role | Depends on |
|---|---|---|
| redpanda-data/docs-extensions-and-macros#225 | Generator: `--plugin` mode, change detection, deprecations, What's-new merge, flag extraction, stub reconciler (publishes doc-tools 5.3.0) | — |
| redpanda-data/docs#1834 | Receiver workflow for plugin-release dispatches | #225 |
| redpanda-data/docs#1844 | Release workflow: auto What's-new diff base + pre-GA plugin pins | #225 |
| redpanda-data/docs#1849 | Removes two stale rpk ai partials | merge before #1852/adp-docs#165 activate |
| redpanda-data/docs#1852 | Sender: docs main → adp-docs stub sync dispatch | #225, adp-docs#165 |
| redpanda-data/adp-docs#165 | Receiver: reconciles rpk ai stubs and nav | #225, docs#1852 |
| Senders (merged/open) | redpanda-data/connect#4636, redpanda-operator#1703 (merged), redpanda-check#10, cloudv2#28552 | docs#1834 |

Merge order: #225 → dependency bumps on docs main and beta → #1834 + #1844 (+ #1849) → #1852 + adp-docs#165 → remaining senders. Jira: DOC-2355, DOC-1090.

