### PR TITLE
Let single-source stubs inherit descriptions as header attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ mcp-usage-stats.json
 # Development rpk JSON files
 docs-data/rpk-vdev.json
 docs-data/rpk-vlocal.json
+
+# Property extractor working data (cloned/built at run time)
+tools/property-extractor/tmp/
+tools/property-extractor/tree-sitter/tree-sitter-cpp/

--- a/__tests__/tools/rpcn-connector-summaries.test.js
+++ b/__tests__/tools/rpcn-connector-summaries.test.js
@@ -400,6 +400,18 @@ describe('backfillPageDescriptions - self-healing page headers', () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
+  test('maps the rate-limits data key to the rate_limits pages directory', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'backfill-rl-'));
+    fs.mkdirSync(path.join(root, 'rate_limits'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'rate_limits', 'local.adoc'),
+      '= local\n// tag::single-source[]\n:type: rate_limit\n\nBody.\n');
+    const result = backfillPageDescriptions({
+      'rate-limits': [{ name: 'local', summary: 'A simple X every Y rate limit.' }],
+    }, { pagesRoot: root });
+    expect(result.backfilled).toEqual(['rate_limits/local']);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
   test('dry run reports without writing', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'backfill-dry-'));
     fs.mkdirSync(path.join(root, 'caches'), { recursive: true });

--- a/__tests__/tools/rpcn-connector-summaries.test.js
+++ b/__tests__/tools/rpcn-connector-summaries.test.js
@@ -340,3 +340,60 @@ describe('buildChangedDefaultsTable - whats-new changed default links', () => {
     expect(table).toContain('|batching.byte_size\n');
   });
 });
+
+describe('backfillPageDescriptions - self-healing page headers', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const os = require('os');
+  const { backfillPageDescriptions } = require('../../tools/redpanda-connect/generate-rpcn-connector-docs');
+
+  const data = {
+    caches: [
+      { name: 'multilevel', summary: 'Combines multiple caches as levels,\nacross them.' },
+      { name: 'has_desc', summary: 'Should not be used.' },
+      { name: 'no_summary', summary: '' },
+      { name: 'no_page', summary: 'Page does not exist.' },
+    ],
+    'bloblang-functions': [{ name: 'not_a_page_family', summary: 'Ignored.' }],
+  };
+
+  test('inserts a tagged description into headers that lack one', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'backfill-'));
+    fs.mkdirSync(path.join(root, 'caches'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'caches', 'multilevel.adoc'),
+      '= multilevel\n// tag::single-source[]\n:type: cache\n:status: stable\n\nBody.\n// end::single-source[]\n');
+    fs.writeFileSync(path.join(root, 'caches', 'has_desc.adoc'),
+      '= has_desc\n// tag::single-source[]\n:description: Already here.\n\nBody.\n// end::single-source[]\n');
+    fs.writeFileSync(path.join(root, 'caches', 'no_summary.adoc'),
+      '= no_summary\n// tag::single-source[]\n:type: cache\n\nBody.\n// end::single-source[]\n');
+
+    const result = backfillPageDescriptions(data, { pagesRoot: root });
+    expect(result.backfilled).toEqual(['caches/multilevel']);
+    expect(result.skippedNoSummary).toEqual(['caches/no_summary']);
+
+    const lines = fs.readFileSync(path.join(root, 'caches', 'multilevel.adoc'), 'utf8').split('\n');
+    // Inserted at the end of the header (before the first blank line),
+    // summary flattened to one line, wrapped in the meta tag region.
+    expect(lines[4]).toBe('// tag::meta[]');
+    expect(lines[5]).toBe(':description: Combines multiple caches as levels, across them.');
+    expect(lines[6]).toBe('// end::meta[]');
+    expect(lines[7]).toBe('');
+    // Pages that already have one are untouched
+    expect(fs.readFileSync(path.join(root, 'caches', 'has_desc.adoc'), 'utf8')).toContain(':description: Already here.');
+
+    // Idempotent: second run backfills nothing
+    expect(backfillPageDescriptions(data, { pagesRoot: root }).backfilled).toEqual([]);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('dry run reports without writing', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'backfill-dry-'));
+    fs.mkdirSync(path.join(root, 'caches'), { recursive: true });
+    const page = '= multilevel\n// tag::single-source[]\n:type: cache\n\nBody.\n';
+    fs.writeFileSync(path.join(root, 'caches', 'multilevel.adoc'), page);
+    const result = backfillPageDescriptions(data, { pagesRoot: root, dryRun: true });
+    expect(result.backfilled).toEqual(['caches/multilevel']);
+    expect(fs.readFileSync(path.join(root, 'caches', 'multilevel.adoc'), 'utf8')).toBe(page);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/__tests__/tools/rpcn-connector-summaries.test.js
+++ b/__tests__/tools/rpcn-connector-summaries.test.js
@@ -400,6 +400,26 @@ describe('backfillPageDescriptions - self-healing page headers', () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
+  test('flattens bare URL macros and internal xref shorthand out of the meta text', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'backfill-url-'));
+    fs.mkdirSync(path.join(root, 'tracers'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'tracers', 'open_telemetry_collector.adoc'),
+      '= open_telemetry_collector\n// tag::single-source[]\n:type: tracer\n\nBody.\n');
+    fs.mkdirSync(path.join(root, 'outputs'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'outputs', 'broker.adoc'),
+      '= broker\n// tag::single-source[]\n:type: output\n\nBody.\n');
+    const result = backfillPageDescriptions({
+      tracers: [{ name: 'open_telemetry_collector', summary: 'Send tracing events to an https://opentelemetry.io/docs/collector/[Open Telemetry collector^].' }],
+      outputs: [{ name: 'broker', summary: 'Allows you to route messages to multiple child outputs using a range of brokering <<patterns>>.' }],
+    }, { pagesRoot: root });
+    expect(result.backfilled).toEqual(['tracers/open_telemetry_collector', 'outputs/broker']);
+    expect(fs.readFileSync(path.join(root, 'tracers', 'open_telemetry_collector.adoc'), 'utf8'))
+      .toContain(':description: Send tracing events to an Open Telemetry collector.');
+    expect(fs.readFileSync(path.join(root, 'outputs', 'broker.adoc'), 'utf8'))
+      .toContain(':description: Allows you to route messages to multiple child outputs using a range of brokering patterns.');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
   test('maps the rate-limits data key to the rate_limits pages directory', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'backfill-rl-'));
     fs.mkdirSync(path.join(root, 'rate_limits'), { recursive: true });

