### PR TITLE
Release 5.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.3.2",
+      "version": "5.3.3",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Version bump only. Ships the already-merged #241 (five rpk generator fixes) and #240 (vanishing-Flags tripwire) — both approved with no bump so this cut could be a single release step, per the note on #241.

On publish, the docs repo sequence resumes: merge redpanda-data/docs#1860, whose auto-rerender then runs with this release and reproduces main byte for byte plus the rpai span/code-block fixes.