### PR TITLE
Warn when a rerender drops a page's Flags section

### DIFF
--- a/__tests__/tools/rpk-docs/generate-rpk-docs.test.js
+++ b/__tests__/tools/rpk-docs/generate-rpk-docs.test.js
@@ -1345,3 +1345,35 @@ describe('placeholder brace escaping', () => {
     expect(out).toContain('`table\\{vbar}json`')
   })
 })
+
+describe('vanishing Flags tripwire', () => {
+  const os2 = require('os')
+
+  test('warns when a rerender drops a previously present Flags section', async () => {
+    const tmp = fs.mkdtempSync(path.join(os2.tmpdir(), 'flags-tripwire-'))
+    const tree = {
+      name: 'rpk',
+      commands: [{
+        name: 'widget',
+        description: 'Widget things.',
+        usage: 'rpk widget [flags]',
+        flags: [{ name: 'verbose', type: 'bool', description: 'Louder.' }],
+        commands: []
+      }]
+    }
+    // First render: page has a Flags section
+    await generateRpkDocs({ tree, overrides: { commands: {} }, outputDir: tmp })
+    const page = path.join(tmp, 'rpk-widget.adoc')
+    expect(fs.readFileSync(page, 'utf8')).toContain('== Flags')
+
+    // Second render: flag data gone (the connect run failure shape)
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    tree.commands[0].flags = []
+    await generateRpkDocs({ tree, overrides: { commands: {} }, outputDir: tmp })
+    const warned = warnSpy.mock.calls.map(a => a.join(' ')).join('\n')
+    warnSpy.mockRestore()
+    expect(warned).toContain('rpk widget')
+    expect(warned).toContain('Flags section and this render has none')
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+})

--- a/tools/rpk-docs/generate-rpk-docs.js
+++ b/tools/rpk-docs/generate-rpk-docs.js
@@ -3000,6 +3000,21 @@ async function generateRpkDocs(options = {}) {
     }
 
     try {
+      // A page that HAD a Flags section and loses it in this render is the
+      // signature of missing flag data (a snapshot without extraction, or a
+      // curated table removed before the extracted one exists). Nothing else
+      // catches this class: the run exits 0 with a clean log while the
+      // published page silently drops its flag documentation (seen on
+      // rpk connect run).
+      if (fs.existsSync(filePath)) {
+        const previous = fs.readFileSync(filePath, 'utf8')
+        if (/^== Flags$/m.test(previous) && !/^== Flags$/m.test(content)) {
+          console.warn(
+            `⚠️  ${commandPath}: the previously rendered page had a Flags section and this render has none. ` +
+            'The command likely lost its flag data (snapshot without extraction, or a curated Flags override removed too early).'
+          )
+        }
+      }
       fs.writeFileSync(filePath, content, 'utf8')
       writtenFiles.add(filePath)
       filesGenerated++


### PR DESCRIPTION
Implements @micheleRP's suggestion from the merge-order review, which came with direct evidence: with the curated `rpk connect run` Flags override removed (#1865) and a snapshot carrying no extracted connect flags, the page renders title → Usage → Global flags with **no Flags section, exit 0, and zero warnings** — nothing catches the class at generation time, and the resulting diff reads like intended cleanup.

The generator now compares each page against the file it is about to overwrite: a page that previously had a `== Flags` section and loses it in the new render emits a warning naming the two likely causes (a snapshot without flag extraction, or a curated Flags override removed before the extracted table exists). Warning-only by design — there are legitimate transitions — but it turns a silent page regression into a reviewable log line and a line in the workflow output.

Tested with a first-render/re-render cycle reproducing the connect run shape. Full suite green. No version bump: rides the next publish.

## Related PRs (rpk docs automation train)

Follow-up from the #1862/#1865 merge-order review.