### PR TITLE
fix(rpk-docs): restore Linux-only platform detection on Linux CI runners

### DIFF
--- a/__tests__/tools/rpk-docs/detect-platform-commands.test.js
+++ b/__tests__/tools/rpk-docs/detect-platform-commands.test.js
@@ -1,0 +1,632 @@
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const {
+  detectLinuxOnlyFromSource,
+  findLinuxConstrainedFiles,
+  warnIfDetectionLooksBroken,
+  fileBuildsOn,
+  goosFromFileName,
+  evaluateBuildExpr,
+  evaluatePlusBuildLines,
+  parseConstructors,
+  parseAddCommandRefs
+} = require('../../../tools/rpk-docs/detect-platform-commands.js')
+
+const { addPlatformMarkersFromSource } = require('../../../tools/rpk-docs/rpk-docs-handler.js')
+
+/**
+ * Write a synthetic source tree: {relativePath: content} pairs
+ */
+function writeSourceTree(root, files) {
+  for (const [relPath, content] of Object.entries(files)) {
+    const fullPath = path.join(root, relPath)
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true })
+    fs.writeFileSync(fullPath, content)
+  }
+}
+
+describe('detect-platform-commands', () => {
+  let tempDir
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rpk-platform-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  describe('goosFromFileName', () => {
+    test('detects GOOS suffix', () => {
+      expect(goosFromFileName('redpanda_darwin.go')).toBe('darwin')
+      expect(goosFromFileName('bundle_linux.go')).toBe('linux')
+      expect(goosFromFileName('root_windows.go')).toBe('windows')
+    })
+
+    test('detects GOOS_GOARCH suffix', () => {
+      expect(goosFromFileName('cpu_linux_arm64.go')).toBe('linux')
+    })
+
+    test('GOARCH alone does not constrain the OS', () => {
+      expect(goosFromFileName('cpu_arm64.go')).toBeNull()
+    })
+
+    test('non-GOOS words after underscore are not constraints', () => {
+      expect(goosFromFileName('bundle_all.go')).toBeNull()
+      expect(goosFromFileName('bundle_k8s.go')).toBeNull()
+      expect(goosFromFileName('start.go')).toBeNull()
+    })
+
+    test('embedded GOOS word only counts as trailing suffix', () => {
+      // bundle_k8s_linux.go -> linux; linux_thing.go -> no constraint
+      expect(goosFromFileName('bundle_k8s_linux.go')).toBe('linux')
+      expect(goosFromFileName('linux_thing.go')).toBeNull()
+    })
+  })
+
+  describe('evaluateBuildExpr', () => {
+    test('plain GOOS tag', () => {
+      expect(evaluateBuildExpr('linux', 'linux')).toBe(true)
+      expect(evaluateBuildExpr('linux', 'darwin')).toBe(false)
+      expect(evaluateBuildExpr('darwin', 'darwin')).toBe(true)
+    })
+
+    test('negation', () => {
+      expect(evaluateBuildExpr('!linux', 'darwin')).toBe(true)
+      expect(evaluateBuildExpr('!linux', 'linux')).toBe(false)
+    })
+
+    test('boolean operators and parentheses', () => {
+      expect(evaluateBuildExpr('linux || darwin', 'darwin')).toBe(true)
+      expect(evaluateBuildExpr('linux && amd64', 'linux')).toBe(true)
+      expect(evaluateBuildExpr('linux && amd64', 'darwin')).toBe(false)
+      expect(evaluateBuildExpr('(linux || darwin) && !windows', 'linux')).toBe(true)
+    })
+
+    test('unix matches both linux and darwin', () => {
+      expect(evaluateBuildExpr('unix', 'linux')).toBe(true)
+      expect(evaluateBuildExpr('unix', 'darwin')).toBe(true)
+    })
+
+    test('unknown custom tags are unset by default', () => {
+      expect(evaluateBuildExpr('withasan', 'linux')).toBe(false)
+      expect(evaluateBuildExpr('!integration', 'linux')).toBe(true)
+    })
+  })
+
+  describe('evaluatePlusBuildLines', () => {
+    test('single OS', () => {
+      expect(evaluatePlusBuildLines(['linux'], 'linux')).toBe(true)
+      expect(evaluatePlusBuildLines(['linux'], 'darwin')).toBe(false)
+    })
+
+    test('space is OR, comma is AND, lines are AND', () => {
+      expect(evaluatePlusBuildLines(['linux darwin'], 'darwin')).toBe(true)
+      expect(evaluatePlusBuildLines(['linux,amd64'], 'linux')).toBe(true)
+      expect(evaluatePlusBuildLines(['linux', '!darwin'], 'linux')).toBe(true)
+      expect(evaluatePlusBuildLines(['linux', 'darwin'], 'linux')).toBe(false)
+    })
+  })
+
+  describe('fileBuildsOn', () => {
+    test('combines filename suffix and explicit tag', () => {
+      expect(fileBuildsOn('foo_linux.go', 'package foo\n', 'linux')).toBe(true)
+      expect(fileBuildsOn('foo_linux.go', 'package foo\n', 'darwin')).toBe(false)
+      expect(fileBuildsOn('foo.go', '//go:build linux\n\npackage foo\n', 'darwin')).toBe(false)
+      expect(fileBuildsOn('foo.go', 'package foo\n', 'darwin')).toBe(true)
+    })
+
+    test('build tags after the package clause are ignored', () => {
+      const content = 'package foo\n\n// mentions //go:build linux in a comment\n'
+      expect(fileBuildsOn('foo.go', content, 'darwin')).toBe(true)
+    })
+  })
+
+  describe('parseConstructors', () => {
+    test('extracts Use name and exclusion markers', () => {
+      const content = `package redpanda
+
+func NewCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "redpanda",
+		Short: "Interact with a local Redpanda process",
+	}
+	return cmd
+}
+
+func NewAdminCommand(fs afero.Fs) *cobra.Command {
+	return &cobra.Command{
+		Use:        "admin",
+		Hidden:     true,
+		Deprecated: "use rpk cluster",
+	}
+}
+`
+      const ctors = parseConstructors(content)
+      expect(ctors.NewCommand.useName).toBe('redpanda')
+      expect(ctors.NewCommand.excluded).toBe(false)
+      expect(ctors.NewAdminCommand.useName).toBe('admin')
+      expect(ctors.NewAdminCommand.excluded).toBe(true)
+    })
+
+    test('takes only the first token of a Use line with arguments', () => {
+      const content = `package foo
+func NewCommand() *cobra.Command {
+	return &cobra.Command{Use: "create [TOPIC]..."}
+}
+`
+      expect(parseConstructors(content).NewCommand.useName).toBe('create')
+    })
+  })
+
+  describe('parseAddCommandRefs', () => {
+    test('captures qualified and unqualified constructor calls', () => {
+      const content = `package cli
+func addCmds(cmd *cobra.Command) {
+	cmd.AddCommand(
+		redpanda.NewCommand(fs, p, rp.NewLauncher()),
+		iotune.NewCommand(fs, p),
+		NewStartCommand(fs, p),
+	)
+}
+`
+      const refs = parseAddCommandRefs(content)
+      const asStrings = refs.map(r => `${r.qualifier || ''}.${r.funcName}`)
+      expect(asStrings).toContain('redpanda.NewCommand')
+      expect(asStrings).toContain('iotune.NewCommand')
+      expect(asStrings).toContain('.NewStartCommand')
+    })
+  })
+
+  describe('detectLinuxOnlyFromSource', () => {
+    /**
+     * Synthetic source tree replicating the modern rpk layout
+     * (pkg/cli/<command>/) and its platform-gating patterns as of
+     * v26.2.1-rc2, including the dual-registration redpanda pattern.
+     */
+    const modernFixture = {
+      'cmd/rpk/main.go': 'package main\n\nfunc main() {}\n',
+      'pkg/cli/root.go': `package cli
+
+func Execute() {
+	root := &cobra.Command{Use: "rpk"}
+	root.AddCommand(
+		topic.NewCommand(fs, p),
+		debug.NewCommand(fs, p),
+	)
+	addPlatformDependentCmds(fs, p, root)
+}
+`,
+      // Filename-implied linux constraint (no explicit tag), like real rpk
+      'pkg/cli/root_linux.go': `package cli
+
+func addPlatformDependentCmds(fs afero.Fs, p *config.Params, cmd *cobra.Command) {
+	cmd.AddCommand(
+		redpanda.NewCommand(fs, p, rp.NewLauncher()),
+		iotune.NewCommand(fs, p),
+	)
+
+	// deprecated
+	cmd.AddCommand(
+		newConfigCommand(fs, p),
+		newTuneCommand(fs, p),
+	)
+}
+
+func newConfigCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return cobraext.DeprecateCmd(redpanda.NewConfigCommand(fs, p), "rpk redpanda config")
+}
+
+func newTuneCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return cobraext.DeprecateCmd(tune.NewCommand(fs, p), "rpk redpanda tune")
+}
+`,
+      'pkg/cli/root_darwin.go': `package cli
+
+func addPlatformDependentCmds(fs afero.Fs, p *config.Params, cmd *cobra.Command) {
+	cmd.AddCommand(redpanda.NewRedpandaDarwinCommand(fs, p))
+}
+`,
+      'pkg/cli/topic/topic.go': `package topic
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{Use: "topic"}
+}
+`,
+      // Dual registration: linux variant registers the full subtree
+      'pkg/cli/redpanda/redpanda.go': `//go:build linux
+
+package redpanda
+
+func NewCommand(fs afero.Fs, p *config.Params, launcher rp.Launcher) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "redpanda",
+		Short: "Interact with a local Redpanda process",
+	}
+	cmd.AddCommand(
+		NewStartCommand(fs, p, launcher),
+		NewStopCommand(fs, p),
+		NewCheckCommand(fs, p),
+		NewModeCommand(fs, p),
+		NewConfigCommand(fs, p),
+
+		tune.NewCommand(fs, p),
+		// deprecated
+		admin.NewCommand(fs, p),
+	)
+	return cmd
+}
+`,
+      // ...while the darwin variant registers a reduced subtree
+      'pkg/cli/redpanda/redpanda_darwin.go': `//go:build darwin
+
+package redpanda
+
+func NewRedpandaDarwinCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "redpanda",
+		Short: "Interact with a local or remote Redpanda process",
+	}
+	cmd.AddCommand(admin.NewCommand(fs, p))
+	return cmd
+}
+`,
+      'pkg/cli/redpanda/start.go': `//go:build linux
+
+package redpanda
+
+func NewStartCommand(fs afero.Fs, p *config.Params, launcher rp.Launcher) *cobra.Command {
+	return &cobra.Command{Use: "start"}
+}
+`,
+      'pkg/cli/redpanda/stop.go': `//go:build linux
+
+package redpanda
+
+func NewStopCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{Use: "stop"}
+}
+`,
+      'pkg/cli/redpanda/check.go': `//go:build linux
+
+package redpanda
+
+func NewCheckCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{Use: "check"}
+}
+`,
+      'pkg/cli/redpanda/mode.go': `//go:build linux
+
+package redpanda
+
+func NewModeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{Use: "mode {development, production}"}
+}
+`,
+      'pkg/cli/redpanda/config.go': `//go:build linux
+
+package redpanda
+
+func NewConfigCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{Use: "config"}
+}
+`,
+      // Hidden + deprecated command, present on both platforms
+      'pkg/cli/redpanda/admin/admin.go': `package admin
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{
+		Use:        "admin",
+		Hidden:     true,
+		Deprecated: "use rpk cluster subcommands",
+	}
+}
+`,
+      // Whole package Linux-gated
+      'pkg/cli/redpanda/tune/tune.go': `//go:build linux
+
+package tune
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{Use: "tune"}
+}
+`,
+      'pkg/cli/redpanda/tune/list.go': `//go:build linux
+
+package tune
+
+func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{Use: "list"}
+}
+`,
+      // Whole package Linux-gated (explicit tag)
+      'pkg/cli/iotune/iotune.go': `//go:build linux
+
+package iotune
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{Use: "iotune"}
+}
+`,
+      'pkg/cli/debug/debug.go': `package debug
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{Use: "debug"}
+	cmd.AddCommand(bundle.NewCommand(fs, p))
+	return cmd
+}
+`,
+      // Linux-gated implementation WITH a darwin-buildable counterpart:
+      // the command exists on both platforms and must NOT be Linux-only
+      'pkg/cli/debug/bundle/bundle.go': `//go:build linux
+
+package bundle
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{Use: "bundle"}
+}
+`,
+      'pkg/cli/debug/bundle/bundle_all.go': `//go:build !linux
+
+package bundle
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{Use: "bundle"}
+}
+`,
+      'pkg/cli/debug/bundle/bundle_k8s_linux.go': `//go:build linux
+
+package bundle
+
+func executeK8SBundle() error { return nil }
+`
+    }
+
+    test('modern pkg/cli layout: detects whole-package and dual-registration gating', () => {
+      writeSourceTree(tempDir, modernFixture)
+      const result = detectLinuxOnlyFromSource(tempDir)
+
+      expect([...result].sort()).toEqual([
+        'rpk iotune',
+        'rpk redpanda check',
+        'rpk redpanda config',
+        'rpk redpanda mode',
+        'rpk redpanda start',
+        'rpk redpanda stop',
+        'rpk redpanda tune'
+      ])
+    })
+
+    test('dual registration keeps shared commands cross-platform', () => {
+      writeSourceTree(tempDir, modernFixture)
+      const result = detectLinuxOnlyFromSource(tempDir)
+
+      // rpk redpanda exists on darwin too (reduced variant)
+      expect(result.has('rpk redpanda')).toBe(false)
+      // Hidden/deprecated admin never shows in --print-tree; not a diff
+      expect(result.has('rpk redpanda admin')).toBe(false)
+      // Cross-platform commands are untouched
+      expect(result.has('rpk topic')).toBe(false)
+      expect(result.has('rpk debug')).toBe(false)
+    })
+
+    test('linux-gated file with a !linux counterpart is not Linux-only', () => {
+      writeSourceTree(tempDir, modernFixture)
+      const result = detectLinuxOnlyFromSource(tempDir)
+      expect(result.has('rpk debug bundle')).toBe(false)
+    })
+
+    test('deprecated top-level aliases are not reported', () => {
+      writeSourceTree(tempDir, modernFixture)
+      const result = detectLinuxOnlyFromSource(tempDir)
+      // root_linux.go registers deprecated (hidden) rpk config / rpk tune
+      expect(result.has('rpk config')).toBe(false)
+      expect(result.has('rpk tune')).toBe(false)
+      // Non-command helper arguments are not misread as commands
+      expect(result.has('rpk rp')).toBe(false)
+    })
+
+    test('_linux.go filename suffix counts as a Linux constraint', () => {
+      writeSourceTree(tempDir, {
+        'pkg/cli/root.go': 'package cli\n',
+        'pkg/cli/foo/foo_linux.go': `package foo
+
+func NewCommand(fs afero.Fs) *cobra.Command {
+	return &cobra.Command{Use: "foo"}
+}
+`
+      })
+      const result = detectLinuxOnlyFromSource(tempDir)
+      expect(result.has('rpk foo')).toBe(true)
+    })
+
+    test('legacy pkg/cli/cmd layout with +build tags', () => {
+      writeSourceTree(tempDir, {
+        'pkg/cli/cmd/root.go': 'package cmd\n',
+        'pkg/cli/cmd/iotune/iotune.go': `// +build linux
+
+package iotune
+
+func NewCommand(fs afero.Fs) *cobra.Command {
+	return &cobra.Command{Use: "iotune"}
+}
+`
+      })
+      const result = detectLinuxOnlyFromSource(tempDir)
+      expect(result.has('rpk iotune')).toBe(true)
+    })
+
+    test('legacy cmd/rpk layout', () => {
+      writeSourceTree(tempDir, {
+        'cmd/rpk/main.go': 'package main\n\nfunc main() {}\n',
+        'cmd/rpk/iotune/iotune.go': `//go:build linux
+
+package iotune
+
+func NewCommand(fs afero.Fs) *cobra.Command {
+	return &cobra.Command{Use: "iotune"}
+}
+`
+      })
+      const result = detectLinuxOnlyFromSource(tempDir)
+      expect(result.has('rpk iotune')).toBe(true)
+    })
+
+    test('descendants of a Linux-only package are collapsed into the root path', () => {
+      writeSourceTree(tempDir, modernFixture)
+      const result = detectLinuxOnlyFromSource(tempDir)
+      // rpk redpanda tune list is implied by rpk redpanda tune
+      expect(result.has('rpk redpanda tune list')).toBe(false)
+    })
+
+    test('returns empty set for a source tree with no platform gating', () => {
+      writeSourceTree(tempDir, {
+        'pkg/cli/root.go': 'package cli\n',
+        'pkg/cli/topic/topic.go': `package topic
+
+func NewCommand(fs afero.Fs) *cobra.Command {
+	return &cobra.Command{Use: "topic"}
+}
+`
+      })
+      expect(detectLinuxOnlyFromSource(tempDir).size).toBe(0)
+    })
+
+    test('missing scan roots return an empty set without throwing', () => {
+      expect(detectLinuxOnlyFromSource(tempDir).size).toBe(0)
+    })
+
+    describe('v26.2.1-rc2 expected set (fixture frozen from empirical ground truth)', () => {
+      // Ground truth generated 2026-07-28 by building rpk from the
+      // v26.2.1-rc2 tag natively on macOS and in a Linux container,
+      // running --print-tree on both, and diffing the trees.
+      const RC2_LINUX_ONLY_ROOTS = [
+        'rpk iotune',
+        'rpk redpanda check',
+        'rpk redpanda config',
+        'rpk redpanda mode',
+        'rpk redpanda start',
+        'rpk redpanda stop',
+        'rpk redpanda tune'
+      ]
+
+      const RC2_EXPANDED_LINUX_ONLY = [
+        'rpk iotune',
+        'rpk redpanda check',
+        'rpk redpanda config',
+        'rpk redpanda config bootstrap',
+        'rpk redpanda config init',
+        'rpk redpanda config print',
+        'rpk redpanda config set',
+        'rpk redpanda mode',
+        'rpk redpanda start',
+        'rpk redpanda stop',
+        'rpk redpanda tune',
+        'rpk redpanda tune help',
+        'rpk redpanda tune list'
+      ]
+
+      test('static detection roots match the dynamic Linux-vs-Darwin diff', () => {
+        writeSourceTree(tempDir, modernFixture)
+        const result = detectLinuxOnlyFromSource(tempDir)
+        expect([...result].sort()).toEqual(RC2_LINUX_ONLY_ROOTS)
+      })
+
+      test('marker expansion over the rc2 tree yields the full 13-path set', () => {
+        // Minimal replica of the built-in Linux-only subtree at rc2
+        const tree = {
+          name: 'rpk',
+          commands: [
+            { name: 'iotune' },
+            {
+              name: 'redpanda',
+              commands: [
+                { name: 'check' },
+                {
+                  name: 'config',
+                  commands: [
+                    { name: 'bootstrap' }, { name: 'init' },
+                    { name: 'print' }, { name: 'set' }
+                  ]
+                },
+                { name: 'mode' },
+                { name: 'start' },
+                { name: 'stop' },
+                { name: 'tune', commands: [{ name: 'help' }, { name: 'list' }] }
+              ]
+            },
+            { name: 'topic', commands: [{ name: 'create' }] }
+          ]
+        }
+
+        const marked = addPlatformMarkersFromSource(tree, new Set(RC2_LINUX_ONLY_ROOTS))
+        expect(marked.linux_only_commands).toEqual(RC2_EXPANDED_LINUX_ONLY)
+
+        const topic = marked.commands.find(c => c.name === 'topic')
+        expect(topic.platforms).toEqual(['linux', 'darwin'])
+        const redpanda = marked.commands.find(c => c.name === 'redpanda')
+        expect(redpanda.platforms).toEqual(['linux', 'darwin'])
+        expect(redpanda.commands.find(c => c.name === 'start').platforms).toEqual(['linux'])
+      })
+    })
+  })
+
+  describe('findLinuxConstrainedFiles', () => {
+    test('lists files with explicit tags and filename suffixes', () => {
+      writeSourceTree(tempDir, {
+        'pkg/cli/iotune/iotune.go': '//go:build linux\n\npackage iotune\n',
+        'pkg/cli/foo/foo_linux.go': 'package foo\n',
+        'pkg/cli/topic/topic.go': 'package topic\n'
+      })
+      const files = findLinuxConstrainedFiles(tempDir)
+      expect(files).toContain(path.join('pkg', 'cli', 'iotune', 'iotune.go'))
+      expect(files).toContain(path.join('pkg', 'cli', 'foo', 'foo_linux.go'))
+      expect(files).not.toContain(path.join('pkg', 'cli', 'topic', 'topic.go'))
+    })
+  })
+
+  describe('warnIfDetectionLooksBroken (tripwire)', () => {
+    let warnSpy
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      warnSpy.mockRestore()
+    })
+
+    test('fires when detection is empty but source has Linux-gated files', () => {
+      writeSourceTree(tempDir, {
+        'pkg/cli/iotune/iotune.go': '//go:build linux\n\npackage iotune\n'
+      })
+      const fired = warnIfDetectionLooksBroken(tempDir, new Set())
+      expect(fired).toBe(true)
+      const output = warnSpy.mock.calls.map(c => c.join(' ')).join('\n')
+      expect(output).toContain('PLATFORM DETECTION TRIPWIRE')
+      expect(output).toContain(path.join('pkg', 'cli', 'iotune', 'iotune.go'))
+    })
+
+    test('stays quiet when detection found commands', () => {
+      writeSourceTree(tempDir, {
+        'pkg/cli/iotune/iotune.go': '//go:build linux\n\npackage iotune\n'
+      })
+      const fired = warnIfDetectionLooksBroken(tempDir, new Set(['rpk iotune']))
+      expect(fired).toBe(false)
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    test('stays quiet when the source has no platform gating at all', () => {
+      writeSourceTree(tempDir, {
+        'pkg/cli/topic/topic.go': 'package topic\n'
+      })
+      const fired = warnIfDetectionLooksBroken(tempDir, new Set())
+      expect(fired).toBe(false)
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tools/rpk-docs/detect-platform-commands.js
+++ b/tools/rpk-docs/detect-platform-commands.js
@@ -1,0 +1,566 @@
+'use strict'
+
+/**
+ * Static (source-based) detection of Linux-only rpk commands.
+ *
+ * Works on any platform (including Linux CI runners, where the dynamic
+ * "build on Linux and Darwin and diff the trees" approach is impossible
+ * because a cross-compiled darwin rpk cannot be executed).
+ *
+ * How it works
+ * ------------
+ * rpk gates platform-specific commands with Go build constraints:
+ *
+ *   1. Whole-package gating: every file in a command's package carries a
+ *      Linux constraint (explicit `//go:build linux` tag or a `_linux.go`
+ *      filename suffix) and no darwin-buildable counterpart exists.
+ *      Example: pkg/cli/iotune, pkg/cli/redpanda/tune.
+ *
+ *   2. Dual registration: a package provides two variants of the same
+ *      command constructor, one per platform, registering different
+ *      subcommand sets. Example: pkg/cli/redpanda/redpanda.go
+ *      (`//go:build linux`, registers start/stop/check/mode/config/tune)
+ *      vs pkg/cli/redpanda/redpanda_darwin.go (`//go:build darwin`,
+ *      registers only the hidden admin command). Same pattern at the root:
+ *      pkg/cli/root_linux.go vs pkg/cli/root_darwin.go.
+ *
+ * This module detects both patterns:
+ *
+ *   - For every scanned package, it computes which files build on linux
+ *     and which build on darwin (from `//go:build` / `// +build` tags AND
+ *     filename-implied constraints like `_linux.go`).
+ *   - Packages whose files all fail to build on darwin (but build on
+ *     linux) and that define a cobra command constructor are Linux-only.
+ *   - Packages containing platform-differential files get a registration
+ *     diff: subcommand constructors referenced from linux-buildable files
+ *     but not from darwin-buildable files are Linux-only. Deprecated and
+ *     hidden constructors are ignored because `rpk --print-tree` (the
+ *     basis of the generated docs) excludes hidden commands.
+ *
+ * Scope: built-in commands only. Plugin commands (rpk connect, rpk ai, ...)
+ * are not part of the rpk source tree, so their platform availability
+ * cannot be derived here. Plugins keep whatever platform behavior the
+ * caller's other detection paths provide (for example, dynamic detection
+ * marks plugin-only commands when plugins are only installed in the Linux
+ * build container).
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+/** GOOS values recognized in filename suffixes and build tags */
+const KNOWN_GOOS = new Set([
+  'aix', 'android', 'darwin', 'dragonfly', 'freebsd', 'hurd', 'illumos',
+  'ios', 'js', 'linux', 'nacl', 'netbsd', 'openbsd', 'plan9', 'solaris',
+  'wasip1', 'windows', 'zos'
+])
+
+/** GOOS values that satisfy the `unix` build tag */
+const UNIX_GOOS = new Set([
+  'aix', 'android', 'darwin', 'dragonfly', 'freebsd', 'hurd', 'illumos',
+  'ios', 'linux', 'netbsd', 'openbsd', 'solaris'
+])
+
+/** GOARCH values recognized in filename suffixes */
+const KNOWN_GOARCH = new Set([
+  '386', 'amd64', 'amd64p32', 'arm', 'arm64', 'arm64be', 'armbe', 'loong64',
+  'mips', 'mips64', 'mips64le', 'mips64p32', 'mips64p32le', 'mipsle',
+  'ppc', 'ppc64', 'ppc64le', 'riscv', 'riscv64', 's390', 's390x',
+  'sparc', 'sparc64', 'wasm'
+])
+
+/**
+ * Directories (relative to the rpk source root) scanned for command
+ * implementations. Modern rpk keeps commands in pkg/cli/<command>/;
+ * the other roots cover older source layouts.
+ */
+const SCAN_ROOTS = ['pkg/cli', 'pkg/cli/cmd', 'cmd/rpk']
+
+/** Directory names that never correspond to a command path segment */
+const NON_COMMAND_SEGMENTS = new Set(['internal', 'common', 'testdata'])
+
+/**
+ * Determine the GOOS constraint implied by a Go filename.
+ * Follows Go's rules: *_GOOS.go, *_GOOS_GOARCH.go constrain the OS;
+ * *_GOARCH.go alone does not.
+ * @param {string} fileName - e.g. 'redpanda_darwin.go', 'bundle_k8s_linux.go'
+ * @returns {string|null} GOOS name or null when unconstrained
+ */
+function goosFromFileName(fileName) {
+  const base = fileName.replace(/\.go$/, '')
+  const parts = base.split('_')
+  if (parts.length < 2) return null
+
+  const last = parts[parts.length - 1]
+  if (KNOWN_GOOS.has(last)) return last
+  if (KNOWN_GOARCH.has(last) && parts.length >= 3) {
+    const secondLast = parts[parts.length - 2]
+    if (KNOWN_GOOS.has(secondLast)) return secondLast
+  }
+  return null
+}
+
+/**
+ * Evaluate a `//go:build` constraint expression for a target GOOS.
+ * Supports identifiers, !, &&, || and parentheses.
+ * Unknown identifiers (custom build tags) evaluate to false, matching a
+ * default `go build` with no -tags flag. GOARCH identifiers evaluate to
+ * true because we only care about OS-level availability.
+ * @param {string} expr - Expression after `//go:build`
+ * @param {string} goos - Target GOOS ('linux' or 'darwin')
+ * @returns {boolean}
+ */
+function evaluateBuildExpr(expr, goos) {
+  const tokens = expr.match(/[A-Za-z0-9_.]+|&&|\|\||!|\(|\)/g) || []
+  let pos = 0
+
+  const peek = () => tokens[pos]
+  const next = () => tokens[pos++]
+
+  function evalIdent(ident) {
+    if (KNOWN_GOOS.has(ident)) return ident === goos
+    if (ident === 'unix') return UNIX_GOOS.has(goos)
+    if (KNOWN_GOARCH.has(ident)) return true
+    if (ident === 'cgo') return true
+    // Custom build tags (e.g. withasan, integration) are unset by default
+    return false
+  }
+
+  function parsePrimary() {
+    const tok = next()
+    if (tok === '(') {
+      const val = parseOr()
+      if (peek() === ')') next()
+      return val
+    }
+    if (tok === '!') return !parsePrimary()
+    if (tok === undefined) return false
+    return evalIdent(tok)
+  }
+
+  function parseAnd() {
+    let val = parsePrimary()
+    while (peek() === '&&') {
+      next()
+      val = parsePrimary() && val
+    }
+    return val
+  }
+
+  function parseOr() {
+    let val = parseAnd()
+    while (peek() === '||') {
+      next()
+      val = parseAnd() || val
+    }
+    return val
+  }
+
+  return parseOr()
+}
+
+/**
+ * Evaluate legacy `// +build` lines for a target GOOS.
+ * Multiple lines AND together; within a line, space-separated options OR
+ * and comma-separated terms AND.
+ * @param {string[]} lines - Contents after `// +build` (one per line)
+ * @param {string} goos - Target GOOS
+ * @returns {boolean}
+ */
+function evaluatePlusBuildLines(lines, goos) {
+  const evalTerm = (term) => {
+    let negate = false
+    while (term.startsWith('!')) {
+      negate = !negate
+      term = term.slice(1)
+    }
+    let val
+    if (KNOWN_GOOS.has(term)) val = term === goos
+    else if (term === 'unix') val = UNIX_GOOS.has(goos)
+    else if (KNOWN_GOARCH.has(term) || term === 'cgo') val = true
+    else val = false
+    return negate ? !val : val
+  }
+
+  return lines.every(line => {
+    const options = line.trim().split(/\s+/).filter(Boolean)
+    if (options.length === 0) return true
+    return options.some(opt => opt.split(',').every(evalTerm))
+  })
+}
+
+/**
+ * Extract the build constraint (if any) from a Go file's header.
+ * Only lines before the `package` declaration are considered.
+ * @param {string} content - Go file content
+ * @returns {{goBuildExpr: string|null, plusBuildLines: string[]}}
+ */
+function extractBuildConstraint(content) {
+  const header = content.split(/^package\s/m)[0]
+  const goBuildMatch = header.match(/^\/\/go:build\s+(.+)$/m)
+  const plusBuildLines = []
+  const plusBuildRe = /^\/\/\s*\+build\s+(.+)$/gm
+  let m
+  while ((m = plusBuildRe.exec(header)) !== null) {
+    plusBuildLines.push(m[1])
+  }
+  return {
+    goBuildExpr: goBuildMatch ? goBuildMatch[1].trim() : null,
+    plusBuildLines
+  }
+}
+
+/**
+ * Determine whether a Go file builds for a target GOOS, taking both the
+ * filename-implied constraint and explicit build tags into account.
+ * @param {string} fileName - Base name of the file
+ * @param {string} content - File content
+ * @param {string} goos - Target GOOS ('linux' or 'darwin')
+ * @returns {boolean}
+ */
+function fileBuildsOn(fileName, content, goos) {
+  const fileGoos = goosFromFileName(fileName)
+  if (fileGoos && fileGoos !== goos) return false
+
+  const { goBuildExpr, plusBuildLines } = extractBuildConstraint(content)
+  if (goBuildExpr) return evaluateBuildExpr(goBuildExpr, goos)
+  if (plusBuildLines.length > 0) return evaluatePlusBuildLines(plusBuildLines, goos)
+  return true
+}
+
+/**
+ * Derive a command name from a cobra constructor function name.
+ * NewStartCommand -> start, newTuneCommand -> tune, NewCommand -> null.
+ * @param {string} funcName
+ * @returns {string|null}
+ */
+function commandNameFromConstructor(funcName) {
+  const m = funcName.match(/^(?:New|new)(\w+?)(?:Command|Cmd)$/)
+  if (m && m[1]) return m[1].toLowerCase()
+  return null
+}
+
+/**
+ * Parse cobra command constructors defined in a Go file.
+ * A constructor is any `func XxxYyy(...) *cobra.Command`. For each one we
+ * record the cobra `Use:` name (first token) and whether the command is
+ * deprecated or hidden (such commands never appear in `rpk --print-tree`).
+ * @param {string} content - Go file content
+ * @returns {Object<string, {useName: string|null, excluded: boolean}>}
+ */
+function parseConstructors(content) {
+  const constructors = {}
+  const funcRe = /^func\s+(\w+)\s*\([^)]*\)\s*\*cobra\.Command\s*\{/gm
+  const matches = []
+  let m
+  while ((m = funcRe.exec(content)) !== null) {
+    matches.push({ name: m[1], start: m.index })
+  }
+
+  for (let i = 0; i < matches.length; i++) {
+    const bodyEnd = i + 1 < matches.length ? matches[i + 1].start : content.length
+    const body = content.slice(matches[i].start, bodyEnd)
+
+    const useMatch = body.match(/\bUse:\s*"([^"]+)"/)
+    const useName = useMatch ? useMatch[1].trim().split(/\s+/)[0] : null
+
+    // Deprecated or hidden commands are excluded from `rpk --print-tree`
+    const excluded = /\bHidden:\s*true\b/.test(body) ||
+                     /\bDeprecated:\s*"/.test(body) ||
+                     /\bDeprecateCmd\s*\(/.test(body)
+
+    constructors[matches[i].name] = { useName, excluded }
+  }
+
+  return constructors
+}
+
+/**
+ * Extract constructor references from all AddCommand(...) calls in a file.
+ * Handles both same-package (`NewStartCommand(...)`) and cross-package
+ * (`tune.NewCommand(...)`) references. Only functions starting with
+ * New/new are considered, which skips wrappers like cobraext.DeprecateCmd.
+ * @param {string} content - Go file content
+ * @returns {Array<{qualifier: string|null, funcName: string}>}
+ */
+function parseAddCommandRefs(content) {
+  const refs = []
+  const addRe = /\bAddCommand\s*\(/g
+  let m
+  while ((m = addRe.exec(content)) !== null) {
+    // Find the span of this AddCommand(...) call by balancing parentheses
+    let depth = 1
+    let i = m.index + m[0].length
+    while (i < content.length && depth > 0) {
+      if (content[i] === '(') depth++
+      else if (content[i] === ')') depth--
+      i++
+    }
+    const span = content.slice(m.index + m[0].length, i - 1)
+
+    const callRe = /(?:(\w+)\.)?((?:New|new)\w*)\s*\(/g
+    let c
+    while ((c = callRe.exec(span)) !== null) {
+      refs.push({ qualifier: c[1] || null, funcName: c[2] })
+    }
+  }
+  return refs
+}
+
+/**
+ * Recursively collect non-test Go files under a directory.
+ * @param {string} dir - Absolute directory path
+ * @param {Array} out - Accumulator of {absPath, dir, name}
+ */
+function collectGoFiles(dir, out) {
+  let entries
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true })
+  } catch (err) {
+    return
+  }
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === 'testdata' || entry.name === 'vendor') continue
+      collectGoFiles(fullPath, out)
+    } else if (entry.name.endsWith('.go') && !entry.name.endsWith('_test.go')) {
+      out.push({ absPath: fullPath, dir, name: entry.name })
+    }
+  }
+}
+
+/**
+ * Build the command path prefix for a package directory.
+ * pkg/cli -> 'rpk'; pkg/cli/redpanda -> 'rpk redpanda';
+ * pkg/cli/cmd/redpanda (legacy) -> 'rpk redpanda'.
+ * @param {string} scanRoot - Absolute path of the scan root
+ * @param {string} dir - Absolute directory path
+ * @returns {string|null} Command path prefix, or null for non-command dirs
+ */
+function commandPrefixForDir(scanRoot, dir) {
+  const rel = path.relative(scanRoot, dir)
+  let segments = rel === '' ? [] : rel.split(path.sep)
+  // Legacy layouts nested commands under an extra cmd/ level
+  if (segments[0] === 'cmd') segments = segments.slice(1)
+  if (segments.some(s => NON_COMMAND_SEGMENTS.has(s))) return null
+  return ['rpk', ...segments].join(' ')
+}
+
+/**
+ * Analyze one scan root and add detected Linux-only command paths.
+ * @param {string} scanRoot - Absolute path of the scan root
+ * @param {Set<string>} linuxOnlyCommands - Accumulator
+ */
+function scanRootForLinuxOnly(scanRoot, linuxOnlyCommands) {
+  const files = []
+  collectGoFiles(scanRoot, files)
+  if (files.length === 0) return
+
+  // Group files (with parsed metadata) by directory
+  const dirs = new Map()
+  for (const file of files) {
+    let content
+    try {
+      content = fs.readFileSync(file.absPath, 'utf8')
+    } catch (err) {
+      continue
+    }
+    const info = {
+      name: file.name,
+      content,
+      buildsOnLinux: fileBuildsOn(file.name, content, 'linux'),
+      buildsOnDarwin: fileBuildsOn(file.name, content, 'darwin')
+    }
+    if (!dirs.has(file.dir)) dirs.set(file.dir, [])
+    dirs.get(file.dir).push(info)
+  }
+
+  // Per-directory constructor index: dir -> {funcName: {useName, excluded}}
+  const constructorIndex = new Map()
+  for (const [dir, dirFiles] of dirs) {
+    const index = {}
+    for (const f of dirFiles) {
+      Object.assign(index, parseConstructors(f.content))
+    }
+    constructorIndex.set(dir, index)
+  }
+
+  /**
+   * Resolve an AddCommand constructor reference to a visible command name.
+   * Returns null for deprecated/hidden/unresolvable commands.
+   */
+  const resolveRef = (dir, ref) => {
+    let target = null
+    let fallback = commandNameFromConstructor(ref.funcName)
+
+    if (ref.qualifier) {
+      const subDir = path.join(dir, ref.qualifier)
+      target = constructorIndex.get(subDir) || null
+      if (!fallback) fallback = ref.qualifier
+    } else {
+      target = constructorIndex.get(dir) || null
+    }
+
+    if (target && target[ref.funcName]) {
+      const ctor = target[ref.funcName]
+      if (ctor.excluded) return null
+      return ctor.useName || fallback
+    }
+
+    // Unresolvable reference: only trust it if the function name follows
+    // the cobra constructor convention (New[Xxx]Command). This skips
+    // helper arguments captured inside AddCommand spans, such as the
+    // rp.NewLauncher() argument in redpanda.NewCommand(fs, p, rp.NewLauncher()).
+    if (!/^(?:New|new)(?:\w*(?:Command|Cmd))?$/.test(ref.funcName)) return null
+    return fallback
+  }
+
+  for (const [dir, dirFiles] of dirs) {
+    const prefix = commandPrefixForDir(scanRoot, dir)
+    if (!prefix) continue
+
+    const hasDifferentialFile = dirFiles.some(f => f.buildsOnLinux !== f.buildsOnDarwin)
+
+    // Pattern 1: whole package is Linux-gated (and defines a command)
+    if (prefix !== 'rpk') {
+      const anyLinux = dirFiles.some(f => f.buildsOnLinux)
+      const anyDarwin = dirFiles.some(f => f.buildsOnDarwin)
+      const definesCommand = Object.keys(constructorIndex.get(dir)).length > 0
+      if (anyLinux && !anyDarwin && definesCommand) {
+        linuxOnlyCommands.add(prefix)
+        continue
+      }
+    }
+
+    // Pattern 2: dual registration - diff subcommands registered from
+    // linux-buildable files vs darwin-buildable files
+    if (!hasDifferentialFile) continue
+
+    const refsFor = (goos) => {
+      const names = new Set()
+      for (const f of dirFiles) {
+        const buildable = goos === 'linux' ? f.buildsOnLinux : f.buildsOnDarwin
+        if (!buildable) continue
+        for (const ref of parseAddCommandRefs(f.content)) {
+          const name = resolveRef(dir, ref)
+          if (name) names.add(name)
+        }
+      }
+      return names
+    }
+
+    const linuxRefs = refsFor('linux')
+    const darwinRefs = refsFor('darwin')
+
+    for (const name of linuxRefs) {
+      if (!darwinRefs.has(name)) {
+        linuxOnlyCommands.add(`${prefix} ${name}`)
+      }
+    }
+  }
+}
+
+/**
+ * Detect Linux-only rpk commands by statically analyzing Go source.
+ * Works on any platform, including Linux CI runners.
+ * @param {string} sourcePath - Path to the rpk Go source root (src/go/rpk)
+ * @returns {Set<string>} Linux-only command paths (e.g. 'rpk iotune').
+ *   Descendants of a returned path are implicitly Linux-only too.
+ */
+function detectLinuxOnlyFromSource(sourcePath) {
+  const linuxOnlyCommands = new Set()
+
+  const scannedRoots = new Set()
+  for (const root of SCAN_ROOTS) {
+    const absRoot = path.join(sourcePath, root)
+    if (!fs.existsSync(absRoot)) continue
+    // pkg/cli/cmd is nested inside pkg/cli; avoid scanning it twice
+    if ([...scannedRoots].some(r => absRoot.startsWith(r + path.sep))) continue
+    scannedRoots.add(absRoot)
+    scanRootForLinuxOnly(absRoot, linuxOnlyCommands)
+  }
+
+  // Drop any detected path that is a descendant of another detected path;
+  // platform markers already propagate to descendants.
+  for (const cmd of [...linuxOnlyCommands]) {
+    if ([...linuxOnlyCommands].some(other => other !== cmd && cmd.startsWith(other + ' '))) {
+      linuxOnlyCommands.delete(cmd)
+    }
+  }
+
+  return linuxOnlyCommands
+}
+
+/**
+ * List Go files under the scanned roots that carry a Linux-only build
+ * constraint (explicit tag or filename suffix). Used as a tripwire: if
+ * detection returns an empty set while this list is non-empty, the scan
+ * is almost certainly broken (wrong directory layout, changed tag style).
+ * @param {string} sourcePath - Path to the rpk Go source root
+ * @returns {string[]} Relative paths of Linux-constrained files
+ */
+function findLinuxConstrainedFiles(sourcePath) {
+  const results = []
+  for (const root of SCAN_ROOTS) {
+    const absRoot = path.join(sourcePath, root)
+    if (!fs.existsSync(absRoot)) continue
+    const files = []
+    collectGoFiles(absRoot, files)
+    for (const file of files) {
+      let content
+      try {
+        content = fs.readFileSync(file.absPath, 'utf8')
+      } catch (err) {
+        continue
+      }
+      if (fileBuildsOn(file.name, content, 'linux') && !fileBuildsOn(file.name, content, 'darwin')) {
+        results.push(path.relative(sourcePath, file.absPath))
+      }
+    }
+  }
+  return [...new Set(results)]
+}
+
+/**
+ * Emit a loud warning when platform detection came back empty even though
+ * the source demonstrably contains Linux-gated files. Never let a scan
+ * failure silently mark every command as cross-platform.
+ * @param {string} sourcePath - Path to the rpk Go source root
+ * @param {Set<string>} linuxOnlyCommands - Combined detection result
+ * @returns {boolean} True when the tripwire fired
+ */
+function warnIfDetectionLooksBroken(sourcePath, linuxOnlyCommands) {
+  if (linuxOnlyCommands.size > 0) return false
+
+  const constrained = findLinuxConstrainedFiles(sourcePath)
+  if (constrained.length === 0) return false
+
+  console.warn('\n' + '!'.repeat(70))
+  console.warn('⚠ PLATFORM DETECTION TRIPWIRE: no Linux-only commands were detected,')
+  console.warn(`⚠ but the rpk source contains ${constrained.length} Linux-constrained file(s), e.g.:`)
+  for (const file of constrained.slice(0, 5)) {
+    console.warn(`⚠   - ${file}`)
+  }
+  console.warn('⚠ This usually means the static source scan failed (unexpected')
+  console.warn('⚠ directory layout or build-tag style) and every command is about')
+  console.warn('⚠ to be marked as available on both Linux and macOS, which is wrong.')
+  console.warn('⚠ Fix tools/rpk-docs/detect-platform-commands.js before publishing')
+  console.warn('⚠ these docs. See redpanda-data/docs#1831 for the impact of this.')
+  console.warn('!'.repeat(70) + '\n')
+  return true
+}
+
+module.exports = {
+  detectLinuxOnlyFromSource,
+  findLinuxConstrainedFiles,
+  warnIfDetectionLooksBroken,
+  // Exported for unit tests
+  fileBuildsOn,
+  goosFromFileName,
+  evaluateBuildExpr,
+  evaluatePlusBuildLines,
+  parseConstructors,
+  parseAddCommandRefs,
+  commandNameFromConstructor
+}

--- a/tools/rpk-docs/rpk-docs-handler.js
+++ b/tools/rpk-docs/rpk-docs-handler.js
@@ -8,6 +8,7 @@ const os = require('os')
 const semver = require('semver')
 const { findRepoRoot } = require('../../cli-utils/doc-tools-utils')
 const { generateRpkDocs, applyOverridesToTree, resolveReferences, shouldExcludeCommand, shouldUsePartialDir } = require('./generate-rpk-docs')
+const { detectLinuxOnlyFromSource, warnIfDetectionLooksBroken } = require('./detect-platform-commands')
 const { generateRpkDiff, printDiffReport, generateWhatsNewSection, flattenToMap } = require('./report-delta')
 const { loadAndValidateOverrides, ValidationResult } = require('./validate-overrides')
 const { validateDirectory, formatResults } = require('./validate-output')
@@ -657,105 +658,6 @@ function fetchRpkTreeFromLinuxSource(sourcePath, pluginPins = {}) {
 }
 
 /**
- * Scan Go source files for Linux-only build tags
- * Looks for //go:build linux or // +build linux
- * @param {string} sourcePath - Path to rpk Go source directory
- * @returns {Set<string>} Set of Linux-only command paths (e.g., 'rpk redpanda tune')
- */
-function detectLinuxOnlyFromSource(sourcePath) {
-  const linuxOnlyCommands = new Set()
-
-  // Map of source directory patterns to command paths
-  // rpk commands are typically in pkg/cli/cmd/<command>/<subcommand>/
-  const scanDirectory = (dir, prefix = '') => {
-    if (!fs.existsSync(dir)) return
-
-    const entries = fs.readdirSync(dir, { withFileTypes: true })
-
-    for (const entry of entries) {
-      const fullPath = path.join(dir, entry.name)
-
-      if (entry.isDirectory()) {
-        // Recurse into subdirectories
-        const newPrefix = prefix ? `${prefix} ${entry.name}` : entry.name
-        scanDirectory(fullPath, newPrefix)
-      } else if (entry.name.endsWith('.go') && !entry.name.endsWith('_test.go')) {
-        // Check Go files for build tags
-        try {
-          const content = fs.readFileSync(fullPath, 'utf8')
-          const firstLines = content.split('\n').slice(0, 20).join('\n')
-
-          // Check for Linux build constraints
-          const hasLinuxTag = /\/\/go:build\s+.*linux/.test(firstLines) ||
-                             /\/\/\s*\+build\s+.*linux/.test(firstLines)
-
-          if (hasLinuxTag) {
-            // Try to determine command path from file location
-            const commandPath = inferCommandPath(sourcePath, fullPath, entry.name)
-            if (commandPath) {
-              linuxOnlyCommands.add(commandPath)
-            }
-          }
-        } catch (err) {
-          // Skip files we can't read
-        }
-      }
-    }
-  }
-
-  // Scan the cmd/rpk directory for command implementations
-  const cmdDir = path.join(sourcePath, 'pkg', 'cli', 'cmd')
-  if (fs.existsSync(cmdDir)) {
-    scanDirectory(cmdDir, 'rpk')
-  }
-
-  // Also check the older structure
-  const oldCmdDir = path.join(sourcePath, 'cmd', 'rpk')
-  if (fs.existsSync(oldCmdDir)) {
-    scanDirectory(oldCmdDir, 'rpk')
-  }
-
-  return linuxOnlyCommands
-}
-
-/**
- * Infer command path from Go source file location
- * @param {string} sourcePath - Root source path
- * @param {string} filePath - Full path to Go file
- * @param {string} fileName - Name of the Go file
- * @returns {string|null} Command path or null
- */
-function inferCommandPath(sourcePath, filePath, fileName) {
-  // Get relative path from source root
-  const relativePath = filePath.replace(sourcePath, '').replace(/^\//, '')
-
-  // Common patterns:
-  // pkg/cli/cmd/redpanda/tune.go -> rpk redpanda tune
-  // pkg/cli/cmd/redpanda/start.go -> rpk redpanda start
-  // cmd/rpk/iotune/iotune.go -> rpk iotune
-
-  // Remove common prefixes and file extension
-  let parts = relativePath
-    .replace(/^pkg\/cli\/cmd\//, '')
-    .replace(/^cmd\/rpk\//, '')
-    .replace(/\.go$/, '')
-    .split('/')
-
-  // If file name matches directory name, use directory only
-  // e.g., iotune/iotune.go -> iotune
-  if (parts.length > 1 && parts[parts.length - 1] === parts[parts.length - 2]) {
-    parts = parts.slice(0, -1)
-  }
-
-  // Filter out common non-command directories
-  parts = parts.filter(p => !['internal', 'common', 'config', 'cmd'].includes(p))
-
-  if (parts.length === 0) return null
-
-  return 'rpk ' + parts.join(' ')
-}
-
-/**
  * Add platform markers to command tree based on source analysis
  * @param {Object} tree - Command tree from rpk --print-tree
  * @param {Set<string>} linuxOnlyCommands - Set of Linux-only command paths
@@ -769,11 +671,18 @@ function addPlatformMarkersFromSource(tree, linuxOnlyCommands) {
            [...linuxOnlyCommands].some(loc => cmdPath.startsWith(loc + ' '))
   }
 
+  // Collect every tree path actually marked Linux-only so the persisted
+  // linux_only_commands list is fully expanded (each descendant listed),
+  // matching what dynamic Linux-vs-Darwin tree comparison produces.
+  const markedPaths = new Set()
+
   const markCommands = (commands, parentPath = 'rpk') => {
     if (!commands) return commands
     return commands.map(cmd => {
       const fullPath = `${parentPath} ${cmd.name}`
-      const platforms = isLinuxOnly(fullPath)
+      const linuxOnly = isLinuxOnly(fullPath)
+      if (linuxOnly) markedPaths.add(fullPath)
+      const platforms = linuxOnly
         ? [PLATFORMS.LINUX]
         : [PLATFORMS.LINUX, PLATFORMS.DARWIN]
       return {
@@ -792,11 +701,15 @@ function addPlatformMarkersFromSource(tree, linuxOnlyCommands) {
     }
   }
 
+  const markedCommands = markCommands(tree.commands)
+
   return {
     ...tree,
     platforms: [PLATFORMS.LINUX, PLATFORMS.DARWIN],
-    linux_only_commands: [...linuxOnlyCommands],
-    commands: markCommands(tree.commands)
+    // Union of detected paths and marked tree paths: keeps detected roots
+    // even when the tree was built on a platform where they don't exist
+    linux_only_commands: [...new Set([...linuxOnlyCommands, ...markedPaths])].sort(),
+    commands: markedCommands
   }
 }
 
@@ -2217,10 +2130,17 @@ async function handleRpkDocsGeneration(options = {}) {
     rpkVersion = effectiveRef || 'local'
 
     // Step 2: Detect Linux-only commands
-    // Try dynamic detection first (compare Linux vs Darwin builds)
-    // Fall back to static lists for plugins and known commands
+    // Static detection (build-constraint analysis) works on any platform,
+    // including Linux CI runners. Dynamic detection (comparing Linux vs
+    // Darwin builds) supplements it below when the host can run both.
     console.log('\nAnalyzing source for Linux-only commands...')
     let linuxOnlyCommands = detectLinuxOnlyFromSource(sourcePath)
+    if (linuxOnlyCommands.size > 0) {
+      console.log(`Static detection found ${linuxOnlyCommands.size} Linux-only command path(s):`)
+      for (const cmd of [...linuxOnlyCommands].sort()) {
+        console.log(`  - ${cmd}`)
+      }
+    }
 
     // Step 3: Build rpk and get command tree
     // Use Docker if available (for running rpk plugins in Linux)
@@ -2230,8 +2150,19 @@ async function handleRpkDocsGeneration(options = {}) {
     const canBuildNative = goCheck.status === 0
     const canBuildLinux = dockerCheck.status === 0
 
-    // Dynamic detection: if we can build on both platforms, compare the trees
-    if (canBuildLinux && canBuildNative && os.platform() !== 'linux') {
+    // Dynamic detection: if we can build on both platforms, compare the trees.
+    // Only possible on non-Linux hosts: a Linux runner can cross-compile a
+    // darwin rpk but cannot execute it to get its command tree, so Linux CI
+    // relies on the static detection above.
+    // RPK_DOCS_SKIP_DYNAMIC_DETECTION=1 forces the static-only path (useful
+    // for testing what a Linux CI runner would produce).
+    const skipDynamicDetection = ['1', 'true'].includes(
+      String(process.env.RPK_DOCS_SKIP_DYNAMIC_DETECTION || '').toLowerCase()
+    )
+    if (skipDynamicDetection) {
+      console.log('\nDynamic platform detection disabled via RPK_DOCS_SKIP_DYNAMIC_DETECTION')
+    }
+    if (canBuildLinux && canBuildNative && os.platform() !== 'linux' && !skipDynamicDetection) {
       console.log('\nBuilding rpk on both Linux and Darwin for dynamic platform detection...')
 
       try {
@@ -2296,6 +2227,12 @@ async function handleRpkDocsGeneration(options = {}) {
         'Install Docker or Go to continue.'
       )
     }
+
+    // Tripwire: an empty combined detection result while the source tree
+    // demonstrably contains Linux-gated files means the scan is broken and
+    // Linux-only pages are about to be published as cross-platform
+    // (see redpanda-data/docs#1831).
+    warnIfDetectionLooksBroken(sourcePath, linuxOnlyCommands)
 
     // Step 4: Add platform markers based on detection
     // This includes both source scanning results and static fallback lists


### PR DESCRIPTION
## Problem

When the rpk-docs generator runs on a Linux CI runner (the docs repo's `update-rpk-docs.yml` on `ubuntu-latest`), Linux-only platform detection silently returns nothing, and every command gets stamped `["linux","darwin"]`. In redpanda-data/docs#1831 this flipped 13 Linux-only pages (`rpk iotune` plus the whole `rpk redpanda` tree) to `:page-platforms: linux,darwin`, and the generated data file `docs-data/rpk-v26.2.1-rc2.json` shipped with `linux_only_commands: []`.

Two defects combined to cause this:

1. **The static scan looked in directories that no longer exist.** `detectLinuxOnlyFromSource` only scanned `<source>/pkg/cli/cmd/` and `<source>/cmd/rpk/` for `//go:build linux` tags. Modern rpk keeps commands in `src/go/rpk/pkg/cli/<command>/` (no `cmd` level), so `fs.existsSync` failed for both roots and the function silently returned an empty set. It also only matched explicit tags, missing filename-implied constraints such as `root_linux.go`.
2. **The reliable path can never run in CI.** Dynamic detection (build rpk in a Linux container and natively, diff the two `--print-tree` outputs) is gated on `os.platform() !== 'linux'`. That is inherent: a Linux runner can cross-compile a darwin rpk but cannot execute it to print its tree. So on `ubuntu-latest` only the (broken) static path ran, and the empty set flowed straight into `addPlatformMarkersFromSource`.

## Fix

New module `tools/rpk-docs/detect-platform-commands.js`: a static, platform-independent analysis of Go build constraints that works on any host, including Linux CI.

* Scans `pkg/cli/` (modern layout) plus the legacy roots `pkg/cli/cmd/` and `cmd/rpk/`.
* Treats both explicit constraints (`//go:build linux`, legacy `// +build linux`, including `!`, `&&`, `||`, parentheses, and `unix`) **and** filename-implied constraints (`_linux.go`, `_linux_arm64.go`) as build gates, evaluated per GOOS.
* Detects two gating patterns:
  * **Whole-package gating** - every file in a command package builds only on Linux (e.g. `pkg/cli/iotune`, `pkg/cli/redpanda/tune`).
  * **Dual registration** - a package ships per-platform variants of the same command that register different subcommand sets (e.g. `redpanda.go` with `//go:build linux` registers `start/stop/check/mode/config/tune`, while `redpanda_darwin.go` registers only the hidden `admin` command; same pattern for `root_linux.go`/`root_darwin.go`). The analyzer diffs the constructors referenced in `AddCommand(...)` calls between the linux-buildable and darwin-buildable views of each package, resolving each constructor to its cobra `Use:` name.
* A file with a Linux gate that has a darwin-buildable counterpart in the same package (like `debug/bundle/bundle.go` + `bundle_all.go` with `//go:build !linux`) is correctly **not** treated as Linux-only.
* Deprecated and `Hidden: true` constructors are ignored because `rpk --print-tree` excludes hidden commands (so the deprecated top-level `rpk start/stop/tune/config/mode` aliases don't leak into the results).
* Deliberately conservative: unresolvable references are only trusted when they follow the `New[Xxx]Command` cobra constructor convention, so helper arguments (e.g. `rp.NewLauncher()`) can't produce false Linux-only markings.

Handler changes (`tools/rpk-docs/rpk-docs-handler.js`):

* Replaces the old scanner with the new module (dynamic detection still runs on macOS hosts and merges with the static result, unchanged).
* **Tripwire:** if the combined detection result is empty while the source tree demonstrably contains Linux-constrained files under the scanned roots, a loud multi-line warning is printed naming the files and the likely scan failure. Detection can no longer fail silently.
* The persisted `linux_only_commands` list is now expanded over the actual command tree (each descendant path listed, sorted), matching what dynamic detection has historically produced, so static-only CI runs and Mac dynamic runs emit identical data files for built-in commands.
* New env escape hatch `RPK_DOCS_SKIP_DYNAMIC_DETECTION=1` forces the static-only path, used to validate exactly what a Linux CI runner would produce.

## Ground truth and validation

Ground truth was generated empirically from the `v26.2.1-rc2` tag: rpk built natively on macOS (darwin tree) and in a `golang:1.26.4` Linux container (linux tree), `--print-tree` output diffed. The built-in Linux-only set is exactly 13 paths:

```
rpk iotune
rpk redpanda check
rpk redpanda config (+ bootstrap, init, print, set)
rpk redpanda mode
rpk redpanda start
rpk redpanda stop
rpk redpanda tune (+ help, list)
```

The full generator was then run twice against `--ref v26.2.1-rc2`:

1. **Baseline (Mac, dynamic + static):** dynamic detection finds the built-in set (plus plugin artifacts, see below).
2. **Simulated Linux CI (`RPK_DOCS_SKIP_DYNAMIC_DETECTION=1`, static only):** the new static detection alone produces the same 13 built-in `linux_only_commands` and the same `:page-platforms:` attributes on all built-in pages.

Diff between the two runs for built-in commands: **empty**.

## Testing

* New fixture-based jest suite `__tests__/tools/rpk-docs/detect-platform-commands.test.js` (synthetic source trees covering the modern `pkg/cli` layout, both legacy layouts, explicit tags, `_linux.go` suffixes, the dual-registration redpanda pattern, deprecated/hidden exclusion, the `!linux` counterpart case, and the empty-tree tripwire), plus an integration-style test frozen to the empirically verified rc2 set (7 detection roots, 13 expanded paths).
* Full suite green: 34 suites, 797 tests.

## Notes

* **docs#1831 impact:** the affected pages in that PR are already protected by pinned platform overrides, so no emergency regen is needed there. The next CI regen with this fix produces correct markers on its own.
* **Plugins are out of scope.** Plugin commands (`rpk ai`, `rpk connect`, ...) are not part of the rpk source tree, so static analysis cannot determine their platform support. Dynamic (Mac) runs historically marked `rpk ai *` Linux-only as an artifact of plugins only being installed in the Linux build container, not as a source-level fact. Plugin platform detection is a known follow-up.
* **PR #221 interaction:** #221 touches `rpk-docs-handler.js` at lines ~477-506 (plugin install failure tracking in `fetchRpkTreeFromLinuxSource`) and `generate-rpk-docs.js`. This PR touches neither region (`generate-rpk-docs.js` is untouched), so there is no textual conflict; the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
