### PR TITLE
Release 5.3.6: export the set-available-attachment-versions extension

### DIFF
--- a/__tests__/package-exports.test.js
+++ b/__tests__/package-exports.test.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+/**
+ * Every extension file must be reachable through the package exports map.
+ * The map enumerates subpaths explicitly, so a new extension that ships
+ * without an entry loads fine in this repo but throws
+ * ERR_PACKAGE_PATH_NOT_EXPORTED in every consumer — found the hard way when
+ * set-available-attachment-versions broke the docs-site build despite the
+ * file being present in the published package.
+ */
+describe('package exports cover all extensions', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'))
+
+  const exportedTargets = new Set(
+    Object.values(pkg.exports || {}).map((v) => (typeof v === 'object' ? v.require : v))
+  )
+
+  const extensionFiles = fs
+    .readdirSync(path.join(__dirname, '..', 'extensions'))
+    .filter((f) => f.endsWith('.js'))
+    .map((f) => `./extensions/${f}`)
+
+  test.each(extensionFiles)('%s is exported', (file) => {
+    expect(exportedTargets).toContain(file)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.3.5",
+      "version": "5.3.6",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",
@@ -60,6 +60,7 @@
     "./extensions/generate-rp-connect-info": "./extensions/generate-rp-connect-info.js",
     "./extensions/generate-fields-only-pages": "./extensions/generate-fields-only-pages.js",
     "./extensions/add-global-attributes": "./extensions/add-global-attributes.js",
+    "./extensions/set-available-attachment-versions": "./extensions/set-available-attachment-versions.js",
     "./extensions/git-full-clone": "./extensions/git-full-clone.js",
     "./extensions/add-git-dates": "./extensions/add-git-dates.js",
     "./extensions/add-faq-structured-data": "./extensions/add-faq-structured-data.js",


### PR DESCRIPTION
## What

docs-site#195's preview build fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`: #224 shipped `extensions/set-available-attachment-versions.js` but never added it to the package `exports` map, which enumerates every extension subpath explicitly. The extension loads fine inside this repo (tests require it by relative path), so nothing here could catch it — only a real consumer build does.

- Adds the missing exports entry (audited: it was the only gap).
- Adds a regression guard test asserting every `extensions/*.js` is reachable through `exports`, so this class can't recur.
- Carries the 5.3.6 bump so docs-site#195 can pin past it.

## Validation

985 tests pass. Subpath resolution verified with `createRequire` against the local package.

cc @micheleRP — this is the missing piece behind the docs-site#195 Netlify failures; after publish I'll bump #195's lockfile and its checks should go green.