### PR TITLE
fix(redpanda-connect): avoid rpk connect upgrade's version-regex bug in report-delta

### DIFF
--- a/tools/redpanda-connect/report-delta.js
+++ b/tools/redpanda-connect/report-delta.js
@@ -424,8 +424,15 @@ function buildComponentMap(indexObj) {
 
 function getRpkConnectVersion() {
   try {
-    // Make sure the connect plugin is upgraded first (silent)
-    execSync('rpk connect upgrade', { stdio: 'ignore' });
+    // Ensure the connect plugin is current (silent). Deliberately "install
+    // --force", not "upgrade": upgrade's version comparison parses the
+    // currently-installed version through a regex capped at two digits per
+    // segment (redpanda.VersionFromString in rpk/pkg/redpanda/version.go),
+    // which throws for any Connect version >= 4.100.0 — the same bug class
+    // as CON-529, in a different function that its fix didn't touch, and
+    // still unfixed as of rpk dev. install's "latest" path (the default)
+    // skips that regex entirely, so it isn't exposed to the bug.
+    execSync('rpk connect install --force', { stdio: 'ignore' });
 
     // Now capture the --version output
     const raw = execSync('rpk connect --version', {


### PR DESCRIPTION
## Why

`getRpkConnectVersion()` (used when `doc-tools generate rpcn-connector-docs --fetch-connectors` runs without `--connect-version`, i.e. the normal CI path) called `rpk connect upgrade` to make sure the plugin was current before reading its version.

`rpk connect upgrade` parses the *currently installed* Connect version through `redpanda.VersionFromString` (`rpk/pkg/redpanda/version.go`) to compare it against latest. That parser's regex caps every version segment at two digits:

```go
regexp.MustCompile(`^v?(\d{1,2})\.(\d{1,2})\.(\d{1,2})(?:\s|-rc\d{1,2}|-dev|-nightly|$)`)
```

So it throws for any installed Connect version >= 4.100.0 — every currently shipping version. This is the same bug class as [CON-529](https://redpandadata.atlassian.net/browse/CON-529) / [redpanda#31432](https://github.com/redpanda-data/redpanda/issues/31432) (fixed in [redpanda#31438](https://github.com/redpanda-data/redpanda/pull/31438)), but in a different function that fix didn't touch — confirmed still present and unfixed on rpk `dev` as of this writing. It's what broke the scheduled `Update RPCN Connector Docs` workflow in rp-connect-docs starting 2026-08-07 (`Cannot process version X - data unavailable`), even after CON-529's own fix landed and after switching to an rpk build (`v26.1.15`) that has it.

## What this does

Swaps the plugin-freshness check from `rpk connect upgrade` to `rpk connect install --force`. Both ensure the latest plugin is installed; `install`'s default version is the string `"latest"`, which its own validator short-circuits before ever reaching a version-parsing regex — so this path isn't exposed to the bug at all, on any rpk build (verified against both the pre-fix v26.2.1 and the post-fix v26.1.15).

Filed against rpk upstream separately; this is a workaround so our pipeline doesn't have to wait on another rpk release.

## Test plan

- [x] Full test suite passes (`npx jest`, 1020/1020)
- [x] Manually verified `rpk connect install --force` succeeds on both v26.2.1 (pre-fix) and v26.1.15 (post-fix) rpk builds, whereas `rpk connect upgrade` fails on both once a >= 4.100.0 version is installed
- [x] Used this patched version to successfully regenerate rp-connect-docs connector docs locally (redpanda-data/rp-connect-docs#489)

[CON-529]: https://redpandadata.atlassian.net/browse/CON-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