### PR TITLE
feat(version-fetcher): emit <base>-version-short attributes

### DIFF
--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -146,12 +146,17 @@ module.exports.register = function ({ config }) {
     }
   });
 
-  // Helper function to set both latest-*version and latest-*tag attributes
+  // Helper function to set latest-*version, latest-*tag, and latest-*version-short attributes
   function setVersionAndTagAttributes(asciidoc, baseName, versionData, name = '', version = '') {
     if (versionData) {
       const versionWithoutPrefix = sanitizeVersion(versionData);
       asciidoc.attributes[`${baseName}-version`] = versionWithoutPrefix; // Without "v" prefix
       asciidoc.attributes[`${baseName}-tag`] = `${versionData}`;
+
+      const shortVersion = toShortVersion(versionWithoutPrefix);
+      if (shortVersion) {
+        asciidoc.attributes[`${baseName}-version-short`] = shortVersion; // major.minor only
+      }
 
       if (name && version) {
         logger.debug(`Set ${baseName}-version to ${versionWithoutPrefix} and ${baseName}-tag to ${versionData} in ${name} ${version}`);
@@ -159,6 +164,12 @@ module.exports.register = function ({ config }) {
         logger.debug(`Updated ${baseName}-version to ${versionWithoutPrefix} and ${baseName}-tag to ${versionData}`);
       }
     }
+  }
+
+  // Helper function to derive the major.minor short version (for example, 26.2.1 -> 26.2)
+  function toShortVersion(version) {
+    const match = /^(\d+)\.(\d+)/.exec(version);
+    return match ? `${match[1]}.${match[2]}` : null;
   }
 
   // Helper function to sanitize version by removing "v" prefix


### PR DESCRIPTION
## Summary

`setVersionAndTagAttributes()` now also emits a `<base>-version-short` attribute containing major.minor — for example `latest-redpanda-version-short: 26.2` alongside `latest-redpanda-version: 26.2.1`. Applies to every component that receives `-version`/`-tag` attributes, including beta variants. Non-semver values (for example `nightly`) simply skip the short attribute.

## Why

Cloud docs ([DOC-1672](https://redpandadata.atlassian.net/browse/DOC-1672)) need a moving short version: the cloud-docs component is unversioned (`version: ~`), so `{page-component-version}` is empty there, and pages such as the BYOVPC guides hardcode values like `REDPANDA_VERSION=25.2` that go stale (see cloud-docs#411, a manual bump prompted by a customer).

Verified with a full local cloud-docs build using this change: the consuming page renders `export REDPANDA_VERSION=26.2`.

Companion PR in cloud-docs adds the fallback attribute and adopts it. Needs an npm release before consuming repos pick it up via update-extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-1672]: https://redpandadata.atlassian.net/browse/DOC-1672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