### PR TITLE
fix(property-extractor): resolve member calls on inline constants in defaults

### DIFF
--- a/__tests__/tools/property-extractor/test_constant_resolution.py
+++ b/__tests__/tools/property-extractor/test_constant_resolution.py
@@ -1,0 +1,74 @@
+"""
+Tests for C++ constant resolution used to render property defaults.
+
+Regression coverage for defaults that reference member calls on inline
+constants (for example, model::schema_registry_internal_tp.topic()), which
+previously leaked raw C++ into rendered docs (log_eviction_exempt_topics
+in v26.1.14 showed a default of [model::schema_registry_internal_tp.topic()]
+instead of ["_schemas"]).
+"""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Add tools/property-extractor to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / 'tools' / 'property-extractor'))
+
+import property_extractor as pe
+
+
+class MemberCallResolutionTest(unittest.TestCase):
+    """Member calls on inline constants must resolve to the literal the
+    constant carries instead of leaking C++ into rendered defaults."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        src = Path(self.tmp.name) / 'src' / 'v' / 'model'
+        src.mkdir(parents=True)
+        (src / 'namespace.h').write_text(
+            'namespace model {\n'
+            'inline const model::topic_partition schema_registry_internal_tp{\n'
+            '  model::topic{"_schemas"}, model::partition_id{0}};\n'
+            '}\n'
+        )
+        self.cache = pe.ConstexprCache()
+        self.cache.build_cache(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_member_call_resolves_qualified(self):
+        self.assertEqual(
+            self.cache.lookup_function('model::schema_registry_internal_tp.topic'),
+            '_schemas'
+        )
+
+    def test_member_call_resolves_unqualified(self):
+        self.assertEqual(
+            self.cache.lookup_function('schema_registry_internal_tp.topic'),
+            '_schemas'
+        )
+
+
+class FunctionCallPatternTest(unittest.TestCase):
+    """FUNCTION_CALL_PATTERN must admit member calls without breaking
+    free-function matching."""
+
+    def test_matches_member_call(self):
+        m = pe.FUNCTION_CALL_PATTERN.match('model::schema_registry_internal_tp.topic()')
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), 'model::schema_registry_internal_tp.topic')
+
+    def test_still_matches_free_function(self):
+        m = pe.FUNCTION_CALL_PATTERN.match('model::kafka_audit_logging_topic()')
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), 'model::kafka_audit_logging_topic')
+
+    def test_does_not_match_calls_with_arguments(self):
+        self.assertIsNone(pe.FUNCTION_CALL_PATTERN.match('std::chrono::milliseconds(30000)'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/__tests__/tools/property-extractor/test_constant_resolution.py
+++ b/__tests__/tools/property-extractor/test_constant_resolution.py
@@ -69,6 +69,17 @@ class FunctionCallPatternTest(unittest.TestCase):
     def test_does_not_match_calls_with_arguments(self):
         self.assertIsNone(pe.FUNCTION_CALL_PATTERN.match('std::chrono::milliseconds(30000)'))
 
+    def test_does_not_match_call_with_trailing_expression(self):
+        """A call that is only the prefix of a compound expression must not
+        match, otherwise the resolver silently discards the rest of the
+        expression (for example, `+ "_suffix"`)."""
+        self.assertIsNone(pe.FUNCTION_CALL_PATTERN.match(
+            'model::schema_registry_internal_tp.topic() + "_suffix"'
+        ))
+        self.assertIsNone(pe.FUNCTION_CALL_PATTERN.match(
+            'model::kafka_audit_logging_topic() + other()'
+        ))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/property-extractor/property_extractor.py
+++ b/tools/property-extractor/property_extractor.py
@@ -79,7 +79,7 @@ ENUM_PATTERN = re.compile(r'^[a-zA-Z0-9_:]+::([a-zA-Z0-9_]+)$')  # Match full qu
 CONSTRUCTOR_PATTERN = re.compile(r'([a-zA-Z0-9_:]+)\((.*)\)')
 BRACED_CONSTRUCTOR_PATTERN = re.compile(r'([a-zA-Z0-9_:]+)\{(.*)\}')
 DIGIT_SEPARATOR_PATTERN = re.compile(r"(?<=\d)'(?=\d)")
-FUNCTION_CALL_PATTERN = re.compile(r'([a-zA-Z0-9_:.]+)\(\)')
+FUNCTION_CALL_PATTERN = re.compile(r'([a-zA-Z0-9_:.]+)\(\)$')
 CHRONO_PATTERN = re.compile(r'std::chrono::([a-zA-Z]+)\s*\{\s*(\d+)\s*\}')
 CHRONO_PAREN_PATTERN = re.compile(r'(?:std::)?chrono::([a-zA-Z]+)\s*\(\s*([^)]+)\s*\)')
 TIME_UNIT_PATTERN = re.compile(r'(\d+)\s*(min|s|ms|h)')

--- a/tools/property-extractor/property_extractor.py
+++ b/tools/property-extractor/property_extractor.py
@@ -79,7 +79,7 @@ ENUM_PATTERN = re.compile(r'^[a-zA-Z0-9_:]+::([a-zA-Z0-9_]+)$')  # Match full qu
 CONSTRUCTOR_PATTERN = re.compile(r'([a-zA-Z0-9_:]+)\((.*)\)')
 BRACED_CONSTRUCTOR_PATTERN = re.compile(r'([a-zA-Z0-9_:]+)\{(.*)\}')
 DIGIT_SEPARATOR_PATTERN = re.compile(r"(?<=\d)'(?=\d)")
-FUNCTION_CALL_PATTERN = re.compile(r'([a-zA-Z0-9_:]+)\(\)')
+FUNCTION_CALL_PATTERN = re.compile(r'([a-zA-Z0-9_:.]+)\(\)')
 CHRONO_PATTERN = re.compile(r'std::chrono::([a-zA-Z]+)\s*\{\s*(\d+)\s*\}')
 CHRONO_PAREN_PATTERN = re.compile(r'(?:std::)?chrono::([a-zA-Z]+)\s*\(\s*([^)]+)\s*\)')
 TIME_UNIT_PATTERN = re.compile(r'(\d+)\s*(min|s|ms|h)')
@@ -159,6 +159,15 @@ class ConstexprCache:
             re.compile(r'const\s+model::ns\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(\s*"([^"]+)"\s*\)'),
         ]
 
+        # Member accessors on inline constants used in property defaults,
+        # for example model::schema_registry_internal_tp.topic() -> "_schemas".
+        # Each entry maps a variable declaration to the member name whose call
+        # returns the captured string, cached under "<variable>.<member>".
+        member_accessor_patterns = [
+            # Pattern: inline const model::topic_partition name{model::topic{"value"}, ...}
+            (re.compile(r'inline\s+const\s+(?:model::)?topic_partition\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\{\s*(?:model::)?topic\{\s*"([^"]+)"\s*\}'), 'topic'),
+        ]
+
         # Legacy specific patterns (kept for compatibility, but general patterns should cover these)
         function_patterns = {}
 
@@ -205,6 +214,17 @@ class ConstexprCache:
                                     if namespace:
                                         qualified_name = f"{namespace}::{func_name}"
                                         self.function_cache[qualified_name] = func_value
+
+                            # Extract member accessors on inline constants
+                            for pattern, member in member_accessor_patterns:
+                                for match in pattern.finditer(content):
+                                    var_name = match.group(1)
+                                    value = match.group(2)
+                                    key = f"{var_name}.{member}"
+                                    namespace = self._extract_namespace_for_function(content, match.start())
+                                    self.function_cache[key] = value
+                                    if namespace:
+                                        self.function_cache[f"{namespace}::{key}"] = value
 
                             # Legacy: Extract function definitions from hardcoded patterns (if any)
                             for func_name, patterns in function_patterns.items():


### PR DESCRIPTION
## Summary

The v26.1.14 property `log_eviction_exempt_topics` leaked raw C++ into its rendered default: `[model::schema_registry_internal_tp.topic()]` instead of `["_schemas"]` (visible in redpanda-data/docs#1824, patched there with a manual `default` override).

## Root cause

Two gaps in the constant resolver:

1. `FUNCTION_CALL_PATTERN` (`([a-zA-Z0-9_:]+)\(\)`) doesn't admit `.`, so a **member call** like `model::schema_registry_internal_tp.topic()` never reached `resolve_cpp_function_call` at all — the existing machinery only handles free zero-arg functions (`model::kafka_audit_logging_topic()`).
2. Even if it had, the `ConstexprCache` has no pattern for inline `model::topic_partition` constants, so there was nothing to resolve against (`src/v/model/namespace.h`: `inline const model::topic_partition schema_registry_internal_tp{model::topic{"_schemas"}, ...}`).

## Fix

- Widen `FUNCTION_CALL_PATTERN` to admit dots (calls with arguments still don't match).
- Cache `<variable>.topic → literal` for inline `topic_partition` declarations, under both qualified (`model::x.topic`) and unqualified names.
- Unresolvable expressions still pass through unchanged, so every other default renders exactly as before.

## Testing

New `test_constant_resolution.py` (5 tests: qualified/unqualified resolution against a synthetic `namespace.h`, member-call and free-function pattern matching, args-rejection). Also verified against the real redpanda checkout: `resolve_cpp_function_call('model::schema_registry_internal_tp.topic')` → `_schemas`, and `model::kafka_audit_logging_topic` still resolves to `_redpanda.audit_log`.

Version bumped to 5.2.6 (adjust on merge if #225's 5.3.0 lands first).