### PR TITLE
Honor --path when locating the Redpanda source in the property extractor

### DIFF
--- a/__tests__/tools/property-extractor/test_source_path.py
+++ b/__tests__/tools/property-extractor/test_source_path.py
@@ -1,0 +1,45 @@
+"""
+find_redpanda_source must honor the --path argument.
+
+Before this, the ConstantResolver initialization and the constexpr fallback
+search hunted hardcoded cwd-relative locations (tmp/redpanda, ...). Running
+the extractor with the source anywhere else silently disabled validator enum
+extraction and enterprise enum metadata: sasl_mechanisms shipped without
+items.enum or x-enum-metadata and only a debug log hinted why.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(
+    0,
+    str(Path(__file__).parent.parent.parent.parent / "tools" / "property-extractor"),
+)
+
+import property_extractor
+
+
+class FindRedpandaSourceTest(unittest.TestCase):
+    def tearDown(self):
+        property_extractor.set_redpanda_source(None)
+
+    def test_explicit_path_wins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            property_extractor.set_redpanda_source(tmp)
+            self.assertEqual(property_extractor.find_redpanda_source(), tmp)
+
+    def test_missing_explicit_path_falls_back(self):
+        property_extractor.set_redpanda_source("/nonexistent/redpanda")
+        result = property_extractor.find_redpanda_source()
+        self.assertNotEqual(result, "/nonexistent/redpanda")
+
+    def test_no_override_uses_search(self):
+        property_extractor.set_redpanda_source(None)
+        # Whatever the search finds, it must not raise
+        property_extractor.find_redpanda_source()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.3.1",
+      "version": "5.3.2",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/property-extractor/property_extractor.py
+++ b/tools/property-extractor/property_extractor.py
@@ -321,16 +321,35 @@ _constexpr_cache = ConstexprCache()
 _type_definitions_cache = {}
 
 # Import topic property extractor
+# Set from --path in main() so every consumer of the Redpanda source uses the
+# tree the caller pointed at, regardless of the current working directory. The
+# hardcoded search below is only a fallback for direct module use.
+_redpanda_source_override = None
+
+
+def set_redpanda_source(path):
+    """Record the Redpanda source directory passed via --path."""
+    global _redpanda_source_override
+    _redpanda_source_override = path
+
+
 def find_redpanda_source():
     """
-    Locate the Redpanda source directory by searching standard locations.
-    
-    The property extractor looks for the Redpanda source code in multiple
-    locations to handle different execution contexts (project root, tools directory, etc.).
-    
+    Locate the Redpanda source directory.
+
+    Prefers the path passed via --path (recorded by set_redpanda_source);
+    falls back to searching standard locations relative to the current
+    working directory. Before this preference existed, running the extractor
+    from any directory that did not match a hardcoded guess silently
+    disabled the ConstantResolver: no validator enums, no enterprise enum
+    metadata, no constexpr resolution, with only a debug-level log line.
+
     Returns:
         str or None: Path to the Redpanda source directory if found, None otherwise.
     """
+    if _redpanda_source_override and os.path.exists(_redpanda_source_override):
+        return _redpanda_source_override
+
     redpanda_source_paths = [
         'tmp/redpanda',  # Current directory
         '../tmp/redpanda',  # Parent directory  
@@ -725,6 +744,13 @@ def transform_files_with_properties(files_with_properties):
         if src_v_path.exists():
             constant_resolver = ConstantResolver(src_v_path)
             logger.debug(f"Initialized ConstantResolver with path: {src_v_path}")
+    if constant_resolver is None:
+        logger.warning(
+            "Redpanda source directory not found: validator enum extraction "
+            "and enterprise enum metadata are DISABLED for this run. "
+            "Properties like sasl_mechanisms will be missing items.enum and "
+            "x-enum-metadata. Pass --path to the Redpanda checkout to fix this."
+        )
 
     transformers = [
         EnterpriseTransformer(), ## this must be the first, as it modifies current data
@@ -2908,6 +2934,11 @@ def main():
     treesitter_parser, cpp_language = get_treesitter_cpp_parser_and_language(
         treesitter_dir, destination_path
     )
+
+    # Every consumer of the Redpanda source (ConstantResolver, constexpr
+    # fallback search) must use the tree the caller pointed at, not a
+    # cwd-relative guess.
+    set_redpanda_source(options.path)
 
     # Pre-build constexpr cache for performance
     # This avoids repeated filesystem walks when resolving C++ identifiers and function calls


### PR DESCRIPTION
## Problem

`find_redpanda_source()` searches hardcoded cwd-relative locations (`tmp/redpanda`, `../tmp/redpanda`, ...) and ignores `--path`, the argument that tells the extractor exactly where the Redpanda source lives. Run the extractor from any directory that does not match one of the guesses and the ConstantResolver plus the constexpr fallback search silently never initialize: no validator enum extraction, no enterprise enum metadata, no constexpr resolution — with only a debug-level log line as evidence.

Concretely: `sasl_mechanisms` ships without `items.enum` and `items.x-enum-metadata`, and `test_enterprise_properties.py::RestrictedOnlyTest::test_sasl_mechanisms_restricted_values` fails against such a build. This surfaced while end-to-end testing #228/#232/#233/#234 with a shared Redpanda clone outside the tool root: the test failure initially looked like a Redpanda dev refactor (`sasl_mechanisms.h`), but the dev source resolves perfectly — the extractor just never looked at it. The Makefile path only works by accident of `cd $(TOOL_ROOT)` plus the clone landing at the hardcoded location.

## Fix

- `main()` records `--path` via a new `set_redpanda_source()`, and `find_redpanda_source()` prefers it, keeping the old search as a fallback for direct module use.
- When the resolver still cannot initialize, the run logs a loud warning naming the exact degradation (which properties lose what) instead of a debug line — the same no-silent-failure treatment as #226's detection tripwire.
- Regression tests for the override, the missing-path fallback, and the no-override search.

## Verification

Real extraction of a Redpanda dev checkout located outside every hardcoded guess, from the tool root (`tmp/` verifiably contains no clone):
- Before: `sasl_mechanisms.items` = `{"type": "string"}` — no enum, no metadata.
- After: full enum `[GSSAPI, SCRAM, OAUTHBEARER, PLAIN]` with `GSSAPI`/`OAUTHBEARER` marked `is_enterprise: true` (matching `enterprise_sasl_mechanisms` in `src/v/config/sasl_mechanisms.h`, the declared source of truth), 654 properties total.
- `test_enterprise_properties.py`: 23/23 pass against the regenerated fixture. Full extractor pytest suite green.

## Relationship to open property PRs

Unblocks the CI concern raised while testing #228/#233/#234 (any extractor-touching PR would hit the failing enterprise test whenever the source lands outside the hardcoded path). No overlap with #228/#232/#233/#234 hunks — merges cleanly alongside all four.