--- a/__tests__/tools/rpcn-connector-summaries.test.js
+++ b/__tests__/tools/rpcn-connector-summaries.test.js
@@ -386,6 +386,20 @@ describe('backfillPageDescriptions - self-healing page headers', () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
+  test('flattens AsciiDoc markup out of the meta text', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'backfill-md-'));
+    fs.mkdirSync(path.join(root, 'processors'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'processors', 'workflow.adoc'),
+      '= workflow\n// tag::single-source[]\n:type: processor\n\nBody.\n');
+    const result = backfillPageDescriptions({
+      processors: [{ name: 'workflow', summary: 'Executes a topology of xref:components:processors/branch.adoc[`branch` processors], in parallel.' }],
+    }, { pagesRoot: root });
+    expect(result.backfilled).toEqual(['processors/workflow']);
+    const page = fs.readFileSync(path.join(root, 'processors', 'workflow.adoc'), 'utf8');
+    expect(page).toContain(':description: Executes a topology of branch processors, in parallel.');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
   test('dry run reports without writing', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'backfill-dry-'));
     fs.mkdirSync(path.join(root, 'caches'), { recursive: true });

--- a/__tests__/tools/rpcn-connector-summaries.test.js
+++ b/__tests__/tools/rpcn-connector-summaries.test.js
@@ -411,3 +411,16 @@ describe('backfillPageDescriptions - self-healing page headers', () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 });
+
+describe('mergeOverrides honors summary overrides', () => {
+  const { mergeOverrides } = require('../../tools/redpanda-connect/generate-rpcn-connector-docs');
+
+  test('a top-level summary override reaches the component', () => {
+    // overrides.json has carried summary overrides (zmq4, ffi) that were
+    // silently dropped: 'summary' was missing from scalarKeys and fell
+    // through every merge branch.
+    const data = { inputs: [{ name: 'zmq4', summary: '' }] };
+    mergeOverrides(data, { inputs: [{ name: 'zmq4', summary: 'Consumes messages from a ZeroMQ socket.' }] });
+    expect(data.inputs[0].summary).toBe('Consumes messages from a ZeroMQ socket.');
+  });
+});

--- a/__tests__/tools/rpk-docs/override-features.test.js
+++ b/__tests__/tools/rpk-docs/override-features.test.js
@@ -981,10 +981,15 @@ Original fields content that should be replaced.`,
       await generateRpcDocsForMetaTest()
       const page = fs.readFileSync(path.join(outputDir, 'rpk-cluster', 'rpk-cluster-health.adoc'), 'utf8')
       const lines = page.split('\n')
+      // The single description lives in the page header, wrapped by the
+      // meta tag region so stubs can inherit it as a header attribute.
+      expect(lines[0]).toBe('= rpk cluster health')
+      expect(lines[1]).toBe('// tag::meta[]')
+      expect(lines[2]).toMatch(/^:description: /)
+      expect(lines[3]).toBe('// end::meta[]')
+      // No duplicate description inside the single-source region.
       const tagIdx = lines.indexOf('// tag::single-source[]')
-      expect(lines[tagIdx + 1]).toBe('// tag::meta[]')
-      expect(lines[tagIdx + 2]).toMatch(/^:description: /)
-      expect(lines[tagIdx + 3]).toBe('// end::meta[]')
+      expect(lines.slice(tagIdx).filter((l) => l.startsWith(':description:'))).toHaveLength(0)
     }, 30000)
 
     async function generateRpcDocsForMetaTest () {

--- a/__tests__/tools/rpk-docs/override-features.test.js
+++ b/__tests__/tools/rpk-docs/override-features.test.js
@@ -977,6 +977,26 @@ Original fields content that should be replaced.`,
       expect(page).toContain('|xref:reference:rpk/rpk-cluster/rpk-cluster-info.adoc[`rpk cluster info`]')
     }, 30000)
 
+    test('the single-source region nests a meta tag around the description', async () => {
+      await generateRpcDocsForMetaTest()
+      const page = fs.readFileSync(path.join(outputDir, 'rpk-cluster', 'rpk-cluster-health.adoc'), 'utf8')
+      const lines = page.split('\n')
+      const tagIdx = lines.indexOf('// tag::single-source[]')
+      expect(lines[tagIdx + 1]).toBe('// tag::meta[]')
+      expect(lines[tagIdx + 2]).toMatch(/^:description: /)
+      expect(lines[tagIdx + 3]).toBe('// end::meta[]')
+    }, 30000)
+
+    async function generateRpcDocsForMetaTest () {
+      await generateRpkDocs({
+        tree: clusterTree(),
+        overrides: {},
+        outputDir,
+        rpkVersion: 'test',
+        pluginVersions: {}
+      })
+    }
+
     // Availability never wraps the page itself: includes only extract the
     // single-source tag region (a page-level conditional outside it is dead
     // code), and a build that did consume it would publish an empty,

