### PR TITLE
fix(connect): emit context-switcher as array and pass URL entries through

### DIFF
--- a/__tests__/extensions/process-context-switcher.test.js
+++ b/__tests__/extensions/process-context-switcher.test.js
@@ -133,7 +133,7 @@ describe('process-context-switcher extension', () => {
     // generate-rp-connect-info sets pub.url values (root-relative) for connector
     // Type switchers; these need no resource-ID resolution or target injection.
     mockPage.asciidoc.attributes['page-context-switcher'] =
-      '[{"name": "Cache", "to": "/redpanda-connect/components/caches/aws_dynamodb/"},{"name": "Output", "to": "/redpanda-connect/components/outputs/aws_dynamodb/"}]';
+      '[{"name": "Cache", "to": "/connect/components/caches/aws_dynamodb/"},{"name": "Output", "to": "/connect/components/outputs/aws_dynamodb/"}]';
 
     extension.register.call(extensionContext, { config: {} });
     const handler = extensionContext.on.mock.calls[0][1];
@@ -144,8 +144,8 @@ describe('process-context-switcher extension', () => {
     // Attribute is untouched: no 'current' replacement, no rewritten targets
     const attr = JSON.parse(mockPage.asciidoc.attributes['page-context-switcher']);
     expect(attr).toEqual([
-      { name: 'Cache', to: '/redpanda-connect/components/caches/aws_dynamodb/' },
-      { name: 'Output', to: '/redpanda-connect/components/outputs/aws_dynamodb/' }
+      { name: 'Cache', to: '/connect/components/caches/aws_dynamodb/' },
+      { name: 'Output', to: '/connect/components/outputs/aws_dynamodb/' }
     ]);
   });
 

--- a/__tests__/extensions/process-context-switcher.test.js
+++ b/__tests__/extensions/process-context-switcher.test.js
@@ -129,6 +129,26 @@ describe('process-context-switcher extension', () => {
     expect(version3Item.to).toBe('current@ROOT:console:config/security/authentication.adoc');
   });
 
+  it('should pass through root-relative URL entries without resolution or warnings', async () => {
+    // generate-rp-connect-info sets pub.url values (root-relative) for connector
+    // Type switchers; these need no resource-ID resolution or target injection.
+    mockPage.asciidoc.attributes['page-context-switcher'] =
+      '[{"name": "Cache", "to": "/redpanda-connect/components/caches/aws_dynamodb/"},{"name": "Output", "to": "/redpanda-connect/components/outputs/aws_dynamodb/"}]';
+
+    extension.register.call(extensionContext, { config: {} });
+    const handler = extensionContext.on.mock.calls[0][1];
+    await handler({ contentCatalog: mockContentCatalog });
+
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    // Attribute is untouched: no 'current' replacement, no rewritten targets
+    const attr = JSON.parse(mockPage.asciidoc.attributes['page-context-switcher']);
+    expect(attr).toEqual([
+      { name: 'Cache', to: '/redpanda-connect/components/caches/aws_dynamodb/' },
+      { name: 'Output', to: '/redpanda-connect/components/outputs/aws_dynamodb/' }
+    ]);
+  });
+
   it('should handle invalid JSON gracefully', async () => {
     mockPage.asciidoc.attributes['page-context-switcher'] = 'invalid json';
 

--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -435,6 +435,9 @@ module.exports.register = function ({ config }) {
       const link = (variant === 'cloud' && row.redpandaCloudUrl) || row.redpandaConnectUrl
       if (!link) continue
       const type = row.type.trim()
+      // First occurrence wins: orderedRows puts the current page's row first,
+      // so a connector with duplicate types keeps its own entry. (The old
+      // object-keyed build let later rows overwrite earlier ones.)
       if (items.some((item) => item.name === capitalize(type))) continue
       items.push({ name: capitalize(type), to: link })
     }

--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -428,13 +428,16 @@ module.exports.register = function ({ config }) {
   function buildContextSwitcher (connectorRows, currentRow, variant) {
     const capitalize = (value) => value.charAt(0).toUpperCase() + value.slice(1)
     const orderedRows = [currentRow, ...connectorRows.filter((row) => row !== currentRow)]
-    const data = {}
+    // The process-context-switcher extension and the UI's context-switcher partial
+    // both expect an array of { name, to } items; `to` is a root-relative pub URL.
+    const items = []
     for (const row of orderedRows) {
       const link = (variant === 'cloud' && row.redpandaCloudUrl) || row.redpandaConnectUrl
       if (!link) continue
       const type = row.type.trim()
-      data[type.toLowerCase()] = { name: capitalize(type), to: link }
+      if (items.some((item) => item.name === capitalize(type))) continue
+      items.push({ name: capitalize(type), to: link })
     }
-    return JSON.stringify(data)
+    return JSON.stringify(items)
   }
 }

--- a/extensions/process-context-switcher.js
+++ b/extensions/process-context-switcher.js
@@ -74,6 +74,11 @@ module.exports.register = function ({ config }) {
           item.to = currentResourceId;
           hasChanges = true;
           logger.debug(`Replaced 'current' with '${currentResourceId}' in context-switcher`);
+        } else if (typeof item.to === 'string' && item.to.startsWith('/')) {
+          // Root-relative URLs (e.g. pub.url values set by generate-rp-connect-info)
+          // need no resolution or target injection: the UI's resolve-resource helper
+          // passes them through, and the producer decorates every variant directly.
+          continue;
         } else if (item.to !== currentResourceId) {
           // For non-current items, find and update the target page
           const targetPage = findPageByResourceId(item.to, contentCatalog, page);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.3.2",
+      "version": "5.3.3",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
## Problem

Since #216, every multi-type connector page (`aws_dynamodb`, `aws_s3`, `gcp_cloud_storage`, `memory`, `mongodb`, …) logs `Invalid context-switcher format ... expected array` on every site build, and the Type context-switcher dropdown silently never gets processed on exactly the pages that need it.

Two mismatches between producer and consumer:

1. `generate-rp-connect-info.js` `buildContextSwitcher()` returned a **type-keyed object** (`{"cache": {...}, "output": {...}}`), but `process-context-switcher.js` requires an **array** and bails out otherwise.
2. The entries carry root-relative **pub URLs**, which the processor would then try to resolve as Antora **resource IDs** — fixing only the array shape would have traded the format warning for a `Target page not found` warning per entry.

## Changes

- `buildContextSwitcher()` emits an array of `{name, to}` items (current page's type first, deduped by type) — the shape both the processor and the UI's `context-switcher.hbs` expect.
- `process-context-switcher.js` passes root-relative URL entries through untouched: the UI's `resolve-resource` helper already supports them (its comment names this exact producer), and `generate-rp-connect-info` decorates every variant directly so no target injection is needed.
- New test: URL entries produce no warnings and are left unmodified. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)