### PR TITLE
fix(ci): isolate the CGO network test and report download failures honestly

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -287,8 +287,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # A CLI --testPathIgnorePatterns REPLACES the array in jest.config.js, it
+      # does not add to it. So this list has to repeat the config's own entries:
+      # without /node_modules/ jest walks dependency test files, and without
+      # cgo-detection.test.js the network-dependent CGO end-to-end test runs
+      # here, where a GitHub download hiccup fails PRs that never touched it.
+      # That test has its own workflow (test-cgo-detection.yml) and npm script
+      # (npm run test:cgo), which run it as a node script.
       - name: Run all tests
-        run: npm test -- --testPathIgnorePatterns="cli-contract.test.js|integration.test.js" --maxWorkers=2
+        run: npm test -- --testPathIgnorePatterns="/node_modules/|cli-contract.test.js|integration.test.js|cgo-detection.test.js" --maxWorkers=2
 
   # Summary job that all other jobs depend on
   test-summary:

--- a/__tests__/tools/cgo-detection.test.js
+++ b/__tests__/tools/cgo-detection.test.js
@@ -14,6 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const { execSync, spawnSync } = require('child_process');
 const os = require('os');
 
@@ -74,6 +75,41 @@ function getPlatformInfo() {
   };
 }
 
+/**
+ * Verify a downloaded asset against the .sha256 published beside it.
+ *
+ * Catches a truncated or substituted download before tar reports it as a
+ * generic archive error. Hashing in node keeps this working on both Linux
+ * (sha256sum) and macOS (shasum), which have different CLIs.
+ */
+function verifyChecksum(filePath, sha256Url, assetName) {
+  let published;
+  try {
+    published = execSync(`curl -sSL --fail --retry 3 --retry-delay 2 "${sha256Url}"`, {
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).toString();
+  } catch (err) {
+    // No checksum published for this asset: keep going rather than fail the
+    // run over a missing side file, since the archive itself still has to
+    // extract and execute below.
+    log(`  Warning: no checksum available at ${sha256Url}, skipping verification`);
+    return;
+  }
+
+  // Format is "<hash>  <filename>"; take the first token.
+  const expected = published.trim().split(/\s+/)[0];
+  const actual = crypto
+    .createHash('sha256')
+    .update(fs.readFileSync(filePath))
+    .digest('hex');
+
+  if (expected && expected !== actual) {
+    throw new Error(
+      `checksum mismatch for ${assetName}\n  expected: ${expected}\n  actual:   ${actual}`
+    );
+  }
+}
+
 function downloadBinary(version, type) {
   const platform = getPlatformInfo();
   const binaryName = type === 'cgo' ? 'redpanda-connect-cgo' : 'redpanda-connect-cloud';
@@ -85,7 +121,18 @@ function downloadBinary(version, type) {
   const tarPath = path.join(TEST_DIR, `${type}.tar.gz`);
 
   try {
-    execSync(`curl -sL "${url}" -o "${tarPath}"`, { stdio: 'pipe' });
+    // --fail matters: without it curl exits 0 on an HTTP error, writes the
+    // error body into the .tar.gz, and the failure surfaces from tar as
+    // "gzip: stdin: not in gzip format" -- which reads like a corrupt archive
+    // rather than a 404 or a rate limit. --retry covers the transient statuses
+    // (429, 5xx) that GitHub returns when throttling release downloads.
+    execSync(
+      `curl -sSL --fail --retry 3 --retry-delay 2 "${url}" -o "${tarPath}"`,
+      { stdio: 'pipe' }
+    );
+
+    verifyChecksum(tarPath, `${url}.sha256`, assetName);
+
     execSync(`tar -xzf "${tarPath}" -C "${TEST_DIR}"`, { stdio: 'pipe' });
 
     // Find extracted binary

--- a/__tests__/tools/cgo-detection.test.js
+++ b/__tests__/tools/cgo-detection.test.js
@@ -15,7 +15,7 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
-const { execSync, spawnSync } = require('child_process');
+const { execSync, execFileSync, spawnSync } = require('child_process');
 const os = require('os');
 
 // Test configuration
@@ -75,35 +75,73 @@ function getPlatformInfo() {
   };
 }
 
+const SHA256_RE = /^[0-9a-f]{64}$/i;
+
+/**
+ * Fetch a URL, returning both the HTTP status and the body.
+ *
+ * Uses execFileSync with an argument array so no part of the URL is passed
+ * through a shell. Deliberately omits --fail so the status code is available
+ * to the caller: a 404 and a 500 need different handling here.
+ */
+function fetchWithStatus(url) {
+  const bodyPath = path.join(TEST_DIR, `.fetch-${crypto.randomBytes(6).toString('hex')}`);
+  try {
+    const status = execFileSync(
+      'curl',
+      ['-sSL', '--retry', '3', '--retry-delay', '2', '-w', '%{http_code}', '-o', bodyPath, url],
+      { stdio: ['pipe', 'pipe', 'pipe'] }
+    ).toString().trim();
+    const body = fs.existsSync(bodyPath) ? fs.readFileSync(bodyPath, 'utf8') : '';
+    return { status: Number(status), body };
+  } finally {
+    if (fs.existsSync(bodyPath)) fs.unlinkSync(bodyPath);
+  }
+}
+
 /**
  * Verify a downloaded asset against the .sha256 published beside it.
  *
  * Catches a truncated or substituted download before tar reports it as a
  * generic archive error. Hashing in node keeps this working on both Linux
  * (sha256sum) and macOS (shasum), which have different CLIs.
+ *
+ * Only a 404 counts as "no checksum published" and skips verification. Any
+ * other outcome -- a 5xx, a transport error, an empty body, a body that isn't
+ * a SHA-256 -- fails loudly. Silently skipping on those would reintroduce the
+ * exact problem this hardening exists to prevent: a verification step that
+ * quietly does nothing and reports success.
  */
 function verifyChecksum(filePath, sha256Url, assetName) {
-  let published;
+  let result;
   try {
-    published = execSync(`curl -sSL --fail --retry 3 --retry-delay 2 "${sha256Url}"`, {
-      stdio: ['pipe', 'pipe', 'pipe']
-    }).toString();
+    result = fetchWithStatus(sha256Url);
   } catch (err) {
-    // No checksum published for this asset: keep going rather than fail the
-    // run over a missing side file, since the archive itself still has to
-    // extract and execute below.
-    log(`  Warning: no checksum available at ${sha256Url}, skipping verification`);
+    throw new Error(`could not retrieve checksum for ${assetName}: ${err.message}`);
+  }
+
+  if (result.status === 404) {
+    log(`  No checksum published for ${assetName} (HTTP 404), skipping verification`);
     return;
+  }
+  if (result.status !== 200) {
+    throw new Error(`could not retrieve checksum for ${assetName}: HTTP ${result.status}`);
   }
 
   // Format is "<hash>  <filename>"; take the first token.
-  const expected = published.trim().split(/\s+/)[0];
+  const expected = result.body.trim().split(/\s+/)[0];
+  if (!SHA256_RE.test(expected || '')) {
+    throw new Error(
+      `checksum for ${assetName} is not a SHA-256 value: ${JSON.stringify((expected || '').slice(0, 80))}`
+    );
+  }
+
   const actual = crypto
     .createHash('sha256')
     .update(fs.readFileSync(filePath))
     .digest('hex');
 
-  if (expected && expected !== actual) {
+  if (expected.toLowerCase() !== actual.toLowerCase()) {
     throw new Error(
       `checksum mismatch for ${assetName}\n  expected: ${expected}\n  actual:   ${actual}`
     );
@@ -126,14 +164,16 @@ function downloadBinary(version, type) {
     // "gzip: stdin: not in gzip format" -- which reads like a corrupt archive
     // rather than a 404 or a rate limit. --retry covers the transient statuses
     // (429, 5xx) that GitHub returns when throttling release downloads.
-    execSync(
-      `curl -sSL --fail --retry 3 --retry-delay 2 "${url}" -o "${tarPath}"`,
+    // execFileSync keeps the URL and paths out of a shell.
+    execFileSync(
+      'curl',
+      ['-sSL', '--fail', '--retry', '3', '--retry-delay', '2', url, '-o', tarPath],
       { stdio: 'pipe' }
     );
 
     verifyChecksum(tarPath, `${url}.sha256`, assetName);
 
-    execSync(`tar -xzf "${tarPath}" -C "${TEST_DIR}"`, { stdio: 'pipe' });
+    execFileSync('tar', ['-xzf', tarPath, '-C', TEST_DIR], { stdio: 'pipe' });
 
     // Find extracted binary
     const files = fs.readdirSync(TEST_DIR);


### PR DESCRIPTION
Two fixes for the flake that failed #248 — a PR touching only helm-spec code, with no relation to CGO detection.

## 1. `test-all` re-included a test the config deliberately excludes

`jest.config.js` already ignores the CGO end-to-end test, because it downloads real release binaries:

```js
testPathIgnorePatterns: ['/node_modules/', '__tests__/tools/cgo-detection.test.js']
```

But a CLI `--testPathIgnorePatterns` **replaces** that array rather than adding to it. So `test-all` passing `"cli-contract.test.js|integration.test.js"` silently dropped both the cgo exclusion and `/node_modules/`.

Verified with `jest --listTests`:

| invocation | cgo test collected? |
|---|---|
| config only | no |
| config + old CLI flag | **yes** |
| config + new CLI flag | no |

This also explains why `test-tools` passed on the same commit — it globs `__tests__/tools/` but doesn't pass the flag, so the config exclusion held.

The ignore list now repeats the config's own entries. The test still runs where it's meant to: `test-cgo-detection.yml` and `npm run test:cgo`, both of which invoke it as a node script. Restoring `/node_modules/` is defensive — no dependency test files are collected today, but the config intended to exclude them.

## 2. A failed download reported itself as a corrupt archive

`curl -sL` has no `--fail`, so on an HTTP error it exits 0, writes the error body into `cloud.tar.gz`, and the run dies in `tar`:

```
gzip: stdin: not in gzip format
tar: Child returned status 1
```

That reads like a bad archive rather than a 404 or a rate limit, which is what made the original failure expensive to diagnose. Reproduced directly:

```
curl -sL  <missing asset>  -> exit 0, wrote 9 bytes of non-tarball
curl --fail <missing asset> -> exit 56, no file left behind
```

Changes:
- `--fail` so an HTTP error surfaces as an HTTP error
- `--retry 3 --retry-delay 2`, covering the 429 and 5xx statuses GitHub returns when throttling release downloads
- a checksum check against the `.sha256` published beside each asset, so a truncated download is named as such. Hashing uses node `crypto` rather than `sha256sum`/`shasum`, which differ between Linux and macOS.

## Verification

Against the real `v4.75.1` cloud asset (73MB):

1. download with `--fail --retry` succeeds
2. checksum matches the published `.sha256`
3. archive extracts cleanly
4. a truncated file is correctly reported as a checksum mismatch
5. a missing `.sha256` degrades to a warning rather than failing the run

Full suite green on a clean `npm ci`: 54 suites, 1198 tests.

Note: `#248` itself needed no change — I re-ran its failed job and it passed.