--- a/__tests__/tools/rpk-docs/plugin-stubs.test.js
+++ b/__tests__/tools/rpk-docs/plugin-stubs.test.js
@@ -274,3 +274,44 @@ describe('dynamic description inheritance via the meta tag region', () => {
     fs.rmSync(dir, { recursive: true, force: true })
   })
 })
+
+describe('existing-stub upgrade to the meta include', () => {
+  const fs = require('fs')
+  const path = require('path')
+  const os = require('os')
+  const { reconcileStubs, readPartialTitles } = require('../../../tools/rpk-docs/generate-plugin-stubs.js')
+
+  test('adds the header include to an existing stub when the partial gains the region', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stub-upgrade-'))
+    const partialsDir = path.join(dir, 'partials')
+    const stubDir = path.join(dir, 'stubs')
+    const navFile = path.join(dir, 'nav.adoc')
+    fs.mkdirSync(partialsDir); fs.mkdirSync(stubDir)
+    fs.writeFileSync(navFile, '* xref:reference:rpk/index.adoc[rpk]\n')
+    const prefix = 'streaming:reference:partial$rpk-ai/'
+    fs.writeFileSync(path.join(partialsDir, 'rpk-ai-run.adoc'),
+      '= rpk ai run\n// tag::single-source[]\n// tag::meta[]\n:description: D.\n// end::meta[]\nBody.\n// end::single-source[]\n')
+    fs.writeFileSync(path.join(stubDir, 'rpk-ai-run.adoc'),
+      `= rpk ai run\n\ninclude::${prefix}rpk-ai-run.adoc[tag=single-source]\n`)
+
+    const run = () => reconcileStubs({
+      partials: readPartialTitles(partialsDir),
+      stubDir,
+      navFile,
+      plugin: 'ai',
+      includePrefix: prefix,
+      attributes: [],
+      dryRun: false
+    })
+    const result = run()
+    expect(result.upgraded).toEqual(['rpk-ai-run.adoc'])
+    const lines = fs.readFileSync(path.join(stubDir, 'rpk-ai-run.adoc'), 'utf8').split('\n')
+    expect(lines[0]).toBe('= rpk ai run')
+    expect(lines[1]).toBe(`include::${prefix}rpk-ai-run.adoc[tag=meta]`)
+    expect(lines[2]).toBe('')
+
+    // Idempotent: a second run changes nothing
+    expect(run().upgraded).toEqual([])
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+})

--- a/__tests__/tools/rpk-docs/plugin-stubs.test.js
+++ b/__tests__/tools/rpk-docs/plugin-stubs.test.js
@@ -314,4 +314,35 @@ describe('existing-stub upgrade to the meta include', () => {
     expect(run().upgraded).toEqual([])
     fs.rmSync(dir, { recursive: true, force: true })
   })
+
+  test('the upgrade strips a backfilled literal description, which would otherwise win', () => {
+    // Later attribute entries override earlier ones, so a literal below
+    // the inserted include would take precedence and freshness would
+    // never materialize (micheleRP's precedence finding, verified).
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stub-strip-'))
+    const partialsDir = path.join(dir, 'partials')
+    const stubDir = path.join(dir, 'stubs')
+    const navFile = path.join(dir, 'nav.adoc')
+    fs.mkdirSync(partialsDir); fs.mkdirSync(stubDir)
+    fs.writeFileSync(navFile, '* xref:reference:rpk/index.adoc[rpk]\n')
+    const prefix = 'streaming:reference:partial$rpk-ai/'
+    fs.writeFileSync(path.join(partialsDir, 'rpk-ai-run.adoc'),
+      '= rpk ai run\n// tag::single-source[]\n// tag::meta[]\n:description: Fresh.\n// end::meta[]\nBody.\n// end::single-source[]\n')
+    fs.writeFileSync(path.join(stubDir, 'rpk-ai-run.adoc'),
+      `= rpk ai run\n:description: Stale backfilled copy.\n\ninclude::${prefix}rpk-ai-run.adoc[tag=single-source]\n`)
+
+    const result = reconcileStubs({
+      partials: readPartialTitles(partialsDir),
+      stubDir,
+      navFile,
+      plugin: 'ai',
+      includePrefix: prefix,
+      attributes: [],
+      dryRun: false
+    })
+    expect(result.upgraded).toEqual(['rpk-ai-run.adoc'])
+    const content = fs.readFileSync(path.join(stubDir, 'rpk-ai-run.adoc'), 'utf8')
+    expect(content).not.toContain(':description: Stale backfilled copy.')
+    expect(content.split('\n')[1]).toBe(`include::${prefix}rpk-ai-run.adoc[tag=meta]`)
+  })
 })

--- a/__tests__/tools/rpk-docs/plugin-stubs.test.js
+++ b/__tests__/tools/rpk-docs/plugin-stubs.test.js
@@ -213,3 +213,64 @@ describe('alias-collision guard', () => {
     fs2.rmSync(dir, { recursive: true, force: true })
   })
 })
+
+describe('dynamic description inheritance via the meta tag region', () => {
+  const fs = require('fs')
+  const path = require('path')
+  const os = require('os')
+  const { readPartialTitles, renderStub } = require('../../../tools/rpk-docs/generate-plugin-stubs.js')
+
+  // Antora resolves page metadata with a header-only parse that stops at the
+  // stub's first blank line, so a description can only reach the rendered
+  // page's <meta> tag as a header attribute: either a literal line or an
+  // include placed above the first blank line. Verified empirically against
+  // an Antora build with the production UI bundle (2026-08-05): the naive
+  // no-blank-line body include inherits the description but destroys the
+  // page body, and the two-include shape delivers both.
+
+  test('stubs for partials with a meta tag region get the header include', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stub-meta-'))
+    fs.writeFileSync(path.join(dir, 'rpk-ai-run.adoc'), [
+      '= rpk ai run',
+      ':description: Run things.',
+      '',
+      '// tag::single-source[]',
+      '// tag::meta[]',
+      ':description: Run things.',
+      '// end::meta[]',
+      'Body.',
+      '// end::single-source[]',
+    ].join('\n'))
+    const [partial] = readPartialTitles(dir)
+    expect(partial.hasMetaTag).toBe(true)
+
+    const stub = renderStub({ ...partial, includePrefix: 'streaming:reference:partial$rpk-ai/', attributes: [] })
+    const lines = stub.split('\n')
+    // The meta include sits in the header: directly under the title with no
+    // blank line before it, and the body include after the blank line.
+    expect(lines[0]).toBe('= rpk ai run')
+    expect(lines[1]).toBe('include::streaming:reference:partial$rpk-ai/rpk-ai-run.adoc[tag=meta]')
+    expect(lines[2]).toBe('')
+    expect(lines[3]).toBe('include::streaming:reference:partial$rpk-ai/rpk-ai-run.adoc[tag=single-source]')
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  test('stubs for older partials without the region keep the plain shape', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stub-nometa-'))
+    fs.writeFileSync(path.join(dir, 'rpk-ai-old.adoc'), [
+      '= rpk ai old',
+      '',
+      '// tag::single-source[]',
+      'Body.',
+      '// end::single-source[]',
+    ].join('\n'))
+    const [partial] = readPartialTitles(dir)
+    expect(partial.hasMetaTag).toBe(false)
+
+    const stub = renderStub({ ...partial, includePrefix: 'p$/', attributes: [] })
+    // No tag=meta include, so the build never warns about a missing tag.
+    expect(stub).not.toContain('[tag=meta]')
+    expect(stub.split('\n')[1]).toBe('')
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+})

--- a/bin/doc-tools.js
+++ b/bin/doc-tools.js
@@ -1660,6 +1660,21 @@ automation
             return match
           }
         })
