### PR TITLE
fix(redpanda-connect): recursively detect new fields nested under existing groups

### DIFF
--- a/__tests__/tools/rpcn-connector-summaries.test.js
+++ b/__tests__/tools/rpcn-connector-summaries.test.js
@@ -156,6 +156,88 @@ describe('generateConnectorDiffJson - config component status and cloud support'
     expect(inDetails).toBe(true);
     expect(added.cloudSupported).toBe(true);
   });
+
+  test('detects a new field nested under an existing group, not just new top-level fields', () => {
+    // aws_s3's "sqs" group already exists in both versions; only a field
+    // nested inside it is new. A diff that only compares top-level field
+    // names would see "sqs" unchanged and report zero new fields, even
+    // though sqs.zero_key_warn_interval is genuinely new.
+    const oldIndex = {
+      inputs: [
+        {
+          name: 'aws_s3',
+          config: {
+            children: [
+              { name: 'bucket', description: 'Bucket name.' },
+              {
+                name: 'sqs',
+                children: [
+                  { name: 'url', description: 'Queue URL.' }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    };
+    const newIndex = {
+      inputs: [
+        {
+          name: 'aws_s3',
+          config: {
+            children: [
+              { name: 'bucket', description: 'Bucket name.' },
+              {
+                name: 'sqs',
+                children: [
+                  { name: 'url', description: 'Queue URL.' },
+                  { name: 'zero_key_warn_interval', description: 'Warn interval.' }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.103.1',
+      newVersion: '4.104.0'
+    });
+
+    expect(diff.summary.newFields).toBe(1);
+    const added = diff.details.newFields.find(f => f.field === 'sqs.zero_key_warn_interval');
+    expect(added).toBeDefined();
+    expect(added.component).toBe('inputs:aws_s3');
+  });
+
+  test('stamps the diff target version onto a new field when the source data carries none', () => {
+    const oldIndex = { inputs: [{ name: 'foo', config: { children: [] } }] };
+    const newIndex = {
+      inputs: [{ name: 'foo', config: { children: [{ name: 'bar', description: 'A field.' } ] } }]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.103.1',
+      newVersion: '4.104.0'
+    });
+
+    expect(diff.details.newFields[0].introducedIn).toBe('4.104.0');
+  });
+
+  test('prefers a field-level version over the diff target version, when the source data has one', () => {
+    const oldIndex = { inputs: [{ name: 'foo', config: { children: [] } }] };
+    const newIndex = {
+      inputs: [{ name: 'foo', config: { children: [{ name: 'bar', introducedInVersion: '4.99.0' }] } }]
+    };
+
+    const diff = generateConnectorDiffJson(oldIndex, newIndex, {
+      oldVersion: '4.103.1',
+      newVersion: '4.104.0'
+    });
+
+    expect(diff.details.newFields[0].introducedIn).toBe('4.99.0');
+  });
 });
 
 describe('buildCleanOssData - pure OSS snapshot for binary analysis', () => {
@@ -318,6 +400,31 @@ describe('buildFieldsTable - whats-new field links', () => {
     ], cap);
 
     expect(table).toContain('* xref:components:inputs/kafka_franz.adoc#regexp_topics_exclude[kafka_franz]');
+  });
+
+  test('omits the "Introduced in" column by default', () => {
+    const table = buildFieldsTable([
+      { component: 'inputs:aws_s3', field: 'sqs.zero_key_warn_interval', description: 'Warn interval.', introducedIn: '4.104.0' }
+    ], cap);
+
+    expect(table).not.toContain('Introduced in');
+  });
+
+  test('adds an "Introduced in" column when showIntroducedIn is set', () => {
+    const table = buildFieldsTable([
+      { component: 'inputs:aws_s3', field: 'sqs.zero_key_warn_interval', description: 'Warn interval.', introducedIn: '4.104.0' }
+    ], cap, { showIntroducedIn: true });
+
+    expect(table).toContain('|Field |Description |Affected components |Introduced in');
+    expect(table).toContain('|4.104.0');
+  });
+
+  test('"Introduced in" column falls back to a dash when a field has no version', () => {
+    const table = buildFieldsTable([
+      { component: 'inputs:aws_s3', field: 'sqs.zero_key_warn_interval', description: 'Warn interval.' }
+    ], cap, { showIntroducedIn: true });
+
+    expect(table).toContain('|-\n');
   });
 });
 

--- a/tools/redpanda-connect/report-delta.js
+++ b/tools/redpanda-connect/report-delta.js
@@ -56,17 +56,15 @@ function generateConnectorDiffJson(oldIndex, newIndex, opts = {}) {
     const newFieldsArr = newMap[cKey].fields || [];
     newFieldsArr.forEach(fName => {
       if (!oldFields.has(fName)) {
-        const [type, compName] = cKey.split(':');
-        let rawFieldObj = null;
-        if (type === 'config') {
-          rawFieldObj = (newMap[cKey].raw.children || []).find(f => f.name === fName);
-        } else {
-          rawFieldObj = (newMap[cKey].raw.config?.children || []).find(f => f.name === fName);
-        }
+        const rawFieldObj = newMap[cKey].fieldMap.get(fName) || null;
         newFields.push({
           component: cKey,
           field: fName,
-          introducedIn: rawFieldObj && (rawFieldObj.introducedInVersion || rawFieldObj.version),
+          // The source data carries no per-field version metadata today, so
+          // fall back to the version this diff is comparing against — it's
+          // still an accurate "introduced in" answer, since this field is
+          // new as of exactly that release.
+          introducedIn: (rawFieldObj && (rawFieldObj.introducedInVersion || rawFieldObj.version)) || opts.newVersion || null,
           description: rawFieldObj && rawFieldObj.description
         });
       }
@@ -172,23 +170,8 @@ function generateConnectorDiffJson(oldIndex, newIndex, opts = {}) {
     // Check fields that exist in both versions
     const commonFields = oldFieldsArr.filter(f => newFieldsArr.includes(f));
     commonFields.forEach(fName => {
-      const [type, compName] = cKey.split(':');
-
-      // Get old field object
-      let oldFieldObj = null;
-      if (type === 'config') {
-        oldFieldObj = (oldMap[cKey].raw.children || []).find(f => f.name === fName);
-      } else {
-        oldFieldObj = (oldMap[cKey].raw.config?.children || []).find(f => f.name === fName);
-      }
-
-      // Get new field object
-      let newFieldObj = null;
-      if (type === 'config') {
-        newFieldObj = (newMap[cKey].raw.children || []).find(f => f.name === fName);
-      } else {
-        newFieldObj = (newMap[cKey].raw.config?.children || []).find(f => f.name === fName);
-      }
+      const oldFieldObj = oldMap[cKey].fieldMap.get(fName) || null;
+      const newFieldObj = newMap[cKey].fieldMap.get(fName) || null;
 
       const oldDeprecated = oldFieldObj && (oldFieldObj.is_deprecated === true || oldFieldObj.deprecated === true || (oldFieldObj.status || '').toLowerCase() === 'deprecated');
       const newDeprecated = newFieldObj && (newFieldObj.is_deprecated === true || newFieldObj.deprecated === true || (newFieldObj.status || '').toLowerCase() === 'deprecated');
@@ -380,6 +363,29 @@ function discoverComponentKeys(obj) {
   return Object.keys(obj).filter(key => Array.isArray(obj[key]));
 }
 
+/**
+ * Recursively flatten a field tree into dotted-path entries, so a field
+ * added under an existing nested group (e.g. "sqs.zero_key_warn_interval"
+ * added under aws_s3's pre-existing "sqs" group) is visible to a diff that
+ * compares field-name sets. A flat map of top-level names alone treats that
+ * as no change at all, because "sqs" itself isn't new.
+ * @param {Array} children - field definitions (each may itself have `children`)
+ * @param {string} [prefix] - dotted path of the parent, if any
+ * @returns {Array<{path: string, field: object}>}
+ */
+function flattenFields(children, prefix = '') {
+  const result = [];
+  (children || []).forEach(f => {
+    if (!f || !f.name) return;
+    const path = prefix ? `${prefix}.${f.name}` : f.name;
+    result.push({ path, field: f });
+    if (Array.isArray(f.children)) {
+      result.push(...flattenFields(f.children, path));
+    }
+  });
+  return result;
+}
+
 function buildComponentMap(indexObj) {
   const map = {};
   const types = discoverComponentKeys(indexObj);
@@ -402,7 +408,9 @@ function buildComponentMap(indexObj) {
         }
       }
 
-      const fieldNames = childArray.map(f => f.name);
+      const flattened = flattenFields(childArray);
+      const fieldNames = flattened.map(f => f.path);
+      const fieldMap = new Map(flattened.map(f => [f.path, f.field]));
 
       // Preserve platform metadata for accurate diff comparison
       const metadata = {
@@ -414,6 +422,7 @@ function buildComponentMap(indexObj) {
       map[lookupKey] = {
         raw: component,
         fields: fieldNames,
+        fieldMap: fieldMap,
         metadata: metadata
       };
     });
@@ -469,17 +478,9 @@ function printDeltaReport(oldIndex, newIndex) {
     const newFieldsArr = newMap[cKey].fields || [];
     newFieldsArr.forEach(fName => {
       if (!oldFields.has(fName)) {
-        // fetch raw field metadata if available
-        const [type, compName] = cKey.split(':');
-        let rawFieldObj = null;
-        if (type === 'config') {
-          rawFieldObj = (newMap[cKey].raw.children || []).find(f => f.name === fName);
-        } else {
-          rawFieldObj = (newMap[cKey].raw.config?.children || []).find(f => f.name === fName);
-        }
-
-        let introducedIn = rawFieldObj && (rawFieldObj.introducedInVersion || rawFieldObj.version);
-        let requiresVer = rawFieldObj && rawFieldObj.requiresVersion;
+        const rawFieldObj = newMap[cKey].fieldMap.get(fName) || null;
+        const introducedIn = rawFieldObj && (rawFieldObj.introducedInVersion || rawFieldObj.version);
+        const requiresVer = rawFieldObj && rawFieldObj.requiresVersion;
 
         newFields.push({
           component: cKey,
@@ -514,19 +515,8 @@ function printDeltaReport(oldIndex, newIndex) {
     const commonFields = oldFieldsArr.filter(f => newFieldsArr.includes(f));
 
     commonFields.forEach(fName => {
-      const [type, compName] = cKey.split(':');
-      let oldFieldObj = null;
-      if (type === 'config') {
-        oldFieldObj = (oldMap[cKey].raw.children || []).find(f => f.name === fName);
-      } else {
-        oldFieldObj = (oldMap[cKey].raw.config?.children || []).find(f => f.name === fName);
-      }
-      let newFieldObj = null;
-      if (type === 'config') {
-        newFieldObj = (newMap[cKey].raw.children || []).find(f => f.name === fName);
-      } else {
-        newFieldObj = (newMap[cKey].raw.config?.children || []).find(f => f.name === fName);
-      }
+      const oldFieldObj = oldMap[cKey].fieldMap.get(fName) || null;
+      const newFieldObj = newMap[cKey].fieldMap.get(fName) || null;
       const oldDeprecated = oldFieldObj && (oldFieldObj.is_deprecated === true || oldFieldObj.deprecated === true || (oldFieldObj.status || '').toLowerCase() === 'deprecated');
       const newDeprecated = newFieldObj && (newFieldObj.is_deprecated === true || newFieldObj.deprecated === true || (newFieldObj.status || '').toLowerCase() === 'deprecated');
       if (!oldDeprecated && newDeprecated) {

--- a/tools/redpanda-connect/rpcn-connector-docs-handler.js
+++ b/tools/redpanda-connect/rpcn-connector-docs-handler.js
@@ -413,7 +413,7 @@ function updateWhatsNew ({ dataDir, oldVersion, newVersion, binaryAnalysis }) {
       if (regularFields.length > 0) {
         section += '\n=== New field support\n\n'
         section += 'This release adds support for the following new fields:\n\n'
-        section += buildFieldsTable(regularFields, capToTwoSentences)
+        section += buildFieldsTable(regularFields, capToTwoSentences, { showIntroducedIn: true })
       }
     }
 
@@ -553,22 +553,24 @@ function fieldAnchor (fieldName) {
  * @param {Function} capFn - Caption function
  * @returns {string} AsciiDoc table
  */
-function buildFieldsTable (fields, capFn) {
+function buildFieldsTable (fields, capFn, opts = {}) {
+  const { showIntroducedIn = false } = opts
   const byField = {}
   for (const field of fields) {
     const [type, compName] = field.component.split(':')
     if (!byField[field.field]) {
       byField[field.field] = {
         description: field.description,
+        introducedIn: field.introducedIn,
         components: []
       }
     }
     byField[field.field].components.push({ type, name: compName })
   }
 
-  let section = '[cols="1m,3,2a"]\n'
+  let section = showIntroducedIn ? '[cols="1m,3,2a,1m"]\n' : '[cols="1m,3,2a"]\n'
   section += '|===\n'
-  section += '|Field |Description |Affected components\n\n'
+  section += showIntroducedIn ? '|Field |Description |Affected components |Introduced in\n\n' : '|Field |Description |Affected components\n\n'
 
   for (const [fieldName, info] of Object.entries(byField)) {
     const byType = {}
@@ -595,7 +597,9 @@ function buildFieldsTable (fields, capFn) {
 
     section += `|${fieldName}\n`
     section += `|${desc}\n`
-    section += `|${componentList}\n\n`
+    section += `|${componentList}\n`
+    if (showIntroducedIn) section += `|${info.introducedIn || '-'}\n`
+    section += '\n'
   }
 
   section += '|===\n\n'


### PR DESCRIPTION
## Why

`rp-connect-docs#489` (a manual run of the connector docs generation) added two genuinely new fields — `sqs.zero_key_warn_interval` on `aws_s3` and `logminer.max_session_age` on `oracledb_cdc` — but neither showed up in `whats-new.adoc`'s "New field support" section or the PR's "Writer Action Items", even though both are confirmed absent from the prior release's connector data and present in the new one.

Root cause: `buildComponentMap()` only records **top-level** field names:

```js
const fieldNames = childArray.map(f => f.name)
```

Both new fields are nested one level inside a group that already existed (`sqs`, `logminer`). Since the group name itself didn't change, the diff saw the top-level field set as unchanged and reported zero new fields for both intermediate releases — this isn't specific to that PR; any field added under an existing nested group hits the same blind spot.

## What this does

- `flattenFields()` recursively walks each field's `children` and returns dotted paths (`sqs.zero_key_warn_interval`), so nested additions are visible to the same Set-based comparison that already worked for top-level fields. `buildComponentMap()` now also builds a `fieldMap` (path → raw field object) alongside the flat name list, which replaces the repeated `type === 'config' ? ... : ...` lookup branching duplicated ~8 times across `generateConnectorDiffJson` and `printDeltaReport` with a single `.get(path)` call.
- New fields now get an `introducedIn` stamped from the diff's own `opts.newVersion` when the source data carries no per-field version (it never does today — checked both real fields, neither has `introducedInVersion`/`version`). Field-level data still wins if it's ever populated.
- `buildFieldsTable` renders that as an "Introduced in" column, opt-in via `{ showIntroducedIn: true }` (only the "New field support" call site uses it — the deprecated-fields table doesn't need it).

## Test plan

- Added a test reproducing the exact bug shape (field added under an existing group) and confirming it's now detected.
- Added tests for the version-stamping fallback and the field-level-version-wins case.
- Added `buildFieldsTable` tests for the new opt-in column (present/absent, and the `-` fallback when a field has no version).
- Ran the fixed `generateConnectorDiffJson` against the real `connect-4.103.1.json` → `connect-4.104.0.json` data from rp-connect-docs#489: both previously-missed fields now appear, each correctly stamped `introducedIn: '4.104.0'`.
- Full suite: `npx jest` — 1037/1037 pass.