### PR TITLE
Validate enterprise macro targets against the shared registry and generate feature tables

### DIFF
--- a/__tests__/macros/enterprise.test.js
+++ b/__tests__/macros/enterprise.test.js
@@ -295,6 +295,13 @@ describe('enterprise macro', () => {
       expect(html).toContain('Topic Deletion Control')
     })
 
+    test('re-emits a block anchor as the table id and resolves crossrefs to it', () => {
+      const html = convert('[[my-table]]\nenterprise_features::redpanda[]\n\nSee <<my-table,the table>>.', { catalog: fakeCatalog() })
+      expect(html).toContain('id="my-table"')
+      expect(html).toContain('href="#my-table"')
+      expect(html).not.toContain('[my-table]')
+    })
+
     test('rejects an unknown scope on the block macro', () => {
       expect(() => convert('enterprise_features::mainframe[]', { catalog: fakeCatalog() }))
         .toThrow(/needs a scope/)

--- a/__tests__/macros/enterprise.test.js
+++ b/__tests__/macros/enterprise.test.js
@@ -3,8 +3,77 @@
 const {
   register,
   buildEnterpriseContent,
+  buildFeatureTable,
+  parseRegistry,
   resolveTooltipAttribute,
 } = require('../../macros/enterprise')
+
+const REGISTRY_YAML = `
+schema-version: 1
+features:
+  - name: Tiered Storage
+    scope: redpanda
+    xref: manage:tiered-storage.adoc
+    description: |
+      Enables data storage in cloud object storage.
+    expiration: |
+      Topics cannot be created or modified to enable Tiered Storage features.
+    aliases: [cloud_storage]
+    source:
+      kind: core-enum
+      value: cloud_storage
+    gating-property: cloud_storage_enabled
+  - name: Topic Deletion Control
+    scope: redpanda
+    description: |
+      Prevents topic deletion through the Kafka DeleteTopics API.
+    expiration: |
+      Topic deletion reverts to enabled.
+    show-gating-property: true
+    source:
+      kind: core-enum
+      value: topic_deletion_disabled
+    gating-property: delete_topic_enable
+  - name: Enterprise connectors
+    scope: connect
+    url: https://docs.redpanda.com/redpanda-connect/components/catalog/?support=enterprise
+    description: |
+      Connectors available only to enterprise customers.
+    expiration: |
+      All enterprise connectors are blocked.
+    source:
+      kind: manual
+      value: Aggregate entry tracked in info.csv.
+  - name: Stretch Clusters
+    scope: operator
+    xref: deploy:redpanda/kubernetes/k-stretch-clusters.adoc
+    description: |
+      Multi-region clusters.
+    expiration: |
+      The multicluster operator requires a valid license to start.
+    feature-suffix: (StretchCluster resource)
+    source:
+      kind: manual
+      value: License gate in cmd/multicluster.
+`
+
+function fakeCatalog (yamlSource = REGISTRY_YAML) {
+  return {
+    findBy: jest.fn(() => [
+      { path: 'modules/ROOT/partials/enterprise-features.yml', contents: Buffer.from(yamlSource) },
+    ]),
+  }
+}
+
+function convert (input, { catalog, attributes = {}, filePath = 'modules/manage/pages/example.adoc' } = {}) {
+  const Asciidoctor = require('@asciidoctor/core')()
+  const extensionRegistry = Asciidoctor.Extensions.create()
+  register(extensionRegistry, catalog && {
+    contentCatalog: catalog,
+    file: { src: { path: filePath } },
+  })
+  return Asciidoctor.convert(input, { extension_registry: extensionRegistry, attributes })
+}
 
 describe('enterprise macro', () => {
   describe('buildEnterpriseContent', () => {
@@ -30,6 +99,15 @@ describe('enterprise macro', () => {
         xref: 'manage:tiered-storage.adoc',
       })
       expect(html).toContain('xref:manage:tiered-storage.adoc[Tiered Storage]')
+    })
+
+    test('links to an absolute URL when only a url is given', () => {
+      const html = buildEnterpriseContent({
+        ...defaults,
+        feature: 'Enterprise connectors',
+        url: 'https://docs.redpanda.com/redpanda-connect/components/catalog/?support=enterprise',
+      })
+      expect(html).toContain('link:https://docs.redpanda.com/redpanda-connect/components/catalog/?support=enterprise[Enterprise connectors]')
     })
 
     test('honors display text and tooltip overrides', () => {
@@ -83,23 +161,173 @@ describe('enterprise macro', () => {
     })
   })
 
+  describe('parseRegistry', () => {
+    test('indexes features by lowercased name and alias', () => {
+      const { lookup } = parseRegistry(REGISTRY_YAML)
+      expect(lookup.get('tiered storage').name).toBe('Tiered Storage')
+      expect(lookup.get('cloud_storage').name).toBe('Tiered Storage')
+    })
+
+    test('throws on duplicate names across entries', () => {
+      const dup = `${REGISTRY_YAML}\n  - name: tiered storage\n    scope: redpanda\n`
+      expect(() => parseRegistry(dup)).toThrow(/Duplicate enterprise feature name 'tiered storage'/)
+    })
+
+    test('throws on an alias that collides with another feature', () => {
+      const dup = `${REGISTRY_YAML}\n  - name: Object Storage Mode\n    scope: redpanda\n    aliases: [Tiered Storage]\n`
+      expect(() => parseRegistry(dup)).toThrow(/Duplicate enterprise feature alias/)
+    })
+
+    test('throws on unknown scope', () => {
+      expect(() => parseRegistry('features:\n  - name: X\n    scope: mainframe\n')).toThrow(/unknown scope 'mainframe'/)
+    })
+
+    test('throws when the features list is missing', () => {
+      expect(() => parseRegistry('schema-version: 1\n')).toThrow(/no 'features' list/)
+    })
+  })
+
+  describe('buildFeatureTable', () => {
+    const { features } = parseRegistry(REGISTRY_YAML)
+
+    test('renders scope rows alphabetically with the scope heading', () => {
+      const table = buildFeatureTable(features, 'redpanda')
+      expect(table).toContain('.Enterprise features in Redpanda')
+      expect(table).toContain('| Feature | Description | Behavior Upon Expiration')
+      expect(table.indexOf('Tiered Storage')).toBeLessThan(table.indexOf('Topic Deletion Control'))
+      expect(table).toContain('| xref:manage:tiered-storage.adoc[Tiered Storage]')
+    })
+
+    test('renders a plain name when the entry has no xref, plus its gating property', () => {
+      const table = buildFeatureTable(features, 'redpanda')
+      expect(table).toContain('| Topic Deletion Control\n(`delete_topic_enable`)')
+    })
+
+    test('renders url links and the non-redpanda third-column heading', () => {
+      const table = buildFeatureTable(features, 'connect')
+      expect(table).toContain('| Feature | Description | Restrictions Without Valid License')
+      expect(table).toContain('link:https://docs.redpanda.com/redpanda-connect/components/catalog/?support=enterprise[Enterprise connectors]')
+      expect(table).not.toContain('Tiered Storage')
+    })
+
+    test('appends the feature suffix after the feature link', () => {
+      const table = buildFeatureTable(features, 'operator')
+      expect(table).toContain('xref:deploy:redpanda/kubernetes/k-stretch-clusters.adoc[Stretch Clusters] (StretchCluster resource)')
+    })
+
+    test('honors title and heading overrides', () => {
+      const table = buildFeatureTable(features, 'connect', { title: 'My Title', heading: 'My Heading' })
+      expect(table).toContain('.My Title')
+      expect(table).toContain('| Feature | Description | My Heading')
+    })
+  })
+
+  describe('registry-backed conversion', () => {
+    test('canonicalizes an alias and links to the registry xref', () => {
+      const html = convert('enterprise:cloud_storage[]', { catalog: fakeCatalog() })
+      expect(html).toContain('Tiered Storage')
+      expect(html).toContain('tiered-storage')
+      expect(html).toContain('class="enterprise-feature"')
+    })
+
+    test('canonicalizes case-insensitive spellings of the name', () => {
+      const html = convert('enterprise:tiered storage[]', { catalog: fakeCatalog() })
+      expect(html).toContain('Tiered Storage requires an Enterprise Edition license.')
+    })
+
+    test('per-use xref overrides the registry xref', () => {
+      const html = convert('enterprise:Tiered Storage[xref=other:page.adoc]', { catalog: fakeCatalog() })
+      expect(html).toContain('other')
+      expect(html).not.toContain('manage:tiered-storage.adoc')
+    })
+
+    test('warns on unknown feature names by default', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const html = convert('enterprise:Warp Drive[]', { catalog: fakeCatalog() })
+      expect(html).toContain('Warp Drive')
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('does not match any feature'))
+      warn.mockRestore()
+    })
+
+    test('fails the conversion in error mode', () => {
+      expect(() => convert('enterprise:Warp Drive[]', {
+        catalog: fakeCatalog(),
+        attributes: { 'enterprise-validate': 'error' },
+      })).toThrow(/does not match any feature/)
+    })
+
+    test('stays silent in off mode', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      convert('enterprise:Warp Drive[]', {
+        catalog: fakeCatalog(),
+        attributes: { 'enterprise-validate': 'off' },
+      })
+      const validationWarnings = warn.mock.calls.filter(([msg]) => String(msg).includes('does not match'))
+      expect(validationWarnings).toHaveLength(0)
+      warn.mockRestore()
+    })
+
+    test('suggests close names in the warning', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      convert('enterprise:Tiered Storage Cache[]', { catalog: fakeCatalog() })
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Did you mean: Tiered Storage'))
+      warn.mockRestore()
+    })
+
+    test('caches the registry on the content catalog across conversions', () => {
+      const catalog = fakeCatalog()
+      convert('enterprise:Tiered Storage[]', { catalog })
+      convert('enterprise:Tiered Storage[]', { catalog })
+      expect(catalog.findBy).toHaveBeenCalledTimes(1)
+    })
+
+    test('renders unvalidated without a catalog (graceful degradation)', () => {
+      const html = convert('enterprise:Anything Goes[]', {})
+      expect(html).toContain('Anything Goes')
+      expect(html).toContain('class="enterprise-feature"')
+    })
+
+    test('renders the feature table through the block macro', () => {
+      const html = convert('enterprise_features::redpanda[]', { catalog: fakeCatalog() })
+      expect(html).toContain('Enterprise features in Redpanda')
+      expect(html).toContain('Behavior Upon Expiration')
+      expect(html).toContain('Tiered Storage')
+      expect(html).toContain('Topic Deletion Control')
+    })
+
+    test('rejects an unknown scope on the block macro', () => {
+      expect(() => convert('enterprise_features::mainframe[]', { catalog: fakeCatalog() }))
+        .toThrow(/needs a scope/)
+    })
+
+    test('renders a warning admonition when the registry is missing', () => {
+      const emptyCatalog = { findBy: jest.fn(() => []) }
+      const html = convert('enterprise_features::redpanda[]', { catalog: emptyCatalog })
+      expect(html).toContain('cannot be rendered')
+    })
+  })
+
   describe('registration', () => {
-    test('registers an inline macro on a plain registry', () => {
+    test('registers inline and block macros on a plain registry', () => {
       const inlineMacro = jest.fn()
-      register({ inlineMacro })
+      const blockMacro = jest.fn()
+      register({ inlineMacro, blockMacro })
       expect(inlineMacro).toHaveBeenCalledTimes(1)
+      expect(blockMacro).toHaveBeenCalledTimes(1)
       expect(typeof inlineMacro.mock.calls[0][0]).toBe('function')
     })
 
     test('uses the group form when the registry supports register()', () => {
       const inlineMacro = jest.fn()
+      const blockMacro = jest.fn()
       const registry = {
         register (group) {
-          group.call({ inlineMacro })
+          group.call({ inlineMacro, blockMacro })
         },
       }
       register(registry)
       expect(inlineMacro).toHaveBeenCalledTimes(1)
+      expect(blockMacro).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/__tests__/macros/enterprise.test.js
+++ b/__tests__/macros/enterprise.test.js
@@ -14,6 +14,8 @@ features:
   - name: Tiered Storage
     scope: redpanda
     xref: manage:tiered-storage.adoc
+    xref-kubernetes: manage:kubernetes/tiered-storage/k-tiered-storage.adoc
+    xref-cloud: cloud-data-platform:manage:tiered-storage.adoc
     description: |
       Enables data storage in cloud object storage.
     expiration: |
@@ -293,6 +295,29 @@ describe('enterprise macro', () => {
       expect(html).toContain('Behavior Upon Expiration')
       expect(html).toContain('Tiered Storage')
       expect(html).toContain('Topic Deletion Control')
+    })
+
+    test('uses the Kubernetes feature page when env-kubernetes is set', () => {
+      const html = convert('enterprise:Tiered Storage[]', {
+        catalog: fakeCatalog(),
+        attributes: { 'env-kubernetes': '' },
+      })
+      expect(html).toContain('k-tiered-storage')
+    })
+
+    test('uses the Cloud feature page when env-cloud is set', () => {
+      const html = convert('enterprise:Tiered Storage[]', {
+        catalog: fakeCatalog(),
+        attributes: { 'env-cloud': '' },
+      })
+      expect(html).toContain('cloud-data-platform')
+    })
+
+    test('falls back to the default xref without env attributes', () => {
+      const html = convert('enterprise:Tiered Storage[]', { catalog: fakeCatalog() })
+      expect(html).not.toContain('k-tiered-storage')
+      expect(html).not.toContain('cloud-data-platform')
+      expect(html).toContain('tiered-storage')
     })
 
     test('re-emits a block anchor as the table id and resolves crossrefs to it', () => {

--- a/macros/REFERENCE.adoc
+++ b/macros/REFERENCE.adoc
@@ -66,6 +66,8 @@ asciidoc:
 
 This inline macro marks a feature as an enterprise feature in prose. The feature name renders as a uniquely styled term with a tooltip explaining that the feature requires an Enterprise Edition license, and links to the feature's documentation or to the licensing page.
 
+The macro validates its target against the enterprise features registry: `modules/ROOT/partials/enterprise-features.yml` in the `shared` component (the `shared/` folder of the docs repository). The registry is the canonical list of enterprise features and their approved external names. Targets are matched case-insensitively, including aliases, and the canonical name, feature page link, and tooltip come from the matching entry. A target that matches no entry is reported according to `enterprise-validate`. To mark a new feature as enterprise, add it to the registry first.
+
 === Usage
 
 [,asciidoc]
@@ -79,15 +81,18 @@ enterprise:Iceberg Topics[tooltip=Iceberg Topics requires an Enterprise Edition 
 The macro target is the feature name, which can contain spaces. Named attributes:
 
 xref::
-Optional Antora resource ID of the feature's documentation page. When set, the term links there. When omitted, the term links to the licensing page.
+Optional Antora resource ID of the feature's documentation page. Overrides the registry entry's `xref`. When neither is set, the term links to the licensing page.
 
 text::
 Optional display text override. Use it when the sentence needs different casing or phrasing than the feature name.
 
 tooltip::
-Optional tooltip text override. The default is `<feature> requires an Enterprise Edition license.`
+Optional tooltip text override. Overrides the registry entry's `tooltip`. The default is `<feature> requires an Enterprise Edition license.`
 
 === Configuration options
+
+enterprise-validate::
+How to report a target that does not match any registry entry: `warn` (default) logs a build warning with the file path and close-match suggestions, `error` fails the build, and `off` disables validation. When no registry is available in the build, the macro renders without validation and logs a single warning.
 
 enterprise-licensing-page::
 Resource ID of the licensing page used when no `xref` attribute is given. The default is `get-started:licensing/overview.adoc`.
@@ -109,6 +114,31 @@ asciidoc:
   extensions:
     - '@redpanda-data/docs-extensions-and-macros/macros/enterprise'
 ----
+
+== enterprise_features
+
+This block macro renders the licensing feature table for one scope from the enterprise features registry (see <<enterprise>>). Because the table is generated, it can never drift from the registry.
+
+=== Usage
+
+[,asciidoc]
+----
+enterprise_features::redpanda[]
+enterprise_features::connect[]
+enterprise_features::operator[title=Operator features,heading=What stops working]
+----
+
+The target is the scope: `redpanda`, `console`, `connect`, `operator`, or `cloud`. Rows render alphabetically by feature name with three columns: the feature name (linked to its documentation page when the entry has an `xref` or `url`), the description, and the expiration or restriction behavior. Named attributes:
+
+title::
+Optional table title override. The default is scope-specific, for example `Enterprise features in Redpanda`.
+
+heading::
+Optional third-column heading override. The default is `Behavior Upon Expiration` for the `redpanda` scope and `Restrictions Without Valid License` for the other scopes.
+
+=== Registration
+
+Registered together with the `enterprise` inline macro (see <<enterprise>>).
 
 == glossterm
 

--- a/macros/REFERENCE.adoc
+++ b/macros/REFERENCE.adoc
@@ -81,7 +81,9 @@ enterprise:Iceberg Topics[tooltip=Iceberg Topics requires an Enterprise Edition 
 The macro target is the feature name, which can contain spaces. Named attributes:
 
 xref::
-Optional Antora resource ID of the feature's documentation page. Overrides the registry entry's `xref`. When neither is set, the term links to the licensing page.
+Optional Antora resource ID of the feature's documentation page. Overrides the registry entry's link. When neither is set, the term links to the licensing page.
++
+Registry entries can carry environment-specific pages: on pages with the `env-cloud` attribute the entry's `xref-cloud` is used, on pages with `env-kubernetes` the entry's `xref-kubernetes` is used, and otherwise the entry's default `xref` (the Linux or generic self-managed page). This mirrors the `config_ref` macro's environment awareness.
 
 text::
 Optional display text override. Use it when the sentence needs different casing or phrasing than the feature name.

--- a/macros/enterprise.js
+++ b/macros/enterprise.js
@@ -1,8 +1,8 @@
 'use strict'
 
-/* Inline macro for marking enterprise features in prose.
+/* Macros for marking and listing enterprise features.
  *
- * Example use in a page:
+ * Inline macro — mark a feature in prose:
  *
  *   enterprise:Continuous Data Balancing[]
  *   enterprise:Tiered Storage[xref=manage:tiered-storage.adoc]
@@ -15,10 +15,29 @@
  * and otherwise to the licensing page, so readers can always reach an
  * explanation of what having (or not having) a license means.
  *
+ * Block macro — render the licensing feature table for one scope:
+ *
+ *   enterprise_features::redpanda[]
+ *   enterprise_features::connect[title=Enterprise features in Redpanda Connect]
+ *
+ * Registry validation:
+ *
+ * Both macros read the canonical enterprise features registry from the
+ * 'shared' component (modules/ROOT/partials/enterprise-features.yml in the
+ * shared folder of the docs repo). Inline targets are resolved against the
+ * registry case-insensitively, including aliases, and the canonical name,
+ * feature xref, and tooltip come from the matching entry. Unknown targets
+ * are reported according to the enterprise-validate attribute. When no
+ * registry is available (for example, outside an Antora build), the macros
+ * fall back to unvalidated rendering with a single warning.
+ *
  * Document or site attributes:
  *
+ *   enterprise-validate        'warn' (default) to log unknown feature names,
+ *                              'error' to fail the build, 'off' to disable
+ *                              validation.
  *   enterprise-licensing-page  Resource ID of the licensing page used when
- *                              no xref attribute is given
+ *                              no feature page is known
  *                              (default: get-started:licensing/overview.adoc).
  *   enterprise-feature-role    CSS class applied to the wrapping span
  *                              (default: enterprise-feature).
@@ -34,8 +53,106 @@
  *     - '@redpanda-data/docs-extensions-and-macros/macros/enterprise'
  */
 
+const yaml = require('js-yaml')
+const chalk = require('chalk')
+
+const $enterpriseRegistry = Symbol('$enterpriseRegistry')
+
 const DEFAULT_LICENSING_PAGE = 'get-started:licensing/overview.adoc'
 const DEFAULT_ROLE = 'enterprise-feature'
+const REGISTRY_FILENAME = 'enterprise-features.yml'
+const VALID_SCOPES = ['redpanda', 'console', 'connect', 'operator', 'cloud']
+
+const TABLE_TITLES = {
+  redpanda: 'Enterprise features in Redpanda',
+  console: 'Enterprise features in Redpanda Console',
+  connect: 'Enterprise features in Redpanda Connect',
+  operator: 'Enterprise features in the Redpanda Operator',
+  cloud: 'Enterprise features in Redpanda Cloud',
+}
+
+const THIRD_COLUMN_HEADINGS = {
+  redpanda: 'Behavior Upon Expiration',
+  default: 'Restrictions Without Valid License',
+}
+
+let warnedNoRegistry = false
+
+/**
+ * Parse the registry YAML into a lookup structure. Exported for unit testing.
+ *
+ * @param {string} source - Raw YAML from enterprise-features.yml.
+ * @param {string} origin - Human-readable location for error messages.
+ * @returns {{features: object[], lookup: Map<string, object>}}
+ */
+function parseRegistry (source, origin = REGISTRY_FILENAME) {
+  const data = yaml.load(source)
+  if (!data || !Array.isArray(data.features)) {
+    throw new Error(`Enterprise features registry ${origin} has no 'features' list.`)
+  }
+  const lookup = new Map()
+  const claim = (rawKey, feature, kind) => {
+    const key = rawKey.trim().toLowerCase()
+    if (!key) return
+    const existing = lookup.get(key)
+    if (existing && existing !== feature) {
+      throw new Error(`Duplicate enterprise feature ${kind} '${rawKey}' in ${origin}: used by both '${existing.name}' and '${feature.name}'.`)
+    }
+    lookup.set(key, feature)
+  }
+  for (const feature of data.features) {
+    if (!feature || !feature.name) {
+      throw new Error(`Enterprise features registry ${origin} has an entry without a name.`)
+    }
+    if (feature.scope && !VALID_SCOPES.includes(feature.scope)) {
+      throw new Error(`Enterprise feature '${feature.name}' in ${origin} has unknown scope '${feature.scope}'.`)
+    }
+    claim(feature.name, feature, 'name')
+    for (const alias of feature.aliases || []) claim(String(alias), feature, 'alias')
+  }
+  return { features: data.features, lookup }
+}
+
+/**
+ * Load and cache the registry from the shared component in the Antora
+ * content catalog. Returns undefined when no registry is available.
+ */
+function loadRegistry (config) {
+  const contentCatalog = config && config.contentCatalog
+  if (!contentCatalog) return undefined
+  if (contentCatalog[$enterpriseRegistry] !== undefined) return contentCatalog[$enterpriseRegistry] || undefined
+  let registry = null
+  const partials = contentCatalog.findBy({ component: 'shared', module: 'ROOT', family: 'partial' }) || []
+  const registryFile = partials.find((file) => file.path && file.path.endsWith(REGISTRY_FILENAME))
+  if (registryFile) {
+    registry = parseRegistry(registryFile.contents.toString(), registryFile.path)
+  }
+  // Cache null too, so a missing registry is only searched for once per build.
+  contentCatalog[$enterpriseRegistry] = registry
+  return registry || undefined
+}
+
+function warnNoRegistry () {
+  if (warnedNoRegistry) return
+  warnedNoRegistry = true
+  console.warn(chalk.yellow(`Enterprise features registry (${REGISTRY_FILENAME} in the shared component) not found; enterprise: targets are not validated.`))
+}
+
+/**
+ * Report an unknown feature name according to the enterprise-validate mode.
+ */
+function reportUnknownFeature ({ feature, mode, registry, filePath }) {
+  if (mode === 'off') return
+  const candidates = registry.features
+    .map((entry) => entry.name)
+    .filter((name) => name.toLowerCase().includes(feature.trim().toLowerCase().split(/\s+/)[0] || ''))
+    .slice(0, 3)
+  const hint = candidates.length ? ` Did you mean: ${candidates.join(', ')}?` : ''
+  const where = filePath ? ` in ${filePath}` : ''
+  const message = `enterprise:${feature}[] does not match any feature in the enterprise features registry${where}.${hint} Add the feature to ${REGISTRY_FILENAME} in the shared component first.`
+  if (mode === 'error') throw new Error(message)
+  console.warn(chalk.yellow(message))
+}
 
 /**
  * Resolve the tooltip attribute name from the enterprise-tooltip document
@@ -54,13 +171,14 @@ function resolveTooltipAttribute (raw) {
 }
 
 /**
- * Build the AsciiDoc content emitted for one macro instance. Exported for
- * unit testing.
+ * Build the AsciiDoc content emitted for one inline macro instance. Exported
+ * for unit testing.
  *
  * @param {object} opts
- * @param {string} opts.feature - Feature name from the macro target.
+ * @param {string} opts.feature - Canonical feature name.
  * @param {string} [opts.text] - Display text override.
  * @param {string} [opts.xref] - Resource ID of the feature documentation.
+ * @param {string} [opts.url] - Absolute link used when no xref exists.
  * @param {string} [opts.tooltip] - Tooltip text override.
  * @param {string} opts.licensingPage - Resource ID of the licensing page.
  * @param {string} opts.role - CSS class for the wrapping span.
@@ -68,16 +186,52 @@ function resolveTooltipAttribute (raw) {
  * @param {boolean} opts.links - Whether to render a link.
  * @returns {string}
  */
-function buildEnterpriseContent ({ feature, text, xref, tooltip, licensingPage, role, tooltipAttr, links }) {
+function buildEnterpriseContent ({ feature, text, xref, url, tooltip, licensingPage, role, tooltipAttr, links }) {
   const display = text || feature
   const tooltipText = tooltip || `${feature} requires an Enterprise Edition license.`
   const escapedTooltip = tooltipText.replace(/"/g, '&quot;')
   const tooltipHtml = tooltipAttr ? ` ${tooltipAttr}="${escapedTooltip}"` : ''
-  const inner = links ? `xref:${xref || licensingPage}[${display}]` : display
+  let inner = display
+  if (links) {
+    inner = xref ? `xref:${xref}[${display}]` : (url ? `link:${url}[${display}]` : `xref:${licensingPage}[${display}]`)
+  }
   return `<span class="${role}"${tooltipHtml}>${inner}</span>`
 }
 
-function enterpriseInlineMacro () {
+/**
+ * Build the AsciiDoc source of the licensing feature table for one scope.
+ * Exported for unit testing.
+ *
+ * @param {object[]} features - All registry entries.
+ * @param {string} scope - Scope to render.
+ * @param {object} [opts]
+ * @param {string} [opts.title] - Table title override.
+ * @param {string} [opts.heading] - Third column heading override.
+ * @returns {string}
+ */
+function buildFeatureTable (features, scope, opts = {}) {
+  const rows = features
+    .filter((feature) => feature.scope === scope)
+    .sort((a, b) => a.name.localeCompare(b.name, 'en', { sensitivity: 'base' }))
+  const title = opts.title || TABLE_TITLES[scope]
+  const heading = opts.heading || THIRD_COLUMN_HEADINGS[scope] || THIRD_COLUMN_HEADINGS.default
+  const lines = [`.${title}`, '[cols="1a,2a,2a"]', '|===', `| Feature | Description | ${heading}`, '']
+  for (const feature of rows) {
+    let cell = feature.xref
+      ? `xref:${feature.xref}[${feature.name}]`
+      : (feature.url ? `link:${feature.url}[${feature.name}]` : feature.name)
+    if (feature['feature-suffix']) cell += ` ${feature['feature-suffix']}`
+    if (feature['show-gating-property'] && feature['gating-property']) cell += `\n(\`${feature['gating-property']}\`)`
+    lines.push(`| ${cell}`)
+    lines.push(`| ${(feature.description || '').trim()}`)
+    lines.push(`| ${(feature.expiration || '').trim()}`)
+    lines.push('')
+  }
+  lines.push('|===')
+  return lines.join('\n')
+}
+
+function enterpriseInlineMacro (config) {
   return function () {
     const self = this
     self.named('enterprise')
@@ -85,11 +239,32 @@ function enterpriseInlineMacro () {
     self.$option('regexp', /enterprise:([^[]+)\[(|.*?[^\\])\]/)
     self.process(function (parent, target, attributes) {
       const document = parent.getDocument()
+      let registry
+      if (config && config.contentCatalog) {
+        registry = loadRegistry(config)
+        if (!registry) warnNoRegistry()
+      }
+      let feature = target
+      let entry
+      if (registry) {
+        entry = registry.lookup.get(target.trim().toLowerCase())
+        if (entry) {
+          feature = entry.name
+        } else {
+          reportUnknownFeature({
+            feature: target,
+            mode: document.getAttribute('enterprise-validate', 'warn'),
+            registry,
+            filePath: config && config.file && config.file.src && config.file.src.path,
+          })
+        }
+      }
       const content = buildEnterpriseContent({
-        feature: target,
+        feature,
         text: attributes.text,
-        xref: attributes.xref,
-        tooltip: attributes.tooltip,
+        xref: attributes.xref || (entry && entry.xref),
+        url: entry && entry.url,
+        tooltip: attributes.tooltip || (entry && entry.tooltip) || undefined,
         licensingPage: document.getAttribute('enterprise-licensing-page', DEFAULT_LICENSING_PAGE),
         role: document.getAttribute('enterprise-feature-role', DEFAULT_ROLE),
         tooltipAttr: resolveTooltipAttribute(document.getAttribute('enterprise-tooltip')),
@@ -102,13 +277,35 @@ function enterpriseInlineMacro () {
   }
 }
 
-function register (registry) {
+function enterpriseFeaturesBlockMacro (config) {
+  return function () {
+    const self = this
+    self.named('enterprise_features')
+    self.process(function (parent, target, attributes) {
+      const scope = (target || attributes.scope || '').trim()
+      if (!VALID_SCOPES.includes(scope)) {
+        throw new Error(`enterprise_features::[] needs a scope of ${VALID_SCOPES.join(', ')} as its target, got '${scope}'.`)
+      }
+      const registry = config && config.contentCatalog ? loadRegistry(config) : undefined
+      if (!registry) {
+        warnNoRegistry()
+        return self.parseContent(parent, `WARNING: The enterprise features registry is unavailable, so the ${scope} feature table cannot be rendered.`)
+      }
+      const table = buildFeatureTable(registry.features, scope, { title: attributes.title, heading: attributes.heading })
+      return self.parseContent(parent, table)
+    })
+  }
+}
+
+function register (registry, config = {}) {
   if (typeof registry.register === 'function') {
     registry.register(function () {
-      this.inlineMacro(enterpriseInlineMacro())
+      this.inlineMacro(enterpriseInlineMacro(config))
+      this.blockMacro(enterpriseFeaturesBlockMacro(config))
     })
   } else if (typeof registry.inlineMacro === 'function') {
-    registry.inlineMacro(enterpriseInlineMacro())
+    registry.inlineMacro(enterpriseInlineMacro(config))
+    if (typeof registry.blockMacro === 'function') registry.blockMacro(enterpriseFeaturesBlockMacro(config))
   } else {
     console.warn("no 'inlineMacro' method on alleged registry")
   }
@@ -117,4 +314,6 @@ function register (registry) {
 
 module.exports.register = register
 module.exports.buildEnterpriseContent = buildEnterpriseContent
+module.exports.buildFeatureTable = buildFeatureTable
+module.exports.parseRegistry = parseRegistry
 module.exports.resolveTooltipAttribute = resolveTooltipAttribute

--- a/macros/enterprise.js
+++ b/macros/enterprise.js
@@ -155,6 +155,25 @@ function reportUnknownFeature ({ feature, mode, registry, filePath }) {
 }
 
 /**
+ * Pick the environment-appropriate feature page from a registry entry.
+ * Some features have separate documentation for Kubernetes, Linux
+ * (self-managed), and Redpanda Cloud. Mirrors the config_ref macro's
+ * environment-awareness: the env-cloud and env-kubernetes page attributes
+ * select the xref-cloud and xref-kubernetes registry fields, falling back
+ * to the default xref.
+ *
+ * @param {object} entry - Registry entry.
+ * @param {object} document - Asciidoctor document (for env attributes).
+ * @returns {string|undefined}
+ */
+function resolveEntryXref (entry, document) {
+  if (!entry) return undefined
+  if (document.getAttribute('env-cloud') !== undefined && entry['xref-cloud']) return entry['xref-cloud']
+  if (document.getAttribute('env-kubernetes') !== undefined && entry['xref-kubernetes']) return entry['xref-kubernetes']
+  return entry.xref
+}
+
+/**
  * Resolve the tooltip attribute name from the enterprise-tooltip document
  * attribute. Mirrors the glossary macro's contract.
  *
@@ -262,7 +281,7 @@ function enterpriseInlineMacro (config) {
       const content = buildEnterpriseContent({
         feature,
         text: attributes.text,
-        xref: attributes.xref || (entry && entry.xref),
+        xref: attributes.xref || resolveEntryXref(entry, document),
         url: entry && entry.url,
         tooltip: attributes.tooltip || (entry && entry.tooltip) || undefined,
         licensingPage: document.getAttribute('enterprise-licensing-page', DEFAULT_LICENSING_PAGE),
@@ -319,4 +338,5 @@ module.exports.register = register
 module.exports.buildEnterpriseContent = buildEnterpriseContent
 module.exports.buildFeatureTable = buildFeatureTable
 module.exports.parseRegistry = parseRegistry
+module.exports.resolveEntryXref = resolveEntryXref
 module.exports.resolveTooltipAttribute = resolveTooltipAttribute

--- a/macros/enterprise.js
+++ b/macros/enterprise.js
@@ -292,7 +292,10 @@ function enterpriseFeaturesBlockMacro (config) {
         return self.parseContent(parent, `WARNING: The enterprise features registry is unavailable, so the ${scope} feature table cannot be rendered.`)
       }
       const table = buildFeatureTable(registry.features, scope, { title: attributes.title, heading: attributes.heading })
-      return self.parseContent(parent, table)
+      // A block anchor before the macro call ([[my-id]]) is consumed into the
+      // macro's id attribute. Re-emit it so crossrefs to the table keep working.
+      const source = attributes.id ? `[[${attributes.id}]]\n${table}` : table
+      return self.parseContent(parent, source)
     })
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.5.0",
+  "version": "5.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.5.0",
+      "version": "5.13.0",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.12.0",
+  "version": "5.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "5.12.0",
+      "version": "5.5.0",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
       "devDependencies": {
         "@antora/cli": "3.1.4",
         "@antora/site-generator": "3.1.4",
+        "@asciidoctor/core": "2.2.8",
         "@web/dev-server": "^0.2.5",
         "jest": "^29.7.0",
         "jest-junit": "^16.0.0"
@@ -231,32 +232,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@antora/asciidoc-loader/node_modules/@asciidoctor/core": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.2.8.tgz",
-      "integrity": "sha512-oozXk7ZO1RAd/KLFLkKOhqTcG4GO3CV44WwOFg2gMcCsqCUTarvMT7xERIoWW2WurKbB0/ce+98r01p8xPOlBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asciidoctor-opal-runtime": "0.3.3",
-        "unxhr": "1.0.1"
-      },
-      "engines": {
-        "node": ">=8.11",
-        "npm": ">=5.0.0",
-        "yarn": ">=1.1.0"
-      }
-    },
-    "node_modules/@antora/asciidoc-loader/node_modules/unxhr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unxhr/-/unxhr-1.0.1.tgz",
-      "integrity": "sha512-MAhukhVHyaLGDjyDYhy8gVjWJyhTECCdNsLwlMoGFoNJ3o79fpQhtQuzmAE4IxCMDwraF4cW8ZjpAV0m9CRQbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.11"
       }
     },
     "node_modules/@antora/cli": {
@@ -531,6 +506,22 @@
       },
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/@asciidoctor/core": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.2.8.tgz",
+      "integrity": "sha512-oozXk7ZO1RAd/KLFLkKOhqTcG4GO3CV44WwOFg2gMcCsqCUTarvMT7xERIoWW2WurKbB0/ce+98r01p8xPOlBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asciidoctor-opal-runtime": "0.3.3",
+        "unxhr": "1.0.1"
+      },
+      "engines": {
+        "node": ">=8.11",
+        "npm": ">=5.0.0",
+        "yarn": ">=1.1.0"
       }
     },
     "node_modules/@asciidoctor/tabs": {
@@ -3768,16 +3759,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/asciidoctor-opal-runtime/node_modules/unxhr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unxhr/-/unxhr-1.0.1.tgz",
-      "integrity": "sha512-MAhukhVHyaLGDjyDYhy8gVjWJyhTECCdNsLwlMoGFoNJ3o79fpQhtQuzmAE4IxCMDwraF4cW8ZjpAV0m9CRQbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.11"
       }
     },
     "node_modules/assign-symbols": {
@@ -15235,6 +15216,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unxhr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unxhr/-/unxhr-1.0.1.tgz",
+      "integrity": "sha512-MAhukhVHyaLGDjyDYhy8gVjWJyhTECCdNsLwlMoGFoNJ3o79fpQhtQuzmAE4IxCMDwraF4cW8ZjpAV0m9CRQbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.11"
       }
     },
     "node_modules/upath": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.12.0",
+  "version": "5.5.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "5.5.0",
+  "version": "5.13.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
   "devDependencies": {
     "@antora/cli": "3.1.4",
     "@antora/site-generator": "3.1.4",
+    "@asciidoctor/core": "2.2.8",
     "@web/dev-server": "^0.2.5",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0"

--- a/preview/extensions-and-macros/modules/ROOT/nav.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/nav.adoc
@@ -1,3 +1,4 @@
 * xref:preview:ROOT:test.adoc[]
+* xref:preview:ROOT:enterprise-kubernetes-test.adoc[]
 * xref:preview:ROOT:docker-labs.adoc[]
 * xref:preview:reference:glossary.adoc[]

--- a/preview/extensions-and-macros/modules/ROOT/pages/enterprise-kubernetes-test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/enterprise-kubernetes-test.adoc
@@ -1,0 +1,11 @@
+= Enterprise Macro: Kubernetes Environment Test
+:env-kubernetes: true
+:enterprise-licensing-page: streaming:get-started:licensing/overview.adoc
+
+This page sets `:env-kubernetes: true`, so the `enterprise` macro resolves each registry entry's `xref-kubernetes` when one exists. Compare with the same calls on the xref:preview:ROOT:test.adoc[main test page], which link to the default (Linux / self-managed) pages.
+
+Tiered Storage's registry entry carries an `xref-kubernetes`, so this links to the Kubernetes feature page: enterprise:Tiered Storage[] in a sentence.
+
+Continuous Data Balancing's entry has no `xref-kubernetes`, so it falls back to the entry's default `xref` (its Linux feature page): enterprise:Continuous Data Balancing[] in a sentence.
+
+The alias `cloud_storage` canonicalizes and gets the environment-specific link too: enterprise:cloud_storage[] in a sentence.

--- a/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
@@ -37,6 +37,24 @@ With display text override: enterprise:Audit Logging[text=audit logging] in a se
 
 With tooltip override: enterprise:Iceberg Topics[tooltip=Iceberg Topics requires an Enterprise Edition license and object storage.] in a sentence.
 
+=== Registry validation
+
+The macro resolves its target against the enterprise features registry (`enterprise-features.yml` in the `shared` component). Aliases and case-insensitive spellings canonicalize to the registry name, and the registry supplies the feature link.
+
+From the alias `cloud_storage`: enterprise:cloud_storage[] in a sentence.
+
+From a lowercase spelling: enterprise:continuous data balancing[] in a sentence.
+
+An unknown feature name renders as written but logs a build warning (set `enterprise-validate` to `error` to fail the build instead): enterprise:Warp Drive[] in a sentence.
+
+=== Generated feature tables
+
+The `enterprise_features` block macro renders the licensing feature table for one scope from the same registry:
+
+enterprise_features::redpanda[]
+
+enterprise_features::connect[]
+
 == Terms
 
 Terms must be defined in the `terms` module of the `shared` component (`shared/modules/terms/partials`).

--- a/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
@@ -35,7 +35,7 @@ Default, no registry xref, linking to the licensing page: enterprise:Continuous 
 
 Registry-supplied feature link (the Tiered Storage entry carries an xref): enterprise:Tiered Storage[] in a sentence.
 
-Per-use xref, overriding the registry: enterprise:Tiered Storage[xref=streaming:manage:tiered-storage/tiered-storage.adoc] in a sentence.
+Per-use xref, overriding the registry (here, the Kubernetes variant of the feature page): enterprise:Tiered Storage[xref=streaming:manage:kubernetes/tiered-storage/k-tiered-storage.adoc] in a sentence.
 
 Display text override (canonical name stays in the tooltip): enterprise:Audit Logging[text=audit logging] in a sentence.
 

--- a/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
@@ -25,35 +25,56 @@ These dates are:
 
 == Enterprise macro
 
-The `enterprise` macro marks a feature as an enterprise feature in prose. The feature name renders as a styled term (`enterprise-feature` class) with a tooltip explaining the license requirement, linking to the feature's page or the licensing page.
+The `enterprise` macro marks a feature as an enterprise feature in prose. The feature name renders as a styled term (`enterprise-feature` class) with a tooltip explaining the license requirement, linking to the feature's page or the licensing page. Targets are validated against the enterprise features registry (`enterprise-features.yml` in the `shared` component).
 
 NOTE: This page sets `:enterprise-licensing-page: streaming:get-started:licensing/overview.adoc` because the default target (`get-started:licensing/overview.adoc`) is only resolvable from inside the docs component itself.
 
-Default, linking to the licensing page: enterprise:Continuous Data Balancing[] in a sentence.
+=== Marking forms
 
-With a feature xref: enterprise:Tiered Storage[xref=streaming:manage:tiered-storage.adoc] in a sentence.
+Default, no registry xref, linking to the licensing page: enterprise:Continuous Data Balancing[] in a sentence.
 
-With display text override: enterprise:Audit Logging[text=audit logging] in a sentence.
+Registry-supplied feature link (the Tiered Storage entry carries an xref): enterprise:Tiered Storage[] in a sentence.
 
-With tooltip override: enterprise:Iceberg Topics[tooltip=Iceberg Topics requires an Enterprise Edition license and object storage.] in a sentence.
+Per-use xref, overriding the registry: enterprise:Tiered Storage[xref=streaming:manage:tiered-storage/tiered-storage.adoc] in a sentence.
 
-=== Registry validation
+Display text override (canonical name stays in the tooltip): enterprise:Audit Logging[text=audit logging] in a sentence.
 
-The macro resolves its target against the enterprise features registry (`enterprise-features.yml` in the `shared` component). Aliases and case-insensitive spellings canonicalize to the registry name, and the registry supplies the feature link.
+Tooltip override: enterprise:Iceberg Topics[tooltip=Iceberg Topics requires an Enterprise Edition license and object storage.] in a sentence.
 
-From the alias `cloud_storage`: enterprise:cloud_storage[] in a sentence.
+Text and tooltip together: enterprise:Audit Logging[text=audit logs,tooltip=Audit logs need an Enterprise Edition license and a SASL listener.] in a sentence.
 
-From a lowercase spelling: enterprise:continuous data balancing[] in a sentence.
+=== Registry resolution
 
-An unknown feature name renders as written but logs a build warning (set `enterprise-validate` to `error` to fail the build instead): enterprise:Warp Drive[] in a sentence.
+Aliases and case-insensitive spellings canonicalize to the registry name, and the registry supplies the feature link.
+
+From the alias `cloud_storage` (an internal core name, renders the canonical external name): enterprise:cloud_storage[] in a sentence.
+
+From a lowercase spelling: enterprise:tiered storage[] in a sentence.
+
+An unknown feature name renders as written but logs a build warning with did-you-mean suggestions (set `enterprise-validate` to `error` to fail the build instead): enterprise:Warp Drive[] in a sentence.
+
+=== Environment-specific feature links
+
+Registry entries can carry `xref-kubernetes` and `xref-cloud` for features with separate Kubernetes, Linux, and Cloud documentation. Resolution follows the page's `env-kubernetes`/`env-cloud` attributes, so it applies page-wide: see the xref:preview:ROOT:enterprise-kubernetes-test.adoc[Kubernetes environment test page], where the same `enterprise:Tiered Storage[]` call links to the Kubernetes feature page instead.
 
 === Generated feature tables
 
-The `enterprise_features` block macro renders the licensing feature table for one scope from the same registry:
+The `enterprise_features` block macro renders the licensing feature table for one scope from the same registry.
 
+Default titles and headings, with a block anchor that survives generation (see the crossref below):
+
+[[demo-redpanda-features]]
 enterprise_features::redpanda[]
 
-enterprise_features::connect[]
+The operator scope demonstrates the `feature-suffix` field (resource-name annotation and beta badge after the feature link):
+
+enterprise_features::operator[]
+
+Custom `title` and `heading` overrides:
+
+enterprise_features::connect[title=Connect features that need a license,heading=What stops working]
+
+The block anchor re-emitted above keeps crossrefs working: jump to <<demo-redpanda-features,the Redpanda table>>.
 
 == Terms
 

--- a/preview/shared/modules/ROOT/partials/enterprise-features.yml
+++ b/preview/shared/modules/ROOT/partials/enterprise-features.yml
@@ -1,0 +1,73 @@
+# Demo enterprise features registry for the preview site. The production
+# registry lives in the shared/ folder of the docs repo.
+schema-version: 1
+features:
+  - name: Tiered Storage
+    scope: redpanda
+    xref: streaming:manage:tiered-storage.adoc
+    description: |
+      Enables data storage in cloud object storage for long-term retention and retrieval.
+    expiration: |
+      Topics cannot be created or modified to enable Tiered Storage features.
+    aliases: [cloud_storage]
+    source:
+      kind: core-enum
+      value: cloud_storage
+    gating-property: cloud_storage_enabled
+  - name: Continuous Data Balancing
+    scope: redpanda
+    xref: streaming:manage:cluster-maintenance/continuous-data-balancing.adoc
+    description: |
+      Automatically balances partitions across a cluster to optimize resource use and performance.
+    expiration: |
+      Continuous balancing is disabled, reverting to `node_add`.
+    aliases: [CDB, partition_auto_balancing_continuous]
+    source:
+      kind: core-enum
+      value: partition_auto_balancing_continuous
+    gating-property: partition_autobalancing_mode
+  - name: Topic Deletion Control
+    scope: redpanda
+    description: |
+      Prevents all users, including superusers, from deleting topics through the Kafka DeleteTopics API.
+    expiration: |
+      Topic deletion reverts to enabled (`true`).
+    show-gating-property: true
+    source:
+      kind: core-enum
+      value: topic_deletion_disabled
+    gating-property: delete_topic_enable
+  - name: Audit Logging
+    scope: redpanda
+    xref: streaming:manage:audit-logging.adoc
+    description: |
+      Records detailed logs of cluster activities for compliance and monitoring.
+    expiration: |
+      Read access to the audit log topic is denied, but logging continues.
+    aliases: [audit_logging]
+    source:
+      kind: core-enum
+      value: audit_logging
+    gating-property: audit_enabled
+  - name: Iceberg Topics
+    scope: redpanda
+    xref: streaming:manage:iceberg/topic-iceberg-integration.adoc
+    description: |
+      Enables Iceberg integration for Redpanda topics.
+    expiration: |
+      Topics cannot be created or modified with the `redpanda.iceberg.mode` property.
+    aliases: [datalake_iceberg]
+    source:
+      kind: core-enum
+      value: datalake_iceberg
+    gating-property: iceberg_enabled
+  - name: Enterprise connectors
+    scope: connect
+    url: https://docs.redpanda.com/redpanda-connect/components/catalog/?support=enterprise
+    description: |
+      Additional inputs, outputs, and processors available only to enterprise customers.
+    expiration: |
+      All enterprise connectors are blocked.
+    source:
+      kind: manual
+      value: Aggregate entry; individual connectors are tracked in connect internal/plugins/info.csv.

--- a/preview/shared/modules/ROOT/partials/enterprise-features.yml
+++ b/preview/shared/modules/ROOT/partials/enterprise-features.yml
@@ -5,6 +5,7 @@ features:
   - name: Tiered Storage
     scope: redpanda
     xref: streaming:manage:tiered-storage.adoc
+    xref-kubernetes: streaming:manage:kubernetes/tiered-storage/k-tiered-storage.adoc
     description: |
       Enables data storage in cloud object storage for long-term retention and retrieval.
     expiration: |
@@ -61,6 +62,17 @@ features:
       kind: core-enum
       value: datalake_iceberg
     gating-property: iceberg_enabled
+  - name: Stretch Clusters
+    scope: operator
+    xref: streaming:deploy:redpanda/kubernetes/k-stretch-clusters.adoc
+    description: |
+      A single logical Redpanda cluster distributed across multiple Kubernetes clusters.
+    expiration: |
+      The multicluster operator requires a valid license to start.
+    feature-suffix: (StretchCluster resource) badge::[label=beta]
+    source:
+      kind: manual
+      value: License gate in operator cmd/multicluster.
   - name: Enterprise connectors
     scope: connect
     url: https://docs.redpanda.com/redpanda-connect/components/catalog/?support=enterprise


### PR DESCRIPTION
## In plain English

The `enterprise:` macro used to accept any text -- `enterprise:Warp Drive[]` would happily render as an enterprise feature. Now every use is checked against the canonical enterprise features registry: misspellings and internal engineering names automatically become the proper external name (writing `cloud_storage` renders "Tiered Storage"), unknown names produce a build warning with suggestions (or fail the build, once we flip the switch), and the feature's link and tooltip come from the registry instead of being retyped at every call site. A second macro renders the licensing feature tables directly from the same registry, so those tables can never quietly disagree with it.

## Description

Part of the enterprise-marking governance work for [DOC-887](https://redpandadata.atlassian.net/browse/DOC-887). Stacked on #249 (the enterprise macro) — review and merge that first; this PR's diff shrinks to the registry work once #249 lands. Companion PRs: redpanda-data/docs#1892 (the registry itself) and #251 (the drift checker).

### enterprise: inline macro — registry validation

The macro now resolves its target against the canonical enterprise features registry (`enterprise-features.yml` in the `shared` component, added in redpanda-data/docs#1892), copying the glossary macro's contentCatalog loading and caching pattern:

- Case-insensitive matching including aliases: `enterprise:cloud_storage[]` and `enterprise:tiered storage[]` both render the canonical **Tiered Storage**, linked to the registry's feature page. Writers can no longer misname a feature.
- Unknown targets are reported per the new `enterprise-validate` attribute: `warn` (default — build warning with file path and did-you-mean suggestions), `error` (fails the build), or `off`. The rollout plan is warn first, flip to error once existing usage is clean.
- Attribute precedence: per-use `xref=`/`tooltip=` still override the registry entry; `text=` overrides the display.
- Environment-aware links: registry entries can carry `xref-kubernetes` and `xref-cloud` for features with separate Kubernetes/Linux/Cloud documentation. Pages with `env-kubernetes`/`env-cloud` get the environment-appropriate page, falling back to the default `xref` (the `config_ref` precedent). Block anchors before `enterprise_features::` are re-emitted so crossrefs to generated tables keep working.
- Duplicate names or alias collisions in the registry are a hard build error (glossary precedent).
- Graceful degradation: with no registry in the build (standalone Asciidoctor, repos without the shared component), the macro renders unvalidated and logs one warning — existing behavior and tests unchanged.

### New enterprise_features block macro

`enterprise_features::redpanda[]` renders the licensing feature table for one scope from the same registry (three columns, alphabetical, scope-specific third-column heading, `title=`/`heading=` overrides). The licensing tables in the docs become macro calls, so they can never drift from the registry.

## Validation

- 37 macro tests (23 new), including real Asciidoctor conversions with a fixture registry: alias canonicalization, precedence, warn/error/off, duplicate hard error, cache reuse, graceful degradation, table rendering per scope.
- Full suite passes.
- Preview site: the test page demonstrates alias resolution, an intentional unknown-name warning, and generated `redpanda` + `connect` tables against a demo registry in `preview/shared`.

## Version

Bumps to 5.13.0 (re-laddered after main moved past the old range; base #249 is now 5.12.0). **Stack**: #249 (5.12.0) ← this PR (5.13.0) ← #251 (5.14.0) ← #254 (5.15.0).

[DOC-887]: https://redpandadata.atlassian.net/browse/DOC-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