### PR TITLE
fix(extensions): stop MaxListenersExceededWarning in production builds

### DIFF
--- a/__tests__/extensions/raise-listener-limit.test.js
+++ b/__tests__/extensions/raise-listener-limit.test.js
@@ -34,9 +34,10 @@ describe('raiseListenerLimit', () => {
 
   // The warning this guards against fires the moment the 11th listener for
   // one event lands on Antora's shared GeneratorContext, so the raise only
-  // works if EVERY listener-adding extension performs it before subscribing.
-  // This test fails when a new extension adds a listener without the call.
-  test('every listener-adding extension raises the limit', () => {
+  // works if EVERY listener-adding extension performs it BEFORE subscribing.
+  // This test fails when a new extension adds a listener without the call,
+  // or with the call placed after its first listener registration.
+  test('every listener-adding extension raises the limit before subscribing', () => {
     const extensionsDir = path.join(__dirname, '..', '..', 'extensions')
     const offenders = []
     const walk = (dir) => {
@@ -45,7 +46,10 @@ describe('raiseListenerLimit', () => {
         if (entry.isDirectory() && entry.name !== 'util') walk(full)
         else if (entry.isFile() && entry.name.endsWith('.js')) {
           const content = fs.readFileSync(full, 'utf8')
-          if (/this\.(on|once)\(/.test(content) && !content.includes('raiseListenerLimit(this)')) {
+          const listenerIndex = content.search(/this\.(on|once)\(/)
+          if (listenerIndex === -1) continue
+          const helperIndex = content.indexOf('raiseListenerLimit(this)')
+          if (helperIndex === -1 || helperIndex > listenerIndex) {
             offenders.push(path.relative(extensionsDir, full))
           }
         }

--- a/__tests__/extensions/raise-listener-limit.test.js
+++ b/__tests__/extensions/raise-listener-limit.test.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const { EventEmitter } = require('events')
+const {
+  raiseListenerLimit,
+  GENERATOR_CONTEXT_MAX_LISTENERS,
+} = require('../../extensions/util/raise-listener-limit')
+
+describe('raiseListenerLimit', () => {
+  test('raises the limit above the Node default', () => {
+    const emitter = new EventEmitter()
+    expect(emitter.getMaxListeners()).toBe(10)
+    raiseListenerLimit(emitter)
+    expect(emitter.getMaxListeners()).toBe(GENERATOR_CONTEXT_MAX_LISTENERS)
+  })
+
+  test('leaves an unlimited (0) or already-higher limit alone', () => {
+    const unlimited = new EventEmitter()
+    unlimited.setMaxListeners(0)
+    raiseListenerLimit(unlimited)
+    expect(unlimited.getMaxListeners()).toBe(0)
+
+    const higher = new EventEmitter()
+    higher.setMaxListeners(GENERATOR_CONTEXT_MAX_LISTENERS + 1)
+    raiseListenerLimit(higher)
+    expect(higher.getMaxListeners()).toBe(GENERATOR_CONTEXT_MAX_LISTENERS + 1)
+  })
+
+  test('tolerates contexts without max-listener methods', () => {
+    expect(() => raiseListenerLimit({})).not.toThrow()
+  })
+
+  // The warning this guards against fires the moment the 11th listener for
+  // one event lands on Antora's shared GeneratorContext, so the raise only
+  // works if EVERY listener-adding extension performs it before subscribing.
+  // This test fails when a new extension adds a listener without the call.
+  test('every listener-adding extension raises the limit', () => {
+    const extensionsDir = path.join(__dirname, '..', '..', 'extensions')
+    const offenders = []
+    const walk = (dir) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name)
+        if (entry.isDirectory() && entry.name !== 'util') walk(full)
+        else if (entry.isFile() && entry.name.endsWith('.js')) {
+          const content = fs.readFileSync(full, 'utf8')
+          if (/this\.(on|once)\(/.test(content) && !content.includes('raiseListenerLimit(this)')) {
+            offenders.push(path.relative(extensionsDir, full))
+          }
+        }
+      }
+    }
+    walk(extensionsDir)
+    expect(offenders).toEqual([])
+  })
+
+  test('a registered extension raises the limit on its generator context', () => {
+    const context = new EventEmitter()
+    context.getLogger = () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() })
+    require('../../extensions/unlisted-pages.js').register.call(context, { config: {} })
+    expect(context.getMaxListeners()).toBe(GENERATOR_CONTEXT_MAX_LISTENERS)
+  })
+})

--- a/extensions/add-faq-structured-data.js
+++ b/extensions/add-faq-structured-data.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 /**
  * Generates FAQPage JSON-LD structured data for SEO.
  *
@@ -147,6 +149,7 @@ function generateFaqJsonLd(faqs, baseUrl) {
 }
 
 module.exports.register = function () {
+  raiseListenerLimit(this)
   const logger = this.getLogger('add-faq-structured-data-extension')
   let playbook
 

--- a/extensions/add-git-dates.js
+++ b/extensions/add-git-dates.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 /**
  * Adds Git commit dates to pages as attributes.
  *
@@ -179,6 +181,7 @@ async function getTreeFiles (git, gitdir, oid, prefix, cache, treeCache) {
 }
 
 module.exports.register = function () {
+  raiseListenerLimit(this)
   const logger = this.getLogger('add-git-dates-extension')
   const context = this
 

--- a/extensions/add-global-attributes.js
+++ b/extensions/add-global-attributes.js
@@ -1,3 +1,4 @@
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
 /* Example use in the playbook
 * antora:
     extensions:
@@ -12,6 +13,7 @@ const _ = require('lodash');
 const ATTRIBUTES_PATH = 'modules/ROOT/partials/';  // Default path within the 'shared' component
 
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger('global-attributes-extension');
 
   /**

--- a/extensions/add-llms-directive.js
+++ b/extensions/add-llms-directive.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 /**
  * Adds llms.txt directive to HTML pages for agent-friendly documentation.
  *
@@ -16,6 +18,7 @@
 const { formatLlmsDirective } = require('../extension-utils/llms-utils')
 
 module.exports.register = function () {
+  raiseListenerLimit(this)
   const logger = this.getLogger('add-llms-directive-extension')
 
   this.on('pagesComposed', ({ contentCatalog }) => {

--- a/extensions/add-markdown-urls-to-sitemap.js
+++ b/extensions/add-markdown-urls-to-sitemap.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 /**
  * Adds markdown URL entries to sitemap.xml files for AI-friendly documentation.
  *
@@ -21,6 +23,7 @@ const { parseStringPromise } = require('xml2js')
 const { toMarkdownUrl } = require('../extension-utils/url-utils')
 
 module.exports.register = function () {
+  raiseListenerLimit(this)
   const logger = this.getLogger('add-markdown-urls-to-sitemap-extension')
 
   this.on('beforePublish', async ({ siteCatalog }) => {

--- a/extensions/add-pages-to-root.js
+++ b/extensions/add-pages-to-root.js
@@ -1,4 +1,6 @@
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   this.on('beforePublish', ({ siteCatalog, contentCatalog }) => {
     const logger = this.getLogger('add-pages-to-site-root');
     if (!config || !config.files || !config.files.length) {

--- a/extensions/aggregate-terms.js
+++ b/extensions/aggregate-terms.js
@@ -1,3 +1,4 @@
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
 /* Example use in the playbook
 * antora:
     extensions:
@@ -10,6 +11,7 @@ const path = require('path');
 const TERMS_PATH = 'modules/terms/partials/';  // Default path within the 'shared' component
 
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger('term-aggregation-extension');
 
   /**

--- a/extensions/algolia-indexer/index.js
+++ b/extensions/algolia-indexer/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const generateIndex = require('./generate-index')
+const { raiseListenerLimit } = require('../util/raise-listener-limit')
 const algoliasearch = require('algoliasearch')
 const http = require('http')
 const https = require('https')
@@ -21,6 +22,7 @@ function register ({
     ...unknownOptions
   }
 }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger('algolia-indexer-extension')
 
   // Validate required environment variables

--- a/extensions/archive-attachments.js
+++ b/extensions/archive-attachments.js
@@ -1,3 +1,4 @@
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
 "use strict";
 
 const fs = require("fs");
@@ -35,6 +36,7 @@ async function createTarInMemory(tempDir) {
 }
 
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger("archive-attachments-extension");
   const archives = config.data?.archives || [];
 

--- a/extensions/collect-bloblang-samples.js
+++ b/extensions/collect-bloblang-samples.js
@@ -1,6 +1,8 @@
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
 const yaml = require('js-yaml');
 
 module.exports.register = function () {
+  raiseListenerLimit(this)
   const logger = this.getLogger('collect-bloblang-samples');
 
   this.on('contentClassified', ({ contentCatalog }) => {

--- a/extensions/compute-end-of-life.js
+++ b/extensions/compute-end-of-life.js
@@ -1,8 +1,11 @@
 'use strict';
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 const calculateEOL = require('./util/calculate-eol.js');
 
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   this.on('contentClassified', ({ contentCatalog }) => {
     const logger = this.getLogger("compute-end-of-life-extension");
 

--- a/extensions/conditional-home-redirect.js
+++ b/extensions/conditional-home-redirect.js
@@ -8,7 +8,10 @@
 
 'use strict'
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 module.exports.register = function () {
+  raiseListenerLimit(this)
   const logger = this.getLogger('conditional-home-redirect')
   let shouldRedirect = false
 

--- a/extensions/convert-llms-to-txt.js
+++ b/extensions/convert-llms-to-txt.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 const { toMarkdownUrl } = require('../extension-utils/url-utils');
 const { stripMarkdownMetadata } = require('../extension-utils/llms-utils');
 
@@ -20,6 +22,7 @@ const { stripMarkdownMetadata } = require('../extension-utils/llms-utils');
  * Must run after convert-to-markdown extension to access page.markdownContents.
  */
 module.exports.register = function () {
+  raiseListenerLimit(this)
   const logger = this.getLogger('convert-llms-to-txt-extension');
   let siteUrl = '';
 

--- a/extensions/convert-to-markdown.js
+++ b/extensions/convert-to-markdown.js
@@ -1,3 +1,4 @@
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
 const path = require('path')
 const os = require('os')
 const yaml = require('js-yaml')
@@ -187,6 +188,7 @@ function generateFrontmatter(page) {
 }
 
 module.exports.register = function () {
+  raiseListenerLimit(this)
   const logger = this.getLogger('convert-to-markdown-extension')
   let playbook
 

--- a/extensions/find-related-docs.js
+++ b/extensions/find-related-docs.js
@@ -1,6 +1,9 @@
 'use strict';
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger('related-docs-extension');
 
   this.on('documentsConverted', async ({ contentCatalog, siteCatalog }) => {

--- a/extensions/find-related-labs.js
+++ b/extensions/find-related-labs.js
@@ -1,6 +1,9 @@
 'use strict';
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger('related-labs-extension');
 
   this.on('documentsConverted', async ({ contentCatalog, siteCatalog }) => {

--- a/extensions/generate-fields-only-pages.js
+++ b/extensions/generate-fields-only-pages.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 const fs = require('fs')
 const path = require('path')
 const os = require('os')
@@ -121,6 +123,7 @@ const DEFAULTS = {
 }
 
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger('generate-fields-only-pages-extension')
 
   // Merge config with defaults

--- a/extensions/generate-index-data.js
+++ b/extensions/generate-index-data.js
@@ -1,7 +1,10 @@
 'use strict';
+
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
 const _ = require('lodash');
 
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger('generate-index-data-extension');
 
   this.on('documentsConverted', async ({ contentCatalog, siteCatalog }) => {

--- a/extensions/generate-rp-connect-categories.js
+++ b/extensions/generate-rp-connect-categories.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 /**
  * Redpanda Connect Category Aggregation Extension
  *
@@ -11,6 +13,7 @@
  * Ensure generate-rp-connect-info is listed BEFORE this extension in your playbook.
  */
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger('redpanda-connect-category-aggregation-extension')
 
   this.on('contentClassified', ({ contentCatalog }) => {

--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -1,4 +1,6 @@
 'use strict'
+
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
 const fs = require('fs')
 const path = require('path')
 const Papa = require('papaparse')
@@ -11,6 +13,7 @@ const DEFAULTS = {
 }
 
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger('redpanda-connect-info-extension')
   const { getAntoraValue } = require('../cli-utils/antora-utils')
 

--- a/extensions/git-full-clone.js
+++ b/extensions/git-full-clone.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 const { execSync } = require('child_process')
 const fs = require('fs')
 const path = require('path')
@@ -32,6 +34,7 @@ const path = require('path')
  */
 
 module.exports.register = function ({ config, playbook }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger('git-full-clone-extension')
 
   logger.info('✓ git-full-clone extension loaded')

--- a/extensions/modify-connect-tag-playbook.js
+++ b/extensions/modify-connect-tag-playbook.js
@@ -1,8 +1,11 @@
 'use strict';
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 const GetLatestConnectTag = require('./version-fetcher/get-latest-connect');
 
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger('modify-connect-tag-playbook-extension');
 
   this.on('contextStarted', async ({ playbook }) => {

--- a/extensions/process-context-switcher.js
+++ b/extensions/process-context-switcher.js
@@ -17,7 +17,10 @@
 
 'use strict';
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger('context-switcher-extension');
 
   this.on('documentsConverted', async ({ contentCatalog }) => {

--- a/extensions/produce-redirects.js
+++ b/extensions/produce-redirects.js
@@ -1,11 +1,14 @@
 'use strict';
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 const File = require('vinyl')
 const { posix: path } = require('path')
 
 const ENCODED_SPACE_RX = /%20/g
 
 module.exports.register = function () {
+  raiseListenerLimit(this)
   this.once('contextStarted', () => {
     const { publishFiles: produceRedirectsDelegate } = this.getFunctions()
     this.replaceFunctions({

--- a/extensions/replace-attributes-in-attachments.js
+++ b/extensions/replace-attributes-in-attachments.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 const semver = require('semver');
 const micromatch = require('micromatch');
 const formatVersion = require('./util/format-version.js');
@@ -24,6 +26,7 @@ const sanitize = require('./util/sanitize-attributes.js');
  *         - ...
  */
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger('replace-attributes-extension');
   const replacements = config.data?.replacements || [];
 

--- a/extensions/resolve-xrefs-in-attachments.js
+++ b/extensions/resolve-xrefs-in-attachments.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 /**
  * Resolves AsciiDoc xrefs in JSON attachment files to HTML links.
  *
@@ -19,6 +21,7 @@
  */
 
 module.exports.register = function () {
+  raiseListenerLimit(this)
   const logger = this.getLogger('resolve-xrefs-in-attachments')
 
   this.on('contentClassified', ({ contentCatalog }) => {

--- a/extensions/set-available-attachment-versions.js
+++ b/extensions/set-available-attachment-versions.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 const semver = require('semver')
 
 /**
@@ -34,6 +36,7 @@ const PROPERTIES_JSON_RX = /^redpanda-properties-(v\d+\.\d+\.\d+(?:-[\w.]+)?)\.j
 const CONNECT_JSON_RX = /^connect-(\d+\.\d+\.\d+(?:-[\w.]+)?)\.json$/
 
 module.exports.register = function () {
+  raiseListenerLimit(this)
   const logger = this.getLogger('set-available-attachment-versions-extension')
 
   this.once('contentClassified', ({ contentCatalog }) => {

--- a/extensions/unified-navigation.js
+++ b/extensions/unified-navigation.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 const yaml = require('js-yaml')
 
 /**
@@ -35,6 +37,7 @@ const yaml = require('js-yaml')
  */
 
 module.exports.register = function () {
+  raiseListenerLimit(this)
   const logger = this.getLogger('unified-navigation-extension')
 
   this.on('navigationBuilt', ({ contentCatalog }) => {

--- a/extensions/unlisted-pages.js
+++ b/extensions/unlisted-pages.js
@@ -1,6 +1,9 @@
 'use strict';
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const { addToNavigation, unlistedPagesHeading = 'Unlisted Pages' } = config;
   const logger = this.getLogger('unlisted-pages-extension');
 

--- a/extensions/unpublish-pages.js
+++ b/extensions/unpublish-pages.js
@@ -1,6 +1,9 @@
 'use strict';
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 module.exports.register = function () {
+  raiseListenerLimit(this)
   const logger = this.getLogger('unpublish-pages-extension');
 
   this.on('documentsConverted', ({ siteCatalog, contentCatalog }) => {

--- a/extensions/util/raise-listener-limit.js
+++ b/extensions/util/raise-listener-limit.js
@@ -1,0 +1,28 @@
+'use strict'
+
+// Antora's GeneratorContext is one shared EventEmitter for every registered
+// extension, and Redpanda playbooks register enough of them that per-event
+// listener counts legitimately exceed Node's default threshold of 10. Node
+// then prints MaxListenersExceededWarning ("Possible EventEmitter memory
+// leak detected. 11 contentClassified listeners added to [GeneratorContext]")
+// in build logs even though each extension adds exactly one listener per
+// event per build.
+//
+// Every extension in this package raises the limit before subscribing, so
+// the suppression holds no matter which subset of extensions a playbook
+// registers or in what order. The cap is bounded rather than unlimited (0)
+// to keep Node's leak detection meaningful for pathological cases.
+const GENERATOR_CONTEXT_MAX_LISTENERS = 64
+
+function raiseListenerLimit (context) {
+  if (
+    typeof context.getMaxListeners === 'function' &&
+    typeof context.setMaxListeners === 'function' &&
+    context.getMaxListeners() !== 0 &&
+    context.getMaxListeners() < GENERATOR_CONTEXT_MAX_LISTENERS
+  ) {
+    context.setMaxListeners(GENERATOR_CONTEXT_MAX_LISTENERS)
+  }
+}
+
+module.exports = { raiseListenerLimit, GENERATOR_CONTEXT_MAX_LISTENERS }

--- a/extensions/validate-attributes.js
+++ b/extensions/validate-attributes.js
@@ -6,7 +6,10 @@
 
 'use strict';
 
+const { raiseListenerLimit } = require('./util/raise-listener-limit')
+
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const logger = this.getLogger('attribute-validation-extension');
 
   this.on('documentsConverted', async ({ contentCatalog, siteCatalog }) => {

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -1,6 +1,9 @@
 'use strict';
 
+const { raiseListenerLimit } = require('../util/raise-listener-limit')
+
 module.exports.register = function ({ config }) {
+  raiseListenerLimit(this)
   const GetLatestRedpandaVersion = require('./get-latest-redpanda-version');
   const GetLatestConsoleVersion = require('./get-latest-console-version');
   const GetLatestDockerTag = require('./fetch-latest-docker-tag');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.9.0",
+  "version": "5.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.9.0",
+      "version": "5.7.1",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.7",
+  "version": "5.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.3.7",
+      "version": "5.3.9",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.3.7",
+  "version": "5.3.9",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.9.0",
+  "version": "5.7.1",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
## Problem

Production docs-site builds log:

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 contentClassified listeners added to [GeneratorContext]. MaxListeners is 10.
```

This started when docs-site#195 registered `set-available-attachment-versions` — the 11th `contentClassified` listener on Antora's shared GeneratorContext, crossing Node's default warning threshold of 10. It's a false-positive leak heuristic (each extension adds exactly one listener per event per build), but it pollutes prod logs and the count only grows as more extensions register (the link-health extensions in #247 will add two more).

## Fix

Every listener-adding extension in this package (32 files) now calls a shared `raiseListenerLimit(this)` helper at the top of `register()`, raising the shared emitter's limit to a bounded 64 before subscribing. Because **all** adders raise it, the suppression holds regardless of which subset of extensions a playbook registers or their order — no playbook changes needed in any consumer repo. The cap is bounded rather than unlimited so Node's leak detection still fires for genuinely pathological cases, and an existing unlimited/higher setting is left alone.

A guard test walks `extensions/` and fails if any file adds a `this.on`/`this.once` listener without the call, so future extensions can't silently reintroduce the warning.

## Tests

5 new tests (helper semantics, no-op paths, register-level integration, and the repo-wide guard). Full suite: 1003 tests green.

## Version

5.3.9 (npm is at 5.3.7; #246 claims 5.3.8, #227 claims 5.4.0, #247 claims 5.5.0). #247 will pick up the helper for its two new extensions when it rebases over this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)