+      // Antora resolves page metadata with a header-only parse that stops at
+      // the first blank line. The chart README templates emit :description:
+      // below the title's blank line, so the page shipped the generic site
+      // meta description despite carrying one (found on k-connect-helm-spec,
+      // DOC-2414 investigation). Relocate the first :description: into the
+      // header, directly under the title.
+      const descMatch = doc.match(/^:description:[^\n]*$/m)
+      if (descMatch) {
+        const headerEnd = doc.indexOf('\n\n')
+        if (headerEnd !== -1 && doc.indexOf(descMatch[0]) > headerEnd) {
+          doc = doc.replace(descMatch[0] + '\n', '')
+          doc = doc.replace(/^(= .+)$/m, `$1\n${descMatch[0]}`)
+          doc = doc.replace(/\n{3,}/g, '\n\n')
+        }
+      }
       fs.writeFileSync(outFile, doc, 'utf8')
 
       console.log(`Done: Wrote ${outFile}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.7",
+  "version": "5.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.3.7",
+      "version": "5.3.8",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.10.0",
+  "version": "5.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.10.0",
+      "version": "5.8.0",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.7",
+  "version": "5.3.8",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.10.0",
+  "version": "5.8.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/redpanda-connect/generate-rpcn-connector-docs.js
+++ b/tools/redpanda-connect/generate-rpcn-connector-docs.js
@@ -674,17 +674,99 @@ async function generateRpcnConnectorDocs(options) {
     }
   }
 
+  // Self-heal published page headers: pages are one-time drafts, so pages
+  // created before the template emitted :description: never got one.
+  let descriptionBackfill = { backfilled: [], skippedNoSummary: [] };
+  if (!writeFullDrafts) {
+    descriptionBackfill = backfillPageDescriptions(dataObj);
+  }
+
   return {
     partialsWritten,
     draftsWritten,
     partialFiles,
     draftFiles,
-    lostSectionWarnings
+    lostSectionWarnings,
+    descriptionBackfill
   };
+}
+
+
+// Connector page families that have per-component pages under
+// modules/components/pages/. Other data keys (config, bloblang-functions,
+// bloblang-methods) have no per-component page to backfill.
+const PAGE_TYPE_DIRS = new Set([
+  'inputs', 'outputs', 'processors', 'caches', 'buffers', 'metrics',
+  'tracers', 'scanners', 'rate-limits', 'rate_limits'
+]);
+
+/**
+ * Insert a tagged :description: into existing connector page headers that
+ * lack one, sourced from the component's summary in the connector data.
+ *
+ * Connector pages are one-time first drafts: pages drafted before the
+ * template emitted :description: never got one, and nothing rewrote them,
+ * so hundreds of published pages ship the generic site meta description
+ * even though ~97% of components carry a summary in the source data. This
+ * runs on every generation, so the page set self-heals and stays healed.
+ *
+ * The inserted block matches the connector template's shape: the meta tag
+ * region lets single-source stubs inherit the description as a header
+ * attribute (see the template comment in connector.hbs).
+ *
+ * @param {Object} connectorData - Parsed connector data (typed arrays)
+ * @param {Object} [options]
+ * @param {string} [options.pagesRoot] - Pages directory (default: modules/components/pages under cwd)
+ * @param {boolean} [options.dryRun] - Report without writing
+ * @returns {{backfilled: string[], skippedNoSummary: string[]}}
+ */
+function backfillPageDescriptions (connectorData, { pagesRoot, dryRun = false } = {}) {
+  const root = pagesRoot || path.resolve(process.cwd(), 'modules/components/pages');
+  const results = { backfilled: [], skippedNoSummary: [] };
+  if (!fs.existsSync(root)) return results;
+
+  for (const [typeDir, items] of Object.entries(connectorData)) {
+    if (!PAGE_TYPE_DIRS.has(typeDir) || !Array.isArray(items)) continue;
+    for (const item of items) {
+      if (!item || !item.name) continue;
+      const pagePath = path.join(root, typeDir, `${item.name}.adoc`);
+      if (!fs.existsSync(pagePath)) continue;
+
+      const content = fs.readFileSync(pagePath, 'utf8');
+      const lines = content.split('\n');
+      const headerEnd = lines.findIndex((l) => l.trim() === '');
+      const header = lines.slice(0, headerEnd === -1 ? lines.length : headerEnd);
+      if (header.some((l) => l.startsWith(':description:'))) continue;
+
+      const summary = (item.summary || '').replace(/\s+/g, ' ').trim();
+      if (!summary) {
+        results.skippedNoSummary.push(`${typeDir}/${item.name}`);
+        continue;
+      }
+
+      const insertAt = headerEnd === -1 ? lines.length : headerEnd;
+      lines.splice(insertAt, 0, '// tag::meta[]', `:description: ${summary}`, '// end::meta[]');
+      if (!dryRun) fs.writeFileSync(pagePath, lines.join('\n'), 'utf8');
+      results.backfilled.push(`${typeDir}/${item.name}`);
+    }
+  }
+
+  if (results.backfilled.length) {
+    console.log(`Backfilled :description: into ${results.backfilled.length} connector page header(s) from source summaries`);
+  }
+  if (results.skippedNoSummary.length) {
+    console.warn(
+      `\u26a0 ${results.skippedNoSummary.length} connector page(s) lack both a header description and a source summary: ` +
+      results.skippedNoSummary.join(', ') +
+      '. Author these in the overrides file or upstream.'
+    );
+  }
+  return results;
 }
 
 module.exports = {
   generateRpcnConnectorDocs,
+  backfillPageDescriptions,
   mergeOverrides,
   resolveReferences
 };

--- a/tools/redpanda-connect/generate-rpcn-connector-docs.js
+++ b/tools/redpanda-connect/generate-rpcn-connector-docs.js
@@ -752,6 +752,14 @@ function backfillPageDescriptions (connectorData, { pagesRoot, dryRun = false } 
       // backticks. No prose is edited.
       const summary = (item.summary || '')
         .replace(/(?:xref|link):[^\[\]]+\[([^\]]*)\]/g, '$1')
+        // Bare URL macros (no xref:/link: prefix) and internal xref shorthand
+        // also appear in source summaries and render literally if left in place.
+        .replace(/https?:\/\/[^\s\[\]]+\[([^\]]*)\]/g, '$1')
+        .replace(/<<[^,>]+,([^>]+)>>/g, '$1')
+        .replace(/<<([^>]+)>>/g, '$1')
+        // Strip the "open in new tab" caret that AsciiDoc URL macros carry
+        // inside the link text, e.g. [Open Telemetry collector^].
+        .replace(/\^/g, '')
         .replace(/`([^`]*)`/g, '$1')
         .replace(/\s+/g, ' ')
         .trim();

--- a/tools/redpanda-connect/generate-rpcn-connector-docs.js
+++ b/tools/redpanda-connect/generate-rpcn-connector-docs.js
@@ -728,8 +728,13 @@ function backfillPageDescriptions (connectorData, { pagesRoot, dryRun = false } 
   const results = { backfilled: [], skippedNoSummary: [] };
   if (!fs.existsSync(root)) return results;
 
-  for (const [typeDir, items] of Object.entries(connectorData)) {
-    if (!PAGE_TYPE_DIRS.has(typeDir) || !Array.isArray(items)) continue;
+  for (const [dataKey, items] of Object.entries(connectorData)) {
+    if (!PAGE_TYPE_DIRS.has(dataKey) || !Array.isArray(items)) continue;
+    // The data uses 'rate-limits' while the pages directory is
+    // 'rate_limits'. Resolve whichever spelling exists on disk.
+    const typeDir = fs.existsSync(path.join(root, dataKey))
+      ? dataKey
+      : dataKey.replace(/-/g, '_');
     for (const item of items) {
       if (!item || !item.name) continue;
       const pagePath = path.join(root, typeDir, `${item.name}.adoc`);

--- a/tools/redpanda-connect/generate-rpcn-connector-docs.js
+++ b/tools/redpanda-connect/generate-rpcn-connector-docs.js
@@ -738,7 +738,15 @@ function backfillPageDescriptions (connectorData, { pagesRoot, dryRun = false } 
       const header = lines.slice(0, headerEnd === -1 ? lines.length : headerEnd);
       if (header.some((l) => l.startsWith(':description:'))) continue;
 
-      const summary = (item.summary || '').replace(/\s+/g, ' ').trim();
+      // Meta descriptions are read as plain text by search results, link
+      // previews, and assistants, so flatten AsciiDoc markup mechanically:
+      // xrefs and links become their labels, inline code loses its
+      // backticks. No prose is edited.
+      const summary = (item.summary || '')
+        .replace(/(?:xref|link):[^\[\]]+\[([^\]]*)\]/g, '$1')
+        .replace(/`([^`]*)`/g, '$1')
+        .replace(/\s+/g, ' ')
+        .trim();
       if (!summary) {
         results.skippedNoSummary.push(`${typeDir}/${item.name}`);
         continue;

--- a/tools/redpanda-connect/generate-rpcn-connector-docs.js
+++ b/tools/redpanda-connect/generate-rpcn-connector-docs.js
@@ -55,7 +55,10 @@ function mergeOverrides(target, overrides) {
     throw new Error('Target must be a valid object');
   }
 
-  const scalarKeys = ['description', 'type', 'annotated_field', 'version'];
+  // 'summary' earns its place here the hard way: overrides.json has carried
+  // summary overrides (zmq4, ffi) that were silently dropped because the key
+  // fell through every branch below. Summaries feed page meta descriptions.
+  const scalarKeys = ['description', 'summary', 'type', 'annotated_field', 'version'];
 
   for (const key in overrides) {
     // === Handle annotated_options ===

--- a/tools/redpanda-connect/templates/bloblang-functions-overview.hbs
+++ b/tools/redpanda-connect/templates/bloblang-functions-overview.hbs
@@ -1,6 +1,8 @@
 = Bloblang Functions
 // tag::single-source[]
+// tag::meta[]
 :description: A list of Bloblang functions
+// end::meta[]
 
 // © 2024 Redpanda Data Inc.
 

--- a/tools/redpanda-connect/templates/bloblang-methods-overview.hbs
+++ b/tools/redpanda-connect/templates/bloblang-methods-overview.hbs
@@ -1,6 +1,8 @@
 = Bloblang Methods
 // tag::single-source[]
+// tag::meta[]
 :description: A list of Bloblang methods
+// end::meta[]
 
 // © 2024 Redpanda Data Inc.
 

--- a/tools/redpanda-connect/templates/connector.hbs
+++ b/tools/redpanda-connect/templates/connector.hbs
@@ -3,7 +3,19 @@
 :type: {{type}}
 {{#if support}}:support: {{support}}{{/if}}
 :categories: [{{join categories ", "}}]
-:description: {{#if summary}}{{{summary}}}{{else if description}}{{description}}{{else}}// TODO: Missing description. Add a description in the overrides file or source data.{{/if}}
+{{#if summary}}
+// tag::meta[]
+:description: {{{summary}}}
+// end::meta[]
+{{else if description}}
+// tag::meta[]
+:description: {{description}}
+// end::meta[]
+{{/if}}
+{{!-- No fallback line when neither exists: an emitted TODO would become
+     the attribute VALUE and stubs would inherit it into their meta tags.
+     Missing descriptions are the tracked editorial backlog
+     (cloud-docs .github/description-allowlist.txt). --}}
 
 component_type_dropdown::[]
 

--- a/tools/rpk-docs/generate-plugin-stubs.js
+++ b/tools/rpk-docs/generate-plugin-stubs.js
@@ -237,7 +237,15 @@ function reconcileStubs({
         const stubContent = fs.readFileSync(stubPath, 'utf8')
         if (!stubContent.includes('[tag=meta]')) {
           const metaInclude = `include::${includePrefix}${partial.file}[tag=meta]`
-          const upgraded = stubContent.replace(/^(= .+)$/m, `$1\n${metaInclude}`)
+          // A later attribute entry overrides an earlier one (verified
+          // empirically against an Antora build), so a literal
+          // :description: below the include would win and leave the
+          // include dead weight. These are generated reference stubs, so
+          // any literal is a static backfill the include supersedes:
+          // strip it. Hand-maintained prose stubs never pass through this
+          // reconciler, so intentionally curated descriptions are safe.
+          let upgraded = stubContent.replace(/^:description: .*\n/m, '')
+          upgraded = upgraded.replace(/^(= .+)$/m, `$1\n${metaInclude}`)
           if (upgraded !== stubContent) {
             fs.writeFileSync(stubPath, upgraded, 'utf8')
             upgraded_.push(partial.file)

--- a/tools/rpk-docs/generate-plugin-stubs.js
+++ b/tools/rpk-docs/generate-plugin-stubs.js
@@ -181,6 +181,7 @@ function reconcileStubs({
   const existingStubs = fs.readdirSync(stubDir).filter(f => f.endsWith('.adoc'))
 
   const created = []
+  const upgraded_ = []
   const deleted = []
   const keptNonStub = []
   const skippedAliasTargets = []
@@ -225,7 +226,26 @@ function reconcileStubs({
     fs.existsSync(stubDir) ? fs.readdirSync(stubDir).filter(f => f.endsWith('.adoc')) : []
   )
   for (const partial of partials) {
-    if (remainingStubs.has(partial.file)) continue
+    if (remainingStubs.has(partial.file)) {
+      // Existing stub: upgrade it in place when the partial has gained the
+      // meta tag region and the stub does not yet include it. The header
+      // include is what lets the stub inherit :description: as page
+      // metadata, so upgrading here makes the consumer repo self-heal on
+      // the next sync instead of needing a hand-written migration PR.
+      if (partial.hasMetaTag && !dryRun) {
+        const stubPath = path.join(stubDir, partial.file)
+        const stubContent = fs.readFileSync(stubPath, 'utf8')
+        if (!stubContent.includes('[tag=meta]')) {
+          const metaInclude = `include::${includePrefix}${partial.file}[tag=meta]`
+          const upgraded = stubContent.replace(/^(= .+)$/m, `$1\n${metaInclude}`)
+          if (upgraded !== stubContent) {
+            fs.writeFileSync(stubPath, upgraded, 'utf8')
+            upgraded_.push(partial.file)
+          }
+        }
+      }
+      continue
+    }
     if (aliasClaims.has(partial.file)) {
       skippedAliasTargets.push({ file: partial.file, claimedBy: aliasClaims.get(partial.file) })
       continue
@@ -304,7 +324,7 @@ function reconcileStubs({
     }
   }
 
-  return { created, deleted, keptNonStub, navUpdated, renameCandidates, skippedAliasTargets }
+  return { created, upgraded: upgraded_, deleted, keptNonStub, navUpdated, renameCandidates, skippedAliasTargets }
 }
 
 module.exports = {

--- a/tools/rpk-docs/generate-plugin-stubs.js
+++ b/tools/rpk-docs/generate-plugin-stubs.js
@@ -23,7 +23,7 @@ const { spawnSync } = require('child_process')
  * authoritative: dashified filenames cannot be reversed unambiguously
  * (rpk-ai-llm-provider could be `llm provider` or `llm-provider`).
  * @param {string} partialsDir - Directory of generated .adoc partials
- * @returns {Array<{file: string, title: string, description: string|undefined}>} Sorted by command path
+ * @returns {Array<{file: string, title: string, description: string|undefined, hasMetaTag: boolean}>} Sorted by command path
  */
 function readPartialTitles(partialsDir) {
   const partials = []
@@ -35,11 +35,18 @@ function readPartialTitles(partialsDir) {
       console.warn(`Warning: no title line in ${file}; skipping`)
       continue
     }
-    // The partial repeats :description: inside its single-source tag, but
-    // Antora resolves page metadata with a header-only parse that never sees
-    // the include — the stub must carry the description in its own header.
+    // Antora resolves page metadata with a header-only parse that never
+    // sees the body include, so the stub must carry the description in its
+    // own header. Partials generated with doc-tools >= 5.4 carry a nested
+    // meta tag region around :description: that stubs include dynamically;
+    // older partials fall back to a literal copy of the header description.
     const description = (content.match(/^:description:[ \t]*(.+)$/m) || [])[1]
-    partials.push({ file, title: match[1].trim(), description: description && description.trim() })
+    partials.push({
+      file,
+      title: match[1].trim(),
+      description: description && description.trim(),
+      hasMetaTag: content.includes('tag::meta['),
+    })
   }
   // Hierarchical order: sort by command words so parents precede children
   partials.sort((a, b) => {
@@ -121,11 +128,23 @@ function inferIncludePrefix(stubDir, plugin) {
  * @param {string} [params.description] - Meta description from the partial header
  * @param {string} params.includePrefix - Antora resource prefix
  * @param {Array<string>} params.attributes - Page attribute lines
+ * @param {boolean} [params.hasMetaTag] - Partial carries a tag::meta[] region (doc-tools >= 5.4)
  * @returns {string}
  */
-function renderStub({ title, file, description, includePrefix, attributes }) {
+function renderStub({ title, file, description, includePrefix, attributes, hasMetaTag }) {
   const lines = [`= ${title}`]
-  if (description) lines.push(`:description: ${description}`)
+  // The description mechanism is always the first header line after the
+  // title: a header include for partials with a meta tag region, or a
+  // literal copy as the fallback for partials generated before 5.4. Antora
+  // resolves page metadata with a header-only parse that stops at the first
+  // blank line, so either form must sit above it — an include below the
+  // blank line is never evaluated for attributes and the page ships the
+  // generic site description.
+  if (hasMetaTag) {
+    lines.push(`include::${includePrefix}${file}[tag=meta]`)
+  } else if (description) {
+    lines.push(`:description: ${description}`)
+  }
   for (const attr of attributes) lines.push(attr)
   lines.push('')
   lines.push(`include::${includePrefix}${file}[tag=single-source]`)

--- a/tools/rpk-docs/templates/command.hbs
+++ b/tools/rpk-docs/templates/command.hbs
@@ -6,7 +6,12 @@
      page at worst. Availability pages are excluded from cloud by not
      generating a stub for them in cloud-docs. --}}
 = {{commandPath}}
+{{!-- Comment lines are legal inside an AsciiDoc header, so the meta tag
+     region can wrap the page's single description. Stub pages inherit it
+     with a header include (see the note at the single-source tag). --}}
+// tag::meta[]
 :description: {{{wrapDescriptionPassthrough shortDesc}}}
+// end::meta[]
 {{#if pageAliases}}
 :page-aliases: {{{pageAliases}}}
 {{/if}}
@@ -23,26 +28,24 @@
 {{/each}}
 
 // tag::single-source[]
-// tag::meta[]
-:description: {{{wrapDescriptionPassthrough shortDesc}}}
-// end::meta[]
-{{!-- The nested meta tag region lets stub pages inherit the description as
-     a real HEADER attribute. A stub that only includes tag=single-source
-     after a blank line never gets it: Antora resolves page metadata with a
-     header-only parse that stops at the stub's first blank line, so the
-     include is never evaluated for attributes and the page ships the
-     generic site description (verified empirically, 2026-08-05). The
-     working stub shape is two includes:
+{{!-- Stub pages inherit this page's description by including the header's
+     meta tag region as a HEADER attribute. A stub that only includes
+     tag=single-source after a blank line never gets it: Antora resolves
+     page metadata with a header-only parse that stops at the stub's first
+     blank line, so the include is never evaluated for attributes and the
+     page ships the generic site description (verified empirically,
+     2026-08-05, including that a headerless include destroys the body).
+     The working stub shape is two includes:
 
        = Page title
        include::...page.adoc[tag=meta]        <- header: no blank line above
                                               <- blank line ends the header
        include::...page.adoc[tag=single-source]
 
-     Tag directive lines are stripped from tag-filtered includes, so
-     consumers of tag=single-source are unaffected by the nested region.
-     page-aliases and page-platforms deliberately stay outside the tag:
-     consumers must not inherit alias registrations. --}}
+     Earlier revisions repeated :description: inside this region on the
+     wrong belief that it reached stub metadata by itself; it never did.
+     page-aliases and page-platforms deliberately stay outside both tag
+     regions: consumers must not inherit alias registrations. --}}
 {{!-- Deprecation notice --}}
 {{#if deprecated}}
 [CAUTION]

--- a/tools/rpk-docs/templates/command.hbs
+++ b/tools/rpk-docs/templates/command.hbs
@@ -23,11 +23,26 @@
 {{/each}}
 
 // tag::single-source[]
+// tag::meta[]
 :description: {{{wrapDescriptionPassthrough shortDesc}}}
-{{!-- The description attribute is repeated inside the tagged region so
-     single-sourcing consumers (stub pages that include this tag) inherit
-     the meta description. page-aliases and page-platforms deliberately stay
-     outside the tag: consumers must not inherit alias registrations. --}}
+// end::meta[]
+{{!-- The nested meta tag region lets stub pages inherit the description as
+     a real HEADER attribute. A stub that only includes tag=single-source
+     after a blank line never gets it: Antora resolves page metadata with a
+     header-only parse that stops at the stub's first blank line, so the
+     include is never evaluated for attributes and the page ships the
+     generic site description (verified empirically, 2026-08-05). The
+     working stub shape is two includes:
+
+       = Page title
+       include::...page.adoc[tag=meta]        <- header: no blank line above
+                                              <- blank line ends the header
+       include::...page.adoc[tag=single-source]
+
+     Tag directive lines are stripped from tag-filtered includes, so
+     consumers of tag=single-source are unaffected by the nested region.
+     page-aliases and page-platforms deliberately stay outside the tag:
+     consumers must not inherit alias registrations. --}}
 {{!-- Deprecation notice --}}
 {{#if deprecated}}
 [CAUTION]


### PR DESCRIPTION
## What

Companion to @micheleRP's description-coverage batch (adp-docs#189, cloud-docs#664, #245): makes stub descriptions **dynamic** so they can never drift when regeneration rewrites them.

## The experiment behind it

Reproduced the root cause in a minimal Antora site built with the production docs-ui bundle:

| Stub shape | Meta description | Page body |
|---|---|---|
| Title, blank line, `include [tag=single-source]` (today) | ❌ generic site text | ✅ |
| Title, include on the next line (no blank) | ✅ inherited | ❌ **destroyed** — first content line parses as an author line |
| Title, `include [tag=meta]`, blank line, `include [tag=single-source]` | ✅ inherited | ✅ |

The header-only metadata parse stops at the first blank line, so the description must arrive as a header attribute — but a bare header include swallows the body. The two-include shape gives both.

## Changes

1. **command.hbs** nests a `tag::meta[]` region around the in-tag `:description:`. Tag directive lines are stripped from tag-filtered includes, so every existing `tag=single-source` consumer renders byte-identically. The old template comment claiming the in-tag copy alone reached stub metadata was wrong (it's where my earlier explanation came from too) — corrected with the verified behavior.
2. **generate-plugin-stubs.js** emits the header include for partials that carry the region, and keeps the plain shape for older partials so builds never warn about a missing tag. Graceful adoption: stubs upgrade as partials regenerate.
3. Tests for the template region, both stub shapes, and the no-warn guard.

## How this composes with the static-backfill batch

- #189/#664 land as-is. ~~Where both a literal and the meta include exist, the include wins.~~ **Corrected (micheleRP's precedence finding, re-verified): the LATER entry wins**, so a literal below the include defeats it. The in-place upgrader therefore strips the backfilled literal from generated reference stubs when it inserts the include — inherently scoped, since the reconciler never touches hand-maintained prose stubs. The cloud-docs conversion (DOC-2414) must do the same, with the same scoping.
- #245's generator change and this one touch the same file — happy to rebase whichever lands second. At rebase, the two compose as `hasMetaTag ? dynamic include : literal copy` (micheleRP's suggestion), so stubs created against pre-5.4 partials keep getting #245's literal description instead of regressing to none.
- The freshness gap this closes: cloud-docs' 145 rpk backfills have no sync mechanism, and rpk descriptions change on regen (the summary fixes in 5.3.3 rewrote ~36 of them).
- No help for the 234 allowlisted Connect stubs — those have no upstream description to inherit; that remains the editorial effort.

No version bump — rides whichever release goes out next (sequencing note on #245 applies).

## Producer coverage (complete)

Every template in this repo that emits a single-source region now carries the meta tag: rpk command pages (`command.hbs`), Connect connector pages (`connector.hbs`), and both Bloblang overview pages. `connector.hbs` also stops emitting the TODO placeholder as the description *value* when a connector has none — a stub would inherit that into its meta tag.

## Consumer-side plan (tracked in [DOC-2414](https://redpandadata.atlassian.net/browse/DOC-2414))

- **adp-docs: nothing to do.** `reconcileStubs` now upgrades existing stubs in place when the partial has gained the region (idempotent, reported as `upgraded`), so the sync workflow self-heals.
- **cloud-docs: one-time scripted conversion PR** after this releases and upstream pages regenerate — no sync workflow exists there. Sequencing and verification steps are in the ticket.

## Validation

958 tests pass (4 new). The Antora experiment is reproducible: three-page site, production UI bundle, results as tabled above.


[DOC-2414]: https://redpandadata.atlassian.net/browse/DOC-2414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Jira

Part of [DOC-2414](https://redpandadata.atlassian.net/browse/DOC-2414) (enabler: the ticket itself is resolved by the cloud-docs conversion this unlocks).

