### PR TITLE
fix(validate): honor --skip-connect for antora.yml and authenticate private fetches

### DIFF
--- a/bin/doc-tools.js
+++ b/bin/doc-tools.js
@@ -2165,17 +2165,28 @@ validation
     const yamlLib = require('js-yaml')
 
     const RAW = 'https://raw.githubusercontent.com'
+    // Some sources live in private repos (docs, rp-connect-docs), which
+    // raw.githubusercontent serves as 404 rather than 401 when unauthenticated
+    // — indistinguishable from a genuinely missing file. Send a token when one
+    // is available so those fetches resolve; public sources are unaffected.
+    const { getGitHubToken } = require('../cli-utils/github-token')
+    const ghToken = getGitHubToken()
     // Sources that fail to load are reported as error-level findings rather
     // than silently skipped, so CI cannot pass on a check that never ran.
     const failedSources = []
     async function fetchText (url, sourceName) {
-      const resp = await fetch(url)
+      const resp = await fetch(url, ghToken ? { headers: { Authorization: `Bearer ${ghToken}` } } : undefined)
       if (!resp.ok) {
+        // A 404 with no token is the signature of an unauthenticated private
+        // repo, so say so instead of leaving it to look like a missing file.
+        const hint = resp.status === 404 && !ghToken
+          ? ' If this source is in a private repository, set GITHUB_TOKEN (or REDPANDA_GITHUB_TOKEN / ACTIONS_BOT_TOKEN) so the fetch can authenticate.'
+          : ''
         if (sourceName) {
-          failedSources.push({ level: 'error', check: 'fetch', message: `Could not load ${sourceName} (${url}): ${resp.status} ${resp.statusText}. The related checks did not run.` })
+          failedSources.push({ level: 'error', check: 'fetch', message: `Could not load ${sourceName} (${url}): ${resp.status} ${resp.statusText}. The related checks did not run.${hint}` })
           return undefined
         }
-        throw new Error(`Failed to fetch ${url}: ${resp.status} ${resp.statusText}`)
+        throw new Error(`Failed to fetch ${url}: ${resp.status} ${resp.statusText}.${hint}`)
       }
       return resp.text()
     }
@@ -2193,9 +2204,14 @@ validation
       const disablePage = options.disablePage
         ? readLocal(options.disablePage)
         : await fetchText(`${RAW}/redpanda-data/docs/${options.docsRef}/modules/get-started/pages/licensing/disable-enterprise-features.adoc`, 'disable-enterprise-features.adoc')
-      const antoraYaml = options.antora
-        ? readLocal(options.antora)
-        : await fetchText(`${RAW}/redpanda-data/rp-connect-docs/main/antora.yml`, 'rp-connect-docs antora.yml')
+      // Only checkConnect consumes this, so --skip-connect has to skip it too.
+      // Fetching it anyway meant --skip-connect still reached a private repo
+      // and failed the run on a source none of the enabled checks used.
+      const antoraYaml = options.skipConnect
+        ? undefined
+        : options.antora
+          ? readLocal(options.antora)
+          : await fetchText(`${RAW}/redpanda-data/rp-connect-docs/main/antora.yml`, 'rp-connect-docs antora.yml')
       const antoraEnterpriseComponents = antoraYaml
         ? extractAntoraEnterpriseComponents(yamlLib.load(antoraYaml))
         : undefined


### PR DESCRIPTION
## Problem

`doc-tools validate enterprise-features` fails on every run, which is why the `validate` check is red on redpanda-data/docs#1895 and #1896:

```
ERROR [fetch] Could not load rp-connect-docs antora.yml
(https://raw.githubusercontent.com/redpanda-data/rp-connect-docs/main/antora.yml): 404 Not Found
```

Two separate causes behind it.

**1. `--skip-connect` was only half-implemented.** It gated the connect `info.csv` fetch but not the `rp-connect-docs` `antora.yml` fetch. That value feeds only `checkConnect` (`tools/enterprise-features/verify.js`), so with `--skip-connect` nothing consumed it — yet the fetch still ran, and its failure was recorded as an error-level finding that failed the whole run. A source no enabled check used was breaking CI.

**2. The fetch was unauthenticated against a private repo.** `rp-connect-docs` and `docs` are both private, and `raw.githubusercontent` answers unauthenticated requests for private content with **404, not 401** — so a permissions problem was indistinguishable from a missing file.

## Changes

- `--skip-connect` now also skips the `antora.yml` fetch
- `fetchText` sends a bearer token when one is resolvable through the existing `cli-utils/github-token` chain (`GIT_CREDENTIALS` → `REDPANDA_GITHUB_TOKEN` → `ACTIONS_BOT_TOKEN` → `GITHUB_TOKEN` → …)
- a tokenless 404 now names the likely cause instead of leaving the reader to guess

The unnamed-source path still throws rather than returning `undefined`, so a missing `--registry` keeps failing hard.

## Verification

Run against the real registry and disable page taken from the docs branch:

| scenario | result |
|---|---|
| before, `--skip-connect`, no token | exit 1 — the exact CI error |
| after, same inputs | **exit 0**, no fetch failure |
| after, connect enabled, no token | same 404, now with the token hint |
| after, connect enabled, with token | private `antora.yml` resolves, zero 404s |

Confirmed independently that `Authorization: Bearer` works on `raw.githubusercontent` for a private repo (404 → 200).

## Note

This unblocks the `validate` check on docs#1895/#1896 with no change needed in those PRs, since their workflow already passes `--skip-connect`. Once released, that check should pass without a token. A token only becomes necessary if the connect comparison is re-enabled by dropping `--skip-connect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)