### PR TITLE
feat(rpk-docs): gate subcommand table rows by cloud availability

### DIFF
--- a/__tests__/tools/rpk-docs/override-features.test.js
+++ b/__tests__/tools/rpk-docs/override-features.test.js
@@ -924,4 +924,153 @@ Original fields content that should be replaced.`,
       expect(fs.existsSync(path.join(secretDir, 'some-partial.adoc'))).toBe(true)
     }, 30000)
   })
+
+  describe('subcommand table env-cloud gating', () => {
+    let outputDir
+    let secretDir
+
+    beforeEach(() => {
+      outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rpk-out-'))
+      secretDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rpk-partials-'))
+    })
+
+    afterEach(() => {
+      fs.rmSync(outputDir, { recursive: true, force: true })
+      fs.rmSync(secretDir, { recursive: true, force: true })
+    })
+
+    const clusterTree = () => ({
+      name: 'rpk',
+      description: 'Root command',
+      commands: [
+        {
+          name: 'cluster',
+          description: 'Cluster command.',
+          usage: 'rpk cluster [flags]',
+          flags: [],
+          commands: [
+            { name: 'health', description: 'Health command.', usage: 'rpk cluster health [flags]', flags: [] },
+            { name: 'info', description: 'Info command.', usage: 'rpk cluster info [flags]', flags: [] }
+          ]
+        }
+      ],
+      global_flags: []
+    })
+
+    // Cloud-docs single-sources these tables, so a row whose page only exists
+    // in the self-managed docs must not render in the cloud build.
+    test('wraps selfHostedOnly subcommand rows in ifndef::env-cloud', async () => {
+      await generateRpkDocs({
+        tree: clusterTree(),
+        overrides: { commands: { 'rpk cluster health': { selfHostedOnly: true } } },
+        outputDir,
+        rpkVersion: 'test',
+        pluginVersions: {}
+      })
+
+      const page = fs.readFileSync(path.join(outputDir, 'rpk-cluster', 'rpk-cluster.adoc'), 'utf8')
+      expect(page).toMatch(
+        /ifndef::env-cloud\[\]\n\|xref:reference:rpk\/rpk-cluster\/rpk-cluster-health\.adoc\[`rpk cluster health`\]\n\|Health command\.\nendif::\[\]/
+      )
+      // The ungated sibling stays a plain row.
+      expect(page).not.toMatch(/ifndef::env-cloud\[\]\n\|xref:reference:rpk\/rpk-cluster\/rpk-cluster-info\.adoc/)
+      expect(page).toContain('|xref:reference:rpk/rpk-cluster/rpk-cluster-info.adoc[`rpk cluster info`]')
+    }, 30000)
+
+    test('wraps cloudOnly subcommand rows in ifdef::env-cloud', async () => {
+      await generateRpkDocs({
+        tree: clusterTree(),
+        overrides: { commands: { 'rpk cluster health': { cloudOnly: true } } },
+        outputDir,
+        rpkVersion: 'test',
+        pluginVersions: {}
+      })
+
+      const page = fs.readFileSync(path.join(outputDir, 'rpk-cluster', 'rpk-cluster.adoc'), 'utf8')
+      expect(page).toMatch(
+        /ifdef::env-cloud\[\]\n\|xref:reference:rpk\/rpk-cluster\/rpk-cluster-health\.adoc\[`rpk cluster health`\]\n\|Health command\.\nendif::\[\]/
+      )
+    }, 30000)
+
+    const securityTree = () => ({
+      name: 'rpk',
+      description: 'Root command',
+      commands: [
+        {
+          name: 'security',
+          description: 'Security command.',
+          usage: 'rpk security [flags]',
+          flags: [],
+          commands: [
+            {
+              name: 'secret',
+              description: 'Secret command.',
+              usage: 'rpk security secret [flags]',
+              flags: [],
+              commands: [
+                { name: 'list', description: 'List command.', usage: 'rpk security secret list [flags]', flags: [] }
+              ]
+            },
+            { name: 'acl', description: 'Acl command.', usage: 'rpk security acl [flags]', flags: [] }
+          ]
+        },
+        {
+          name: 'cloud',
+          description: 'Cloud command.',
+          usage: 'rpk cloud [flags]',
+          flags: [],
+          commands: [
+            { name: 'login', description: 'Login command.', usage: 'rpk cloud login [flags]', flags: [] }
+          ]
+        }
+      ],
+      global_flags: []
+    })
+
+    // rpk cloud and rpk security secret pages are routed to cloudSecretDir and
+    // published by cloud-docs, so rows in regular pages must cross components —
+    // an in-component xref would point at a page that does not exist.
+    test('links cloudSecretDir-routed rows across to the cloud component', async () => {
+      await generateRpkDocs({
+        tree: securityTree(),
+        overrides: { commands: {} },
+        outputDir,
+        cloudSecretDir: secretDir,
+        rpkVersion: 'test',
+        pluginVersions: {}
+      })
+
+      const security = fs.readFileSync(path.join(outputDir, 'rpk-security', 'rpk-security.adoc'), 'utf8')
+      expect(security).toContain(
+        '|xref:cloud-data-platform:reference:rpk/rpk-security/rpk-security-secret.adoc[`rpk security secret`]'
+      )
+      expect(security).toContain('|xref:reference:rpk/rpk-security/rpk-security-acl.adoc[`rpk security acl`]')
+
+      // Inside the cloud family the tables render in cloud-docs itself, so
+      // in-component xrefs are correct and must not gain a component prefix.
+      const secret = fs.readFileSync(path.join(secretDir, 'rpk-security', 'rpk-security-secret.adoc'), 'utf8')
+      expect(secret).toContain('|xref:reference:rpk/rpk-security/rpk-security-secret-list.adoc[`rpk security secret list`]')
+      expect(secret).not.toContain('cloud-data-platform:')
+
+      const cloud = fs.readFileSync(path.join(secretDir, 'rpk-cloud', 'rpk-cloud.adoc'), 'utf8')
+      expect(cloud).toContain('|xref:reference:rpk/rpk-cloud/rpk-cloud-login.adoc[`rpk cloud login`]')
+      expect(cloud).not.toContain('cloud-data-platform:')
+    }, 30000)
+
+    // Without cloudSecretDir every page lands in the normal output tree, so
+    // in-component xrefs stay correct.
+    test('keeps in-component xrefs when no cloudSecretDir is configured', async () => {
+      await generateRpkDocs({
+        tree: securityTree(),
+        overrides: { commands: {} },
+        outputDir,
+        rpkVersion: 'test',
+        pluginVersions: {}
+      })
+
+      const security = fs.readFileSync(path.join(outputDir, 'rpk-security', 'rpk-security.adoc'), 'utf8')
+      expect(security).toContain('|xref:reference:rpk/rpk-security/rpk-security-secret.adoc[`rpk security secret`]')
+      expect(security).not.toContain('cloud-data-platform:')
+    }, 30000)
+  })
 })

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -2742,16 +2742,13 @@ async function generateRpkDocs(options = {}) {
     // Build subcommands with correct xref paths
     // Filter out excluded and asPartial subcommands — excluded have no file,
     // asPartial ones live in the partials directory with no linkable xref.
-    // rpk cloud and rpk security secret are hardcoded-routed to partials
-    // (single-sourced into cloud docs), so they have no linkable pages
-    // either: rpk-security.adoc linking rpk-security-secret.adoc was a
-    // broken xref in the published site.
+    // rpk cloud and rpk security secret rows stay in the table: their pages
+    // are routed to the cloud partials directory and published by
+    // cloud-docs, so the xref below links across to the cloud component
+    // instead of dropping the row (which hid the subcommand entirely).
     const subcommands = (command.commands || [])
       .filter(sub => {
         const subPath = `${commandPath} ${sub.name}`
-        if (subPath.startsWith('rpk cloud') || subPath.startsWith('rpk security secret')) {
-          return false
-        }
         return !shouldExcludeCommand(resolvedOverrides, subPath) && !shouldUsePartialDir(resolvedOverrides, subPath)
       })
       .map(sub => {

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -292,6 +292,24 @@ function shouldUsePartialDir(overrides, commandPath) {
 }
 
 /**
+ * Check if a command belongs to the rpk cloud or rpk security secret families.
+ * Their pages are routed to the cloud partials directory (cloudSecretDir) and
+ * published by cloud-docs, so links to them from regular pages must cross to
+ * the cloud component.
+ * @param {string} commandPath - Full command path (e.g., "rpk cloud login")
+ * @returns {boolean}
+ */
+function isCloudSecretCommand(commandPath) {
+  return commandPath === 'rpk cloud' || commandPath.startsWith('rpk cloud ') ||
+    commandPath === 'rpk security secret' || commandPath.startsWith('rpk security secret ')
+}
+
+/**
+ * Antora component that publishes the rpk cloud and rpk security secret pages.
+ */
+const CLOUD_DOCS_COMPONENT = 'cloud-data-platform'
+
+/**
  * Get command metadata from overrides
  * @param {Object} overrides - Overrides object (resolved)
  * @param {string} commandPath - Full command path (e.g., "rpk topic create")
@@ -2420,8 +2438,7 @@ function updateNavFile(navFile, commands, resolvedOverrides, topLevelWithSubcomm
     if (isProtectedCommandPath(commandPath, protectedPlugins)) continue
     if (shouldExcludeCommand(resolvedOverrides, commandPath)) continue
     if (shouldUsePartialDir(resolvedOverrides, commandPath)) continue
-    if (commandPath.startsWith('rpk cloud')) continue
-    if (commandPath.startsWith('rpk security secret')) continue
+    if (isCloudSecretCommand(commandPath)) continue
 
     const parts = commandPath.split(' ')
     const stars = '*'.repeat(parts.length + 1)
@@ -2756,6 +2773,13 @@ async function generateRpkDocs(options = {}) {
           }
         }
 
+        // rpk cloud and rpk security secret pages are routed to the cloud
+        // partials directory and published by cloud-docs, so rows in regular
+        // pages must link across to the cloud component.
+        if (cloudSecretDir && isCloudSecretCommand(subPath) && !isCloudSecretCommand(commandPath)) {
+          xrefPath = `${CLOUD_DOCS_COMPONENT}:${xrefPath}`
+        }
+
         // Use overridden description if available
         const subOverride = resolvedOverrides?.commands?.[subPath]
         const subDescription = subOverride?.description || sub.description || ''
@@ -2765,6 +2789,8 @@ async function generateRpkDocs(options = {}) {
           fullPath: subPath,
           dashifiedPath: dashifiedSubPath,
           xrefPath,
+          cloudOnly: subOverride?.cloudOnly === true,
+          selfHostedOnly: subOverride?.selfHostedOnly === true,
           shortDesc: ensurePeriod(capToTwoSentences(formatDescription(subDescription, textTransformations, { skipTableConversion: true, skipListConversion: true })))
         }
       })
@@ -2949,10 +2975,8 @@ async function generateRpkDocs(options = {}) {
 
     // Determine output path
     // Check if this command should go to cloudSecretDir
-    const isCloudCommand = commandPath.startsWith('rpk cloud')
-    const isSecuritySecretCommand = commandPath.startsWith('rpk security secret')
     const useCloudSecretDir = cloudSecretDir && (
-      isCloudCommand || isSecuritySecretCommand || shouldUsePartialDir(resolvedOverrides, commandPath)
+      isCloudSecretCommand(commandPath) || shouldUsePartialDir(resolvedOverrides, commandPath)
     )
     const effectiveOutputDir = useCloudSecretDir ? cloudSecretDir : outputDir
 

--- a/tools/rpk-docs/templates/command.hbs
+++ b/tools/rpk-docs/templates/command.hbs
@@ -389,8 +389,20 @@ This section provides examples of how to use `{{commandPath}}`.
 |Command |Description
 
 {{#each subcommands}}
+{{#if cloudOnly}}
+ifdef::env-cloud[]
+{{/if}}
+{{#if selfHostedOnly}}
+ifndef::env-cloud[]
+{{/if}}
 |xref:{{xrefPath}}[`{{fullPath}}`]
 |{{{shortDesc}}}
+{{#if cloudOnly}}
+endif::[]
+{{/if}}
+{{#if selfHostedOnly}}
+endif::[]
+{{/if}}
 
 {{/each}}
 |===


### PR DESCRIPTION
## Problem

The rpk generator emits subcommand tables with no `env-cloud` gating, while the flags table already supports `cloudOnly`/`selfHostedOnly` conditionals. Cloud-docs single-sources these tables, so rows for commands whose pages exist only in the self-managed docs produced 20+ `target of xref not found` errors in every full-site build. Separately, the `rpk cloud` and `rpk security secret` rows in regular pages emitted in-component xrefs even though their pages are routed to the cloud partials directory and published only by cloud-docs, so those links never resolved.

## Changes

- `templates/command.hbs`: subcommand rows honor `cloudOnly`/`selfHostedOnly` and get wrapped in `ifdef::env-cloud[]`/`ifndef::env-cloud[]`, mirroring the existing flag-row pattern.
- `generate-rpk-docs.js`:
  - The subcommands array carries `cloudOnly`/`selfHostedOnly` from the child command's overrides.
  - New `isCloudSecretCommand()` helper replaces the scattered `startsWith('rpk cloud')`/`startsWith('rpk security secret')` checks (nav skip, cloudSecretDir routing) with strict word-boundary matching.
  - When `cloudSecretDir` is configured, rows for cloud-routed commands in regular pages link across to the `cloud-data-platform` component. Tables inside those families keep in-component xrefs since they render in cloud-docs itself.
- Tests: four new integration tests covering row gating (ifdef/ifndef), the cross-component xref, in-family tables staying in-component, and the no-`cloudSecretDir` case. Full rpk-docs suite passes (293 tests).

## Verification

Ran the updated generator against the real `rpk-v26.2.1-rc2.json` tree with `selfHostedOnly` overrides for the 22 cloud-unavailable commands (redpanda-data/docs branch `rpk-cloud-availability-overrides`): the regenerated parent pages are byte-identical to the hand-fixed pages that shipped in redpanda-data/docs#1837.

The overrides schema already allows both keys at command level, so no schema change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)