### PR TITLE
fix(property-extractor): derive property names from the registered name literal, not the C++ member

### DIFF
--- a/__tests__/tools/property-extractor/test_transformers.py
+++ b/__tests__/tools/property-extractor/test_transformers.py
@@ -351,6 +351,45 @@ class TestBasicInfoTransformer(unittest.TestCase):
         self.assertEqual(result["name"], "default_topic_replications")
         self.assertEqual(result["description"], "Default replication factor for new topics.")
 
+    def test_description_extracted_after_leading_lambda_with_unquoted_literals(self):
+        """Description indexing must align with normalized (unquoted) literals.
+
+        Regression test: the parser strips quotes from string literals, so the
+        start-index scan must select by parameter type, not by surrounding
+        quotes. With a leading lambda, the old quote-based scan left start_idx
+        at 0 and description extraction read the lambda source instead of the
+        real description.
+        """
+        info = {
+            "params": [
+                {"value": "[](const auto& v) { return v > 0; }", "type": "lambda_expression"},
+                {"value": "timeout_ms", "type": "string_literal"},
+                {"value": "Timeout in milliseconds for the request.", "type": "string_literal"},
+            ],
+        }
+
+        property = PropertyBag()
+        result = self.transformer.parse(property, info, self.file_pair)
+
+        self.assertEqual(result["name"], "timeout_ms")
+        self.assertEqual(result["description"], "Timeout in milliseconds for the request.")
+
+    def test_no_description_when_no_string_literal_params(self):
+        """No description is extracted when the params hold no string literal."""
+        info = {
+            "name_in_file": "some_property",
+            "params": [
+                {"value": "[](const auto& v) { return v > 0; }", "type": "lambda_expression"},
+                {"value": "config::defaults::some_value", "type": "qualified_identifier"},
+            ],
+        }
+
+        property = PropertyBag()
+        result = self.transformer.parse(property, info, self.file_pair)
+
+        self.assertEqual(result["name"], "some_property")
+        self.assertIsNone(result["description"])
+
     def test_member_identifier_fallback_when_no_name_literal(self):
         """Fall back to the member identifier when the first string literal is not a name."""
         info = {

--- a/__tests__/tools/property-extractor/test_transformers.py
+++ b/__tests__/tools/property-extractor/test_transformers.py
@@ -328,6 +328,43 @@ class TestBasicInfoTransformer(unittest.TestCase):
         # BasicInfoTransformer should skip lambda and find first string literal
         self.assertEqual(result["name"], "timeout_ms")
 
+    def test_name_string_literal_wins_over_member_identifier(self):
+        """The registered name string literal must win over the C++ member name.
+
+        Regression test for redpanda-data/docs#1657: the member
+        `default_topic_replication` registers the property name
+        "default_topic_replications" (plural). The parser normalizes string
+        literals by stripping quotes, so values here are unquoted, exactly as
+        BasicInfoTransformer receives them in production.
+        """
+        info = {
+            "name_in_file": "default_topic_replication",
+            "params": [
+                {"value": "default_topic_replications", "type": "string_literal"},
+                {"value": "Default replication factor for new topics.", "type": "string_literal"},
+            ],
+        }
+
+        property = PropertyBag()
+        result = self.transformer.parse(property, info, self.file_pair)
+
+        self.assertEqual(result["name"], "default_topic_replications")
+        self.assertEqual(result["description"], "Default replication factor for new topics.")
+
+    def test_member_identifier_fallback_when_no_name_literal(self):
+        """Fall back to the member identifier when the first string literal is not a name."""
+        info = {
+            "name_in_file": "some_property",
+            "params": [
+                {"value": "A description with spaces, not a name.", "type": "string_literal"},
+            ],
+        }
+
+        property = PropertyBag()
+        result = self.transformer.parse(property, info, self.file_pair)
+
+        self.assertEqual(result["name"], "some_property")
+
     def test_normalize_file_path(self):
         """Test that file paths are normalized to start with src/."""
         info = {"params": [

--- a/tools/property-extractor/property_extractor.py
+++ b/tools/property-extractor/property_extractor.py
@@ -753,7 +753,24 @@ def transform_files_with_properties(files_with_properties):
                 continue
 
             if len(property_definition) > 0:
-                all_properties[name] = property_definition
+                # Key the output by the property's registered name (the string
+                # literal passed to the constructor), which can differ from the
+                # C++ member identifier used as the parser key. For example,
+                # the member `default_topic_replication` registers the name
+                # "default_topic_replications".
+                output_key = property_definition.get("name") or name
+                existing = all_properties.get(output_key)
+                if existing is not None and existing.get("defined_in") == property_definition.get("defined_in"):
+                    # Two members of the same config store register the same
+                    # property name. config_store registers properties with
+                    # emplace(), so the first registration wins at runtime.
+                    # Match that behavior and keep the first definition.
+                    logging.warning(
+                        f"Duplicate property name '{output_key}' (member '{name}') in "
+                        f"{property_definition.get('defined_in')}: keeping the first definition."
+                    )
+                    continue
+                all_properties[output_key] = property_definition
 
     return all_properties
 

--- a/tools/property-extractor/transformers.py
+++ b/tools/property-extractor/transformers.py
@@ -639,8 +639,9 @@ class BasicInfoTransformer:
     
     NAME RESOLUTION PRIORITY:
     1. Pre-existing property["name"] (from previous processing)
-    2. info["name_in_file"] (C++ variable name from Tree-sitter)  
-    3. First parameter value if it looks like an identifier
+    2. First string-literal parameter if it looks like an identifier
+       (the name argument passed to the property constructor)
+    3. info["name_in_file"] (C++ member name from Tree-sitter) as fallback
     
     DESCRIPTION EXTRACTION LOGIC:
     1. If first parameter is a string and differs from name → use as description
@@ -689,9 +690,26 @@ class BasicInfoTransformer:
             break
 
         # --- Step 2: extract name and description robustly ---
-        name = property.get("name") or info.get("name_in_file")
-        if not name and len(params) > start_idx:
-            name = params[start_idx].get("value", "").strip('"')
+        # The property's registered name is the first string-literal constructor
+        # argument, NOT the C++ member identifier. They usually match, but not
+        # always: for example, the member `default_topic_replication` registers
+        # the name "default_topic_replications". info["name_in_file"] (the
+        # member identifier) is only a fallback.
+        name = property.get("name")
+        if not name:
+            for p in params:
+                if p.get("type") != "string_literal":
+                    continue
+                candidate = str(p.get("value", "")).strip().strip('"')
+                # The name literal is a single identifier with no whitespace.
+                # If the first string literal looks like a description instead
+                # (for example, the name was passed as a constant), fall back
+                # to the member identifier below.
+                if candidate and not re.search(r"\s", candidate):
+                    name = candidate
+                break  # only the first string literal can be the name
+        if not name:
+            name = info.get("name_in_file")
         property["name"] = name
 
         desc = None

--- a/tools/property-extractor/transformers.py
+++ b/tools/property-extractor/transformers.py
@@ -674,16 +674,14 @@ class BasicInfoTransformer:
             return property
 
         # --- Step 1: find the "real" start of the property definition ---
-        # Skip lambdas, validators, and non-string literals at the start
-        start_idx = 0
+        # Skip lambdas, validators, and non-string literals at the start.
+        # The parser normalizes string_literal values to unquoted strings, so
+        # select by parameter type rather than by surrounding quotes.
+        start_idx = None
         for i, p in enumerate(params):
-            val = str(p.get("value", ""))
-            typ = p.get("type", "")
             if is_validator_param(p):
                 continue
-            if typ in ("lambda_expression", "qualified_identifier", "unresolved_identifier"):
-                continue
-            if not (val.startswith('"') and val.endswith('"')):
+            if p.get("type") != "string_literal":
                 continue
             # First string literal we hit is the name
             start_idx = i
@@ -713,7 +711,7 @@ class BasicInfoTransformer:
         property["name"] = name
 
         desc = None
-        if len(params) > start_idx + 1:
+        if start_idx is not None and len(params) > start_idx + 1:
             v0 = params[start_idx].get("value")
             v1 = params[start_idx + 1].get("value")
             if isinstance(v1, str) and len(v1) > 10 and " " in v1:


### PR DESCRIPTION
Fixes redpanda-data/docs#1657 (interim docs-side fix: redpanda-data/docs#1846).

**Root cause:** #149 changed `BasicInfoTransformer` to prefer the C++ member identifier (`info["name_in_file"]`) over the property name string literal passed to the constructor, and keyed the output JSON by the member identifier. The string-literal fallback was dead code in production because the parser strips quotes during normalization, so the `startswith('"')` check never matched (unit test fixtures kept quotes, which is why tests passed). When member and registered name differ, the docs emit a property name that does not exist in Redpanda: member `default_topic_replication` registers `"default_topic_replications"`, so 25.3+ docs documented the singular name.

**Fix:**
- `BasicInfoTransformer` takes the name from the first string-literal constructor argument when it is a whitespace-free identifier, falling back to the member identifier.
- The output JSON is keyed by the registered name.
- Duplicate registrations of one name within a config store keep the first definition, matching `config_store`'s `emplace()` semantics, with a warning.

**Impact (verified against redpanda v25.3.1):** 23 properties regain their real names, including `default_topic_replications`, `minimum_topic_replications`, `election_timeout_ms`, `memory_enable_memory_sampling`, `kafka_tcp_keepalive_timeout`, and the kafka client `consumer_*_ms` properties. All 620 unaffected properties are byte-identical before/after. `leader_balancer_node_mute_timeout` disappears because Redpanda registers both leader-balancer mute members under the same name `"leader_balancer_mute_timeout"` (configuration.cc:3387,3393) — the old entry was not a settable name; worth reporting upstream.

**Tests:** 69 pytest (2 new regression tests using parser-normalized values), 9 jest, all passing. The next `make compare` will report the 23 renames as removed+added, which is expected one-time churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
